### PR TITLE
Refactor Item class, remove static methods

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/IfRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/IfRuntimeIterator.java
@@ -66,7 +66,7 @@ public class IfRuntimeIterator extends LocalRuntimeIterator {
                 elseBranch = this._children.get(2);
             Item conditionResult = getSingleItemOfTypeFromIterator(condition, Item.class);
             result = new ArrayList<>();
-            if (Item.getEffectiveBooleanValue(conditionResult)) {
+            if (conditionResult.getEffectiveBooleanValue()) {
                 result = getItemsFromIteratorWithCurrentContext(branch);
             } else {
                 result = getItemsFromIteratorWithCurrentContext(elseBranch);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/SwitchRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/SwitchRuntimeIterator.java
@@ -93,7 +93,7 @@ public class SwitchRuntimeIterator extends LocalRuntimeIterator {
                     // no match, do nothing
                 }
             }
-            else if (caseValue != null && Item.checkEquality(testValue, caseValue)) {
+            else if (caseValue != null && testValue.checkEquality(caseValue)) {
                 matchingIterator = cases.get(caseKey);
                 break;
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -39,8 +39,8 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
-                Double result = Math.abs(Item.getNumericValue(value, Double.class));
+            if (value.isNumeric()) {
+                Double result = Math.abs(value.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
@@ -39,8 +39,8 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
-                Double result = Math.ceil(Item.getNumericValue(value, Double.class));
+            if (value.isNumeric()) {
+                Double result = Math.ceil(value.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -39,8 +39,8 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
-                Double result = Math.floor(Item.getNumericValue(value, Double.class));
+            if (value.isNumeric()) {
+                Double result = Math.floor(value.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
@@ -56,10 +56,10 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
             else {
                 precision = new IntegerItem(0, ItemMetadata.fromIteratorMetadata(this.getMetadata()));
             }
-            if (Item.isNumeric(value) && Item.isNumeric(precision)) {
+            if (value.isNumeric() && precision.isNumeric()) {
 
-                Double val = Item.getNumericValue(value, Double.class);
-                Integer prec = Item.getNumericValue(precision, Integer.class);
+                Double val = value.getNumericValue(Double.class);
+                Integer prec = precision.getNumericValue(Integer.class);
 
                 BigDecimal bd = new BigDecimal(val);
                 bd = bd.setScale(prec, RoundingMode.HALF_UP);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -56,10 +56,10 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
             else {
                 precision = new IntegerItem(0, ItemMetadata.fromIteratorMetadata(this.getMetadata()));
             }
-            if (Item.isNumeric(value) && Item.isNumeric(precision)) {
+            if (value.isNumeric() && precision.isNumeric()) {
 
-                Double val = Item.getNumericValue(value, Double.class);
-                Integer prec = Item.getNumericValue(precision, Integer.class);
+                Double val = value.getNumericValue(Double.class);
+                Integer prec = precision.getNumericValue(Integer.class);
 
                 BigDecimal bd = new BigDecimal(val);
                 bd = bd.setScale(prec, RoundingMode.HALF_EVEN);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -39,8 +39,8 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item exponent = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(exponent)) {
-                Double result = Math.pow(10.0, Item.getNumericValue(exponent, Double.class));
+            if (exponent.isNumeric()) {
+                Double result = Math.pow(10.0, exponent.getNumericValue(Double.class));
 
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
@@ -39,8 +39,8 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item exponent = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(exponent)) {
-                Double result = Math.exp(Item.getNumericValue(exponent, Double.class));
+            if (exponent.isNumeric()) {
+                Double result = Math.exp(exponent.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -39,8 +39,8 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
-                Double result = Math.log10(Item.getNumericValue(value, Double.class));
+            if (value.isNumeric()) {
+                Double result = Math.log10(value.getNumericValue(Double.class));
 
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -39,8 +39,8 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
-                Double result = Math.log(Item.getNumericValue(value, Double.class));
+            if (value.isNumeric()) {
+                Double result = Math.log(value.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -46,9 +46,9 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
             } else {
                 throw new UnexpectedTypeException("Type error; Exponent parameter can't be empty sequence ", getMetadata());
             }
-            if (Item.isNumeric(base) && Item.isNumeric(exponent)) {
-                Double result = Math.pow(Item.getNumericValue(base, Double.class)
-                        , Item.getNumericValue(exponent, Double.class));
+            if (base.isNumeric() && exponent.isNumeric()) {
+                Double result = Math.pow(base.getNumericValue(Double.class)
+                        , exponent.getNumericValue(Double.class));
                 this._hasNext = false;
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -38,8 +38,8 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
     public Item next() {
         if (this._hasNext) {
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
-                Double result = Math.sqrt(Item.getNumericValue(value, Double.class));
+            if (value.isNumeric()) {
+                Double result = Math.sqrt(value.getNumericValue(Double.class));
                 this._hasNext = false;
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -39,8 +39,8 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
-                Double result = Math.acos(Item.getNumericValue(radians, Double.class));
+            if (radians.isNumeric()) {
+                Double result = Math.acos(radians.getNumericValue(Double.class));
 
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -39,8 +39,8 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
-                Double result = Math.asin(Item.getNumericValue(radians, Double.class));
+            if (radians.isNumeric()) {
+                Double result = Math.asin(radians.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -38,9 +38,9 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
                 throw new UnexpectedTypeException("Type error; x parameter can't be empty sequence ", getMetadata());
             }
 
-            if (Item.isNumeric(y) && Item.isNumeric(x)) {
-                Double result = Math.atan2(Item.getNumericValue(y, Double.class)
-                        , Item.getNumericValue(x, Double.class));
+            if (y.isNumeric() && x.isNumeric()) {
+                Double result = Math.atan2(y.getNumericValue(Double.class)
+                        , x.getNumericValue(Double.class));
                 this._hasNext = false;
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -39,8 +39,8 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
-                Double result = Math.atan(Item.getNumericValue(radians, Double.class));
+            if (radians.isNumeric()) {
+                Double result = Math.atan(radians.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -40,8 +40,8 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
-                Double result = Math.cos(Item.getNumericValue(radians, Double.class));
+            if (radians.isNumeric()) {
+                Double result = Math.cos(radians.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -39,8 +39,8 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
-                Double result = Math.sin(Item.getNumericValue(radians, Double.class));
+            if (radians.isNumeric()) {
+                Double result = Math.sin(radians.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -39,8 +39,8 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
-                Double result = Math.tan(Item.getNumericValue(radians, Double.class));
+            if (radians.isNumeric()) {
+                Double result = Math.tan(radians.getNumericValue(Double.class));
                 return new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -40,14 +40,14 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
             List<Item> results = getItemsFromIteratorWithCurrentContext(_iterator);
             this._hasNext = false;
             results.forEach(r -> {
-                if (!Item.isNumeric(r))
+                if (!r.isNumeric())
                     throw new UnexpectedTypeException("Average expression has non numeric args " +
                             r.serialize(), getMetadata());
             });
             //TODO check numeric types conversions
             BigDecimal sum = new BigDecimal(0);
             for (Item r : results)
-                sum = sum.add(Item.getNumericValue(r, BigDecimal.class));
+                sum = sum.add(r.getNumericValue(BigDecimal.class));
             return new DecimalItem(sum.divide(new BigDecimal(results.size())),
                     ItemMetadata.fromIteratorMetadata(getMetadata()));
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MaxFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MaxFunctionIterator.java
@@ -8,6 +8,7 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 
 public class MaxFunctionIterator extends AggregateFunctionIterator {
@@ -38,20 +39,22 @@ public class MaxFunctionIterator extends AggregateFunctionIterator {
             List<Item> results = getItemsFromIteratorWithCurrentContext(_iterator);
             this._hasNext = false;
             results.forEach(r -> {
-                if (!Item.isNumeric(r))
+                if (!r.isNumeric())
                     throw new UnexpectedTypeException("Max expression has non numeric args " +
                             r.serialize(), getMetadata());
             });
 
+
             Item itemResult = results.get(0);
-            BigDecimal max  = Item.getNumericValue(results.get(0), BigDecimal.class);
+            BigDecimal max  = results.get(0).getNumericValue(BigDecimal.class);
             for(Item r: results) {
-                BigDecimal current = Item.getNumericValue(r, BigDecimal.class);
+                BigDecimal current = r.getNumericValue(BigDecimal.class);
                 if(max.compareTo(current) < 0) {
                     max = current;
                     itemResult = r;
                 }
             }
+
             return itemResult;
         } else
             throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "MAX function",

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MinFunctionIterator.java
@@ -38,15 +38,15 @@ public class MinFunctionIterator extends AggregateFunctionIterator {
             List<Item> results = getItemsFromIteratorWithCurrentContext(_iterator);
             this._hasNext = false;
             results.forEach(r -> {
-                if (!Item.isNumeric(r))
+                if (!r.isNumeric())
                     throw new UnexpectedTypeException("Min expression has non numeric args " +
                             r.serialize(), getMetadata());
             });
 
             Item itemResult = results.get(0);
-            BigDecimal min = Item.getNumericValue(results.get(0), BigDecimal.class);
+            BigDecimal min = results.get(0).getNumericValue(BigDecimal.class);
             for (Item r : results) {
-                BigDecimal current = Item.getNumericValue(r, BigDecimal.class);
+                BigDecimal current = r.getNumericValue(BigDecimal.class);
                 if (min.compareTo(current) > 0) {
                     min = current;
                     itemResult = r;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
@@ -26,14 +26,14 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
             List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);
             this._hasNext = false;
             results.forEach(r -> {
-                if (!Item.isNumeric(r))
+                if (!r.isNumeric())
                     throw new UnexpectedTypeException("Sum expression has non numeric args " +
                             r.serialize(), getMetadata());
             });
 
             BigDecimal sumResult = new BigDecimal(0);
             for (Item r : results) {
-                BigDecimal current = Item.getNumericValue(r, BigDecimal.class);
+                BigDecimal current = r.getNumericValue(BigDecimal.class);
                 sumResult = sumResult.add(current);
             }
             return new DecimalItem(sumResult, ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
@@ -49,26 +49,26 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
         if(this._hasNext){
             this._hasNext = false;
 
-            Type returnType = Item.getNumericResultType(_left, _right);
+            Type returnType = _left.getNumericResultType(_right);
             if(returnType.equals(IntegerItem.class)){
-                int l = Item.<Integer>getNumericValue(_left, Integer.class);
-                int r = Item.<Integer>getNumericValue(_right, Integer.class);
+                int l = _left.getNumericValue(Integer.class);
+                int r = _right.getNumericValue(Integer.class);
                 return this._operator == OperationalExpressionBase.Operator.PLUS?
                         new IntegerItem(l + r,
                                 ItemMetadata.fromIteratorMetadata(getMetadata())) :
                         new IntegerItem(l - r,
                                 ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else if(returnType.equals(DoubleItem.class)){
-                double l = Item.<Double>getNumericValue(_left, Double.class);
-                double r = Item.<Double>getNumericValue(_right, Double.class);
+                double l = _left.getNumericValue(Double.class);
+                double r = _right.getNumericValue(Double.class);
                 return this._operator == OperationalExpressionBase.Operator.PLUS?
                         new DoubleItem(l + r,
                                 ItemMetadata.fromIteratorMetadata(getMetadata())) :
                         new DoubleItem(l - r,
                                 ItemMetadata.fromIteratorMetadata(getMetadata()));
             } else if(returnType.equals(DecimalItem.class)){
-                BigDecimal l = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
-                BigDecimal r = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
+                BigDecimal l = _left.getNumericValue(BigDecimal.class);
+                BigDecimal r = _right.getNumericValue(BigDecimal.class);
                 return this._operator == OperationalExpressionBase.Operator.PLUS?
                         new DecimalItem(l.add(r),
                                 ItemMetadata.fromIteratorMetadata(getMetadata())) :
@@ -95,7 +95,7 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
         else {
             _left = _leftIterator.next();
             _right = _rightIterator.next();
-            if(_leftIterator.hasNext() || _rightIterator.hasNext() || !Item.isNumeric(_left) || !Item.isNumeric(_right))
+            if(_leftIterator.hasNext() || _rightIterator.hasNext() || !_left.isNumeric() || !_right.isNumeric())
                 throw new UnexpectedTypeException("Additive expression has non numeric args " +
                         _left.serialize() + ", " + _right.serialize(), getMetadata());
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AndOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AndOperationIterator.java
@@ -51,7 +51,7 @@ public class AndOperationIterator extends BinaryOperationBaseIterator {
             _leftIterator.close();
             _rightIterator.close();
             this._hasNext = false;
-            return new BooleanItem(Item.getEffectiveBooleanValue(left) && Item.getEffectiveBooleanValue(right)
+            return new BooleanItem(left.getEffectiveBooleanValue() && right.getEffectiveBooleanValue()
                     , ItemMetadata.fromIteratorMetadata(getMetadata()));
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
@@ -151,8 +151,8 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
         if (left instanceof NullItem || right instanceof NullItem) {
             return compareItems(left, right);
         }
-        else if (Item.isNumeric(left)) {
-            if (!Item.isNumeric(right))
+        else if (left.isNumeric()) {
+            if (!right.isNumeric())
                 throw new UnexpectedTypeException("Invalid args for numerics comparison " + left.serialize() +
                         ", " + right.serialize(), getMetadata());
             return compareItems(left, right);
@@ -175,7 +175,7 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
     }
 
     public BooleanItem compareItems (Item left, Item right) {
-        int comparison = Item.compareItems(left, right);
+        int comparison = left.compareTo(right);
         switch (this._operator) {
             case VC_EQ:
             case GC_EQ:

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -56,7 +56,7 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
         } else {
             _left = _leftIterator.next();
             _right = _rightIterator.next();
-            if (_leftIterator.hasNext() || _rightIterator.hasNext() || !Item.isNumeric(_left) || !Item.isNumeric(_right))
+            if (_leftIterator.hasNext() || _rightIterator.hasNext() || !_left.isNumeric() || !_right.isNumeric())
                 throw new UnexpectedTypeException("Multiplicative expression has non numeric args " +
                         _left.serialize() + ", " + _right.serialize(), getMetadata());
 
@@ -71,16 +71,16 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
         if (this._hasNext) {
             this._hasNext = false;
 
-            Type returnType = Item.getNumericResultType(_left, _right);
+            Type returnType = _left.getNumericResultType(_right);
             if (returnType.equals(IntegerItem.class)) {
-                int l = Item.<Integer>getNumericValue(_left, Integer.class);
-                int r = Item.<Integer>getNumericValue(_right, Integer.class);
+                int l = _left.getNumericValue(Integer.class);
+                int r = _right.getNumericValue(Integer.class);
                 switch (this._operator) {
                     case MUL:
                         return new IntegerItem(l * r, ItemMetadata.fromIteratorMetadata(getMetadata()));
                     case DIV:
-                        BigDecimal decLeft = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
-                        BigDecimal decRight = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
+                        BigDecimal decLeft = _left.getNumericValue(BigDecimal.class);
+                        BigDecimal decRight = _right.getNumericValue(BigDecimal.class);
                         BigDecimal bdResult = decLeft.divide(decRight, 10, BigDecimal.ROUND_HALF_UP);
                         // if the result contains no decimal part, convert to integer
                         if (bdResult.stripTrailingZeros().scale() <= 0) {
@@ -101,8 +101,8 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                         return new IntegerItem(l / r, ItemMetadata.fromIteratorMetadata(getMetadata()));
                 }
             } else if (returnType.equals(DoubleItem.class)) {
-                double l = Item.<Double>getNumericValue(_left, Double.class);
-                double r = Item.<Double>getNumericValue(_right, Double.class);
+                double l = _left.getNumericValue(Double.class);
+                double r = _right.getNumericValue(Double.class);
                 switch (this._operator) {
                     case MUL:
                         return new DoubleItem(l * r, ItemMetadata.fromIteratorMetadata(getMetadata()));
@@ -114,8 +114,8 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                         return new DoubleItem((int) (l / r), ItemMetadata.fromIteratorMetadata(getMetadata()));
                 }
             } else if (returnType.equals(DecimalItem.class)) {
-                BigDecimal l = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
-                BigDecimal r = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
+                BigDecimal l = _left.getNumericValue(BigDecimal.class);
+                BigDecimal r = _right.getNumericValue(BigDecimal.class);
                 switch (this._operator) {
                     case MUL:
                         return new DecimalItem(l.multiply(r), ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/NotOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/NotOperationIterator.java
@@ -40,6 +40,6 @@ public class NotOperationIterator extends UnaryOperationBaseIterator {
         Item child = _child.next();
         _child.close();
         this._hasNext = false;
-        return new BooleanItem(!Item.getEffectiveBooleanValue(child), ItemMetadata.fromIteratorMetadata(getMetadata()));
+        return new BooleanItem(!child.getEffectiveBooleanValue(), ItemMetadata.fromIteratorMetadata(getMetadata()));
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/OrOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/OrOperationIterator.java
@@ -49,7 +49,7 @@ public class OrOperationIterator extends BinaryOperationBaseIterator {
         _leftIterator.close();
         _rightIterator.close();
         this._hasNext = false;
-        return new BooleanItem(Item.getEffectiveBooleanValue(left) || Item.getEffectiveBooleanValue(right)
+        return new BooleanItem(left.getEffectiveBooleanValue() || right.getEffectiveBooleanValue()
                 , ItemMetadata.fromIteratorMetadata(getMetadata()));
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
@@ -64,8 +64,8 @@ public class RangeOperationIterator extends BinaryOperationBaseIterator {
             if (_leftIterator.hasNext() || _rightIterator.hasNext() || !(left instanceof IntegerItem) || !(right instanceof IntegerItem))
                 throw new UnexpectedTypeException("Range expression has non numeric args " +
                         left.serialize() + ", " + right.serialize(), getMetadata());
-            _left = Item.getNumericValue(left, Integer.class);
-            _right = Item.getNumericValue(right, Integer.class);
+            _left = left.getNumericValue(Integer.class);
+            _right = right.getNumericValue(Integer.class);
             if (_right < _left) {
                 this._hasNext = false;
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
@@ -49,7 +49,7 @@ public class UnaryOperationIterator extends UnaryOperationBaseIterator {
 
             if(this._operator== OperationalExpressionBase.Operator.MINUS)
             {
-                if(Item.isNumeric(child)){
+                if(child.isNumeric()){
                     if(child instanceof IntegerItem)
                         return new IntegerItem(-1 * ((IntegerItem)child).getIntegerValue(),
                                 ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -70,13 +70,13 @@ public class ArrayLookupIterator extends LocalRuntimeIterator {
         if (lookupIterator.hasNext())
             throw new InvalidSelectorException("\"Invalid Lookup Key; Array lookup can't be performed with multiple keys: "
                     + lookupExpression.serialize(), getMetadata());
-        if (!Item.isNumeric(lookupExpression)) {
+        if (!lookupExpression.isNumeric()) {
             throw new UnexpectedTypeException("Type error; Non numeric array lookup for : "
                     + lookupExpression.serialize(), getMetadata());
         }
         lookupIterator.close();
 
-        _lookup = Item.getNumericValue(lookupExpression, Integer.class);
+        _lookup = lookupExpression.getNumericValue(Integer.class);
 
         _iterator.open(_currentDynamicContext);
         setNextResult();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
@@ -99,7 +99,7 @@ public class PredicateIterator extends LocalRuntimeIterator {
                     _nextResult = sequence.get(index - 1);
                 }
                 break;
-            } else if (Item.getEffectiveBooleanValue(fil)) {
+            } else if (fil != null && fil.getEffectiveBooleanValue()) {
                 _nextResult = item;
             }
             _filter.close();

--- a/src/main/java/sparksoniq/spark/closures/GroupByToPairMapClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/GroupByToPairMapClosure.java
@@ -53,7 +53,7 @@ public class GroupByToPairMapClosure implements PairFunction<FlworTuple, FlworKe
                 _groupVariable.getExpression().open(new DynamicContext(tuple));
                 while (_groupVariable.getExpression().hasNext()) {
                     Item resultItem = _groupVariable.getExpression().next();
-                    if (!Item.isAtomic(resultItem))
+                    if (!resultItem.isAtomic())
                         throw new NonAtomicKeyException("Group by keys must be atomics",
                                 _groupVariable.getIteratorMetadata().getExpressionMetadata());
                     newVariableResults.add(resultItem);

--- a/src/main/java/sparksoniq/spark/closures/OrderByMapToPairClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/OrderByMapToPairClosure.java
@@ -49,7 +49,7 @@ public class OrderByMapToPairClosure implements PairFunction<FlworTuple, FlworKe
             orderByExpression.getExpression().open(new DynamicContext(tuple));
             while (orderByExpression.getExpression().hasNext()){
                 Item resultItem = orderByExpression.getExpression().next();
-                if(resultItem != null && !Item.isAtomic(resultItem))
+                if(resultItem != null && !resultItem.isAtomic())
                     throw new NonAtomicKeyException("Order by keys must be atomics",
                             orderByExpression.getIteratorMetadata().getExpressionMetadata());
                 results.add(resultItem);

--- a/src/main/java/sparksoniq/spark/tuple/FlworKey.java
+++ b/src/main/java/sparksoniq/spark/tuple/FlworKey.java
@@ -94,10 +94,10 @@ public class FlworKey implements KryoSerializable, Comparable<FlworKey> {
                     comparisonItem instanceof ArrayItem || comparisonItem instanceof ObjectItem)
                 throw new SparksoniqRuntimeException("Non atomic key not allowed");
             else if(!currentItem.getClass().getSimpleName().equals(comparisonItem.getClass().getSimpleName())
-                    && (!Item.isNumeric(comparisonItem) || !Item.isNumeric(currentItem)))
+                    && (!comparisonItem.isNumeric() || !currentItem.isNumeric()))
                 throw new SparksoniqRuntimeException("Invalid sort key, different Item types");
             else
-                result = Item.compareItems(currentItem, comparisonItem);
+                result = currentItem.compareTo(comparisonItem);
 
             if(result != 0)
                 return new ResultIndexKeyTuple(result, index);


### PR DESCRIPTION
As preparation to the following PR on sequence max-min methods, I have implemented Comparable interface in the Item class. Edit: Mentioned PR is https://github.com/Sparksoniq/sparksoniq/pull/106

Following this, I have went through a refactoring process to remove static methods and replaced them with functions that worked on instances. I believe this improves usability as well as provides better overriding capabilities for the child classes. @wscsprint3r If there is a point I'm missing regarding the original static implementations, please provide feedback.