### PR TITLE
[WIP] Fix orderby and groupby implementations

### DIFF
--- a/src/main/resources/test_files/runtime-spark/LocalClauses/GroupbyClauseLocalError1.iq
+++ b/src/main/resources/test_files/runtime-spark/LocalClauses/GroupbyClauseLocalError1.iq
@@ -2,7 +2,7 @@
 for $i in (
    { "product" : "broiler", "store number" : 1, "quantity" : 20  },
    { "product" : "toaster", "store number" : 2, "quantity" : "aaaa"  })
-order by $i."quantity"
+group by $j := $i."quantity"
 return $i
 
-(: mismatch in order types:)
+(: mismatch in group types:)

--- a/src/main/resources/test_files/runtime-spark/LocalClauses/GroupbyClauseLocalError2.iq
+++ b/src/main/resources/test_files/runtime-spark/LocalClauses/GroupbyClauseLocalError2.iq
@@ -1,0 +1,8 @@
+(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; :)
+for $i in (1,2,3)
+let $j := (1, 2)
+order by $j
+return $i
+
+(: can't order on sequences :)
+

--- a/src/main/resources/test_files/runtime-spark/LocalClauses/OrderClauseLocalError2.iq
+++ b/src/main/resources/test_files/runtime-spark/LocalClauses/OrderClauseLocalError2.iq
@@ -1,0 +1,9 @@
+(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; :)
+for $i in (1,2,3)
+let $j := (1, 2)
+order by $j
+return $i
+
+(: can't group on sequences :)
+
+


### PR DESCRIPTION
Implementations of orderby and groupby clauses work with sequences which should be throwing a TypeMismatchError as implemented in the Dataframe extension (#251 )

Groupby implementation doesn't throw an error when the grouping variable contains different types. TypeMismatchError should be thrown