### PR TITLE
Variable dependencies

### DIFF
--- a/src/main/java/sparksoniq/JsoniqQueryExecutor.java
+++ b/src/main/java/sparksoniq/JsoniqQueryExecutor.java
@@ -78,6 +78,13 @@ public class JsoniqQueryExecutor {
         generateStaticContext(visitor.getQueryExpression());
         // generate iterators
         RuntimeIterator result = generateRuntimeIterators(visitor.getQueryExpression());
+        if(_configuration.isPrintIteratorTree())
+        {
+            StringBuffer sb = new StringBuffer();
+            result.print(sb, 0);
+            System.out.println(sb);
+            return;
+        }
         if (result.isRDD() && outputPath != null) {
             JavaRDD<Item> rdd = result.getRDD(new DynamicContext());
             JavaRDD<String> output = rdd.map(o -> o.serialize());

--- a/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
+++ b/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
@@ -80,6 +80,13 @@ public class SparksoniqRuntimeConfiguration {
         else
             return false;
     }
+
+    public boolean isPrintIteratorTree() {
+        if (this._arguments.containsKey("print-iterator-tree"))
+            return _arguments.get("print-iterator-tree").equals("yes");
+        else
+            return false;
+    }
     
     public boolean isLocal() {
         String masterConfig = SparkSessionManager.getInstance().getJavaSparkContext().getConf().get("spark.master");

--- a/src/main/java/sparksoniq/jsoniq/compiler/translator/expr/primary/VariableReference.java
+++ b/src/main/java/sparksoniq/jsoniq/compiler/translator/expr/primary/VariableReference.java
@@ -21,13 +21,10 @@ package sparksoniq.jsoniq.compiler.translator.expr.primary;
 
 
 import sparksoniq.jsoniq.compiler.translator.metadata.ExpressionMetadata;
-import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.semantics.types.SequenceType;
 import sparksoniq.semantics.visitor.AbstractExpressionOrClauseVisitor;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 
 public class VariableReference extends PrimaryExpression implements Serializable {
 

--- a/src/main/java/sparksoniq/jsoniq/compiler/translator/expr/primary/VariableReference.java
+++ b/src/main/java/sparksoniq/jsoniq/compiler/translator/expr/primary/VariableReference.java
@@ -21,10 +21,13 @@ package sparksoniq.jsoniq.compiler.translator.expr.primary;
 
 
 import sparksoniq.jsoniq.compiler.translator.metadata.ExpressionMetadata;
+import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.semantics.types.SequenceType;
 import sparksoniq.semantics.visitor.AbstractExpressionOrClauseVisitor;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 public class VariableReference extends PrimaryExpression implements Serializable {
 
@@ -60,6 +63,4 @@ public class VariableReference extends PrimaryExpression implements Serializable
         result += (prefix ? ")" : "") + ")";
         return result;
     }
-
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -222,6 +222,13 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
             buffer.append("  ");
         }
         buffer.append(getClass().getName());
+        buffer.append(" | ");
+
+        buffer.append("Variable dependencies: ");
+        for(String v : getVariableDependencies())
+        {
+          buffer.append(v + " ");
+        }
         buffer.append("\n");
         for (RuntimeIterator iterator : this._children) {
             iterator.print(buffer, indent + 1);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -33,7 +33,9 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static sparksoniq.jsoniq.item.Item.isNumeric;
 
@@ -198,5 +200,15 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
         if (result != null && !(type.isInstance(result)))
             throw new UnexpectedTypeException("Invalid item type returned by iterator", iterator.getMetadata());
         return (T) result;
+    }
+
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        for(RuntimeIterator iterator : _children)
+        {
+            result.addAll(iterator.getVariableDependencies());
+        }
+        return result;
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -23,6 +23,9 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+
+import scala.reflect.internal.Trees.This;
+
 import org.apache.spark.api.java.JavaRDD;
 import sparksoniq.exceptions.InvalidArgumentTypeException;
 import sparksoniq.exceptions.IteratorFlowException;
@@ -210,5 +213,18 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
             result.addAll(iterator.getVariableDependencies());
         }
         return result;
+    }
+    
+    public void print(StringBuffer buffer, int indent)
+    {
+        for (int i = 0; i < indent; ++i)
+        {
+            buffer.append("  ");
+        }
+        buffer.append(getClass().getName());
+        buffer.append("\n");
+        for (RuntimeIterator iterator : this._children) {
+            iterator.print(buffer, indent + 1);
+        }
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
@@ -32,7 +32,9 @@ import sparksoniq.semantics.DynamicContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class PredicateIterator extends HybridRuntimeIterator {
 
@@ -141,5 +143,14 @@ public class PredicateIterator extends HybridRuntimeIterator {
     @Override
     protected boolean initIsRDD() {
         return this._iterator.isRDD();
+    }
+
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_filter.getVariableDependencies());
+        result.remove("$");
+        result.addAll(_iterator.getVariableDependencies());
+        return result;
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
@@ -22,6 +22,7 @@ package sparksoniq.jsoniq.runtime.iterator.primary;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;
+import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 
 import java.util.ArrayList;
@@ -44,5 +45,10 @@ public class ContextExpressionIterator extends LocalRuntimeIterator {
         throw new IteratorFlowException("Invalid next() call in Context Expression!", getMetadata());
     }
 
-
+    public List<String> getVariableDependencies()
+    {
+        List<String> result = new ArrayList<String>();
+        result.add("$");
+        return result;
+    }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
@@ -22,11 +22,12 @@ package sparksoniq.jsoniq.runtime.iterator.primary;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;
-import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ContextExpressionIterator extends LocalRuntimeIterator {
     public ContextExpressionIterator(IteratorMetadata iteratorMetadata) {
@@ -45,9 +46,9 @@ public class ContextExpressionIterator extends LocalRuntimeIterator {
         throw new IteratorFlowException("Invalid next() call in Context Expression!", getMetadata());
     }
 
-    public List<String> getVariableDependencies()
+    public Set<String> getVariableDependencies()
     {
-        List<String> result = new ArrayList<String>();
+        Set<String> result = new HashSet<String>();
         result.add("$");
         return result;
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/VariableReferenceIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/VariableReferenceIterator.java
@@ -27,6 +27,7 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.semantics.types.SequenceType;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class VariableReferenceIterator extends LocalRuntimeIterator {
@@ -79,5 +80,12 @@ public class VariableReferenceIterator extends LocalRuntimeIterator {
 
     public String getVariableName() {
         return _variableName;
+    }
+
+    public List<String> getVariableDependencies()
+    {
+        List<String> result = new ArrayList<String>();
+        result.add(_variableName);
+        return result;
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/VariableReferenceIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/VariableReferenceIterator.java
@@ -27,8 +27,9 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.semantics.types.SequenceType;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class VariableReferenceIterator extends LocalRuntimeIterator {
 
@@ -82,9 +83,9 @@ public class VariableReferenceIterator extends LocalRuntimeIterator {
         return _variableName;
     }
 
-    public List<String> getVariableDependencies()
+    public Set<String> getVariableDependencies()
     {
-        List<String> result = new ArrayList<String>();
+        Set<String> result = new HashSet<String>();
         result.add(_variableName);
         return result;
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
@@ -101,6 +101,16 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
 
     public abstract JavaRDD<FlworTuple> getRDD(DynamicContext context);
 
+    /*
+    * Variable dependencies are variables that MUST be provided in the dynamic context
+    * for successful execution.
+    * 
+    * These variables are:
+    * 1. All variables that the expression of the clause depends on (recursive call of getVariableDependencies on the expression)
+    * 2. Except those variables bound in the current FLWOR (obtained from the auxiliary method getVariablesBoundInCurrentFLWORExpression), because those are provided in the Tuples
+    * 3.Plus (recursively calling getVariableDependencies) all the Variable Dependencies of the child clause if it exists.
+    * 
+    */
     public Set<String> getVariableDependencies()
     {
         Set<String> result = new HashSet<String>();
@@ -108,6 +118,11 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
         return result;
     }
 
+    /*
+     * Returns the variables bound in previous clauses of the current FLWOR.
+     * These variables can be removed from the dependencies of expressions in subsequent clauses,
+     * because their values are provided in the tuples rather than the dynamic context object.
+     */
     public Set<String> getVariablesBoundInCurrentFLWORExpression()
     {
         return new HashSet<String>();

--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
@@ -24,14 +24,11 @@ import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.apache.spark.api.java.JavaRDD;
 import sparksoniq.exceptions.IteratorFlowException;
-import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;

--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
@@ -23,8 +23,15 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.spark.api.java.JavaRDD;
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
@@ -96,5 +103,10 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
 
     public abstract JavaRDD<FlworTuple> getRDD(DynamicContext context);
 
-
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_child.getVariableDependencies());
+        return result;
+    }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
@@ -120,23 +120,15 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
             buffer.append("  ");
         }
         buffer.append(getClass().getName());
-        buffer.append("\n");
+        buffer.append(" | ");
 
-        for (int i = 0; i < indent + 1; ++i)
-        {
-            buffer.append("  ");
-        }
         buffer.append("Variable dependencies: ");
         for(String v : getVariableDependencies())
         {
           buffer.append(v + " ");
         }
-        buffer.append("\n");
+        buffer.append(" | ");
 
-        for (int i = 0; i < indent + 1; ++i)
-        {
-            buffer.append("  ");
-        }
         buffer.append("Variables bound in current FLWOR: ");
         for(String v : getBoundVariables())
         {

--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
@@ -108,7 +108,7 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
         return result;
     }
 
-    public Set<String> getBoundVariables()
+    public Set<String> getVariablesBoundInCurrentFLWORExpression()
     {
         return new HashSet<String>();
     }
@@ -130,7 +130,7 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
         buffer.append(" | ");
 
         buffer.append("Variables bound in current FLWOR: ");
-        for(String v : getBoundVariables())
+        for(String v : getVariablesBoundInCurrentFLWORExpression())
         {
           buffer.append(v + " ");
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.apache.spark.api.java.JavaRDD;
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
@@ -110,5 +111,42 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
     public Set<String> getBoundVariables()
     {
         return new HashSet<String>();
+    }
+    
+    public void print(StringBuffer buffer, int indent)
+    {
+        for (int i = 0; i < indent; ++i)
+        {
+            buffer.append("  ");
+        }
+        buffer.append(getClass().getName());
+        buffer.append("\n");
+
+        for (int i = 0; i < indent + 1; ++i)
+        {
+            buffer.append("  ");
+        }
+        buffer.append("Variable dependencies: ");
+        for(String v : getVariableDependencies())
+        {
+          buffer.append(v + " ");
+        }
+        buffer.append("\n");
+
+        for (int i = 0; i < indent + 1; ++i)
+        {
+            buffer.append("  ");
+        }
+        buffer.append("Variables bound in current FLWOR: ");
+        for(String v : getBoundVariables())
+        {
+          buffer.append(v + " ");
+        }
+        buffer.append("\n");
+
+        if(_child != null)
+        {
+          _child.print(buffer, indent + 1);
+        }
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
@@ -106,4 +106,9 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
         result.addAll(_child.getVariableDependencies());
         return result;
     }
+
+    public Set<String> getBoundVariables()
+    {
+        return new HashSet<String>();
+    }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
@@ -119,10 +119,10 @@ public class CountClauseSparkIterator extends SparkRuntimeTupleIterator {
         return result;
     }
 
-    public Set<String> getBoundVariables()
+    public Set<String> getVariablesBoundInCurrentFLWORExpression()
     {
         Set<String> result = new HashSet<String>();
-        result.addAll(_child.getBoundVariables());
+        result.addAll(_child.getVariablesBoundInCurrentFLWORExpression());
         result.add(_variableName);
         return result;
     }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
@@ -122,6 +122,7 @@ public class CountClauseSparkIterator extends SparkRuntimeTupleIterator {
     public Set<String> getBoundVariables()
     {
         Set<String> result = new HashSet<String>();
+        result.addAll(_child.getBoundVariables());
         result.add(_variableName);
         return result;
     }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
@@ -115,6 +115,13 @@ public class CountClauseSparkIterator extends SparkRuntimeTupleIterator {
     public Set<String> getVariableDependencies()
     {
         Set<String> result = new HashSet<String>();
+        result.addAll(_child.getVariableDependencies());
+        return result;
+    }
+
+    public Set<String> getBoundVariables()
+    {
+        Set<String> result = new HashSet<String>();
         result.add(_variableName);
         return result;
     }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
@@ -126,4 +126,15 @@ public class CountClauseSparkIterator extends SparkRuntimeTupleIterator {
         result.add(_variableName);
         return result;
     }
+    
+    public void print(StringBuffer buffer, int indent)
+    {
+        super.print(buffer, indent);
+        for (int i = 0; i < indent + 1; ++i)
+        {
+            buffer.append("  ");
+        }
+        buffer.append("Variable " + _variableName);
+        buffer.append("\n");
+    }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
@@ -35,7 +35,9 @@ import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.closures.CountClauseClosure;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class CountClauseSparkIterator extends SparkRuntimeTupleIterator {
     private String _variableName;
@@ -108,5 +110,12 @@ public class CountClauseSparkIterator extends SparkRuntimeTupleIterator {
         return _child.getRDD(context).zipWithIndex()
                 .mapValues(index -> index + 1)
                 .map(new CountClauseClosure(variableName, getMetadata()));
+    }
+
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        result.add(_variableName);
+        return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -204,4 +204,16 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
         result.add(_variableName);
         return result;
     }
+    
+    public void print(StringBuffer buffer, int indent)
+    {
+        super.print(buffer, indent);
+        for (int i = 0; i < indent + 1; ++i)
+        {
+            buffer.append("  ");
+        }
+        buffer.append("Variable " + _variableName);
+        buffer.append("\n");
+        _expression.print(buffer, indent+1);
+    }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -186,15 +186,21 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
     {
         Set<String> result = new HashSet<String>();
         result.addAll(_expression.getVariableDependencies());
-        result.remove(_child.getBoundVariables());
-        result.addAll(_child.getVariableDependencies());
+        if(_child != null)
+        {
+            result.remove(_child.getBoundVariables());
+            result.addAll(_child.getVariableDependencies());
+        }
         return result;
     }
 
     public Set<String> getBoundVariables()
     {
         Set<String> result = new HashSet<String>();
-        result.addAll(_child.getBoundVariables());
+        if(_child != null)
+        {
+            result.addAll(_child.getBoundVariables());
+        }
         result.add(_variableName);
         return result;
     }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -188,7 +188,7 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
         result.addAll(_expression.getVariableDependencies());
         if(_child != null)
         {
-            result.remove(_child.getBoundVariables());
+            result.removeAll(_child.getBoundVariables());
             result.addAll(_child.getVariableDependencies());
         }
         return result;

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -186,7 +186,16 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
     {
         Set<String> result = new HashSet<String>();
         result.addAll(_expression.getVariableDependencies());
-        result.remove(_variableName);
+        result.remove(_child.getBoundVariables());
+        result.addAll(_child.getVariableDependencies());
+        return result;
+    }
+
+    public Set<String> getBoundVariables()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_child.getBoundVariables());
+        result.add(_variableName);
         return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -188,18 +188,18 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
         result.addAll(_expression.getVariableDependencies());
         if(_child != null)
         {
-            result.removeAll(_child.getBoundVariables());
+            result.removeAll(_child.getVariablesBoundInCurrentFLWORExpression());
             result.addAll(_child.getVariableDependencies());
         }
         return result;
     }
 
-    public Set<String> getBoundVariables()
+    public Set<String> getVariablesBoundInCurrentFLWORExpression()
     {
         Set<String> result = new HashSet<String>();
         if(_child != null)
         {
-            result.addAll(_child.getBoundVariables());
+            result.addAll(_child.getVariablesBoundInCurrentFLWORExpression());
         }
         result.add(_variableName);
         return result;

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -35,7 +35,9 @@ import sparksoniq.spark.closures.ForClauseLocalToRDDClosure;
 import sparksoniq.spark.closures.InitialForClauseClosure;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
 
@@ -178,5 +180,13 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
             }
         }
         return _rdd;
+    }
+
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_expression.getVariableDependencies());
+        result.remove(_variableName);
+        return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -216,8 +216,20 @@ public class GroupByClauseSparkIterator extends SparkRuntimeTupleIterator {
         for(GroupByClauseSparkIteratorExpression iterator : _variables)
         {
             result.addAll(iterator.getExpression().getVariableDependencies());
-            result.remove(iterator.getVariableReference());
         }
+        result.remove(_child.getBoundVariables());
+        result.addAll(_child.getVariableDependencies());
+        return result;
+    }
+
+    public Set<String> getBoundVariables()
+    {
+        Set<String> result = new HashSet<String>();
+        for(GroupByClauseSparkIteratorExpression iterator : _variables)
+        {
+            result.add(iterator.getVariableReference().getVariableName());
+        }
+        result.addAll(_child.getBoundVariables());
         return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -40,9 +40,11 @@ import sparksoniq.spark.iterator.flowr.expression.GroupByClauseSparkIteratorExpr
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class GroupByClauseSparkIterator extends SparkRuntimeTupleIterator {
     private final List<GroupByClauseSparkIteratorExpression> _variables;
@@ -206,5 +208,16 @@ public class GroupByClauseSparkIterator extends SparkRuntimeTupleIterator {
         //linearize iterable tuples into arrays
         this._rdd = groupedPair.map(new GroupByLinearizeTupleClosure(_variables));
         return _rdd;
+    }
+
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        for(GroupByClauseSparkIteratorExpression iterator : _variables)
+        {
+            result.addAll(iterator.getExpression().getVariableDependencies());
+            result.remove(iterator.getVariableReference());
+        }
+        return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -217,7 +217,7 @@ public class GroupByClauseSparkIterator extends SparkRuntimeTupleIterator {
         {
             result.addAll(iterator.getExpression().getVariableDependencies());
         }
-        result.remove(_child.getBoundVariables());
+        result.removeAll(_child.getBoundVariables());
         result.addAll(_child.getVariableDependencies());
         return result;
     }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -232,4 +232,19 @@ public class GroupByClauseSparkIterator extends SparkRuntimeTupleIterator {
         result.addAll(_child.getBoundVariables());
         return result;
     }
+    
+    public void print(StringBuffer buffer, int indent)
+    {
+        super.print(buffer, indent);
+        for(GroupByClauseSparkIteratorExpression iterator : _variables)
+        {
+            for (int i = 0; i < indent + 1; ++i)
+            {
+                buffer.append("  ");
+            }
+            buffer.append("Variable " + iterator.getVariableReference().getVariableName());
+            buffer.append("\n");
+            iterator.getExpression().print(buffer, indent+1);
+        }
+    }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -217,19 +217,19 @@ public class GroupByClauseSparkIterator extends SparkRuntimeTupleIterator {
         {
             result.addAll(iterator.getExpression().getVariableDependencies());
         }
-        result.removeAll(_child.getBoundVariables());
+        result.removeAll(_child.getVariablesBoundInCurrentFLWORExpression());
         result.addAll(_child.getVariableDependencies());
         return result;
     }
 
-    public Set<String> getBoundVariables()
+    public Set<String> getVariablesBoundInCurrentFLWORExpression()
     {
         Set<String> result = new HashSet<String>();
         for(GroupByClauseSparkIteratorExpression iterator : _variables)
         {
             result.add(iterator.getVariableReference().getVariableName());
         }
-        result.addAll(_child.getBoundVariables());
+        result.addAll(_child.getVariablesBoundInCurrentFLWORExpression());
         return result;
     }
     

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -161,4 +161,16 @@ public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
         result.add(_variableName);
         return result;
     }
+    
+    public void print(StringBuffer buffer, int indent)
+    {
+        super.print(buffer, indent);
+        for (int i = 0; i < indent + 1; ++i)
+        {
+            buffer.append("  ");
+        }
+        buffer.append("Variable " + _variableName);
+        buffer.append("\n");
+        _expression.print(buffer, indent+1);
+    }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -145,18 +145,18 @@ public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
         result.addAll(_expression.getVariableDependencies());
         if(_child != null)
         {
-            result.removeAll(_child.getBoundVariables());
+            result.removeAll(_child.getVariablesBoundInCurrentFLWORExpression());
             result.addAll(_child.getVariableDependencies());
         }
         return result;
     }
 
-    public Set<String> getBoundVariables()
+    public Set<String> getVariablesBoundInCurrentFLWORExpression()
     {
         Set<String> result = new HashSet<String>();
         if(_child != null)
         {
-            result.addAll(_child.getBoundVariables());
+            result.addAll(_child.getVariablesBoundInCurrentFLWORExpression());
         }
         result.add(_variableName);
         return result;

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -143,7 +143,16 @@ public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
     {
         Set<String> result = new HashSet<String>();
         result.addAll(_expression.getVariableDependencies());
-        result.remove(_variableName);
+        result.remove(_child.getBoundVariables());
+        result.addAll(_child.getVariableDependencies());
+        return result;
+    }
+
+    public Set<String> getBoundVariables()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_child.getBoundVariables());
+        result.add(_variableName);
         return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -33,7 +33,9 @@ import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.closures.LetClauseMapClosure;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
 
@@ -135,5 +137,13 @@ public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
             return _rdd;
         }
         throw new SparksoniqRuntimeException("Initial letClauses don't support RDDs");
+    }
+
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_expression.getVariableDependencies());
+        result.remove(_variableName);
+        return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -145,7 +145,7 @@ public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
         result.addAll(_expression.getVariableDependencies());
         if(_child != null)
         {
-            result.remove(_child.getBoundVariables());
+            result.removeAll(_child.getBoundVariables());
             result.addAll(_child.getVariableDependencies());
         }
         return result;

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -143,15 +143,21 @@ public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
     {
         Set<String> result = new HashSet<String>();
         result.addAll(_expression.getVariableDependencies());
-        result.remove(_child.getBoundVariables());
-        result.addAll(_child.getVariableDependencies());
+        if(_child != null)
+        {
+            result.remove(_child.getBoundVariables());
+            result.addAll(_child.getVariableDependencies());
+        }
         return result;
     }
 
     public Set<String> getBoundVariables()
     {
         Set<String> result = new HashSet<String>();
-        result.addAll(_child.getBoundVariables());
+        if(_child != null)
+        {
+            result.addAll(_child.getBoundVariables());
+        }
         result.add(_variableName);
         return result;
     }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -197,4 +197,13 @@ public class OrderByClauseSparkIterator extends SparkRuntimeTupleIterator {
         result.addAll(_child.getBoundVariables());
         return result;
     }
+    
+    public void print(StringBuffer buffer, int indent)
+    {
+        super.print(buffer, indent);
+        for(OrderByClauseSparkIteratorExpression iterator : _expressions)
+        {
+            iterator.getExpression().print(buffer, indent+1);
+        }
+    }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -34,10 +34,13 @@ import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.closures.OrderByClauseSortClosure;
 import sparksoniq.spark.closures.OrderByMapToPairClosure;
+import sparksoniq.spark.iterator.flowr.expression.GroupByClauseSparkIteratorExpression;
 import sparksoniq.spark.iterator.flowr.expression.OrderByClauseSparkIteratorExpression;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.TreeMap;
 
 public class OrderByClauseSparkIterator extends SparkRuntimeTupleIterator {
@@ -174,5 +177,15 @@ public class OrderByClauseSparkIterator extends SparkRuntimeTupleIterator {
         keyTuplePair = keyTuplePair.sortByKey(new OrderByClauseSortClosure(this._expressions, _isStable));
         //map back to tuple RDD
         return keyTuplePair.map(tuple2 -> tuple2._2());
+    }
+
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        for(OrderByClauseSparkIteratorExpression iterator : _expressions)
+        {
+            result.addAll(iterator.getExpression().getVariableDependencies());
+        }
+        return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -186,15 +186,15 @@ public class OrderByClauseSparkIterator extends SparkRuntimeTupleIterator {
         {
             result.addAll(iterator.getExpression().getVariableDependencies());
         }
-        result.removeAll(_child.getBoundVariables());
+        result.removeAll(_child.getVariablesBoundInCurrentFLWORExpression());
         result.addAll(_child.getVariableDependencies());
         return result;
     }
 
-    public Set<String> getBoundVariables()
+    public Set<String> getVariablesBoundInCurrentFLWORExpression()
     {
         Set<String> result = new HashSet<String>();
-        result.addAll(_child.getBoundVariables());
+        result.addAll(_child.getVariablesBoundInCurrentFLWORExpression());
         return result;
     }
     

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -34,7 +34,6 @@ import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.closures.OrderByClauseSortClosure;
 import sparksoniq.spark.closures.OrderByMapToPairClosure;
-import sparksoniq.spark.iterator.flowr.expression.GroupByClauseSparkIteratorExpression;
 import sparksoniq.spark.iterator.flowr.expression.OrderByClauseSparkIteratorExpression;
 
 import java.util.ArrayList;

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -34,6 +34,7 @@ import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.closures.OrderByClauseSortClosure;
 import sparksoniq.spark.closures.OrderByMapToPairClosure;
+import sparksoniq.spark.iterator.flowr.expression.GroupByClauseSparkIteratorExpression;
 import sparksoniq.spark.iterator.flowr.expression.OrderByClauseSparkIteratorExpression;
 
 import java.util.ArrayList;
@@ -185,6 +186,15 @@ public class OrderByClauseSparkIterator extends SparkRuntimeTupleIterator {
         {
             result.addAll(iterator.getExpression().getVariableDependencies());
         }
+        result.removeAll(_child.getBoundVariables());
+        result.addAll(_child.getVariableDependencies());
+        return result;
+    }
+
+    public Set<String> getBoundVariables()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_child.getBoundVariables());
         return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -141,7 +141,7 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
     {
         Set<String> result = new HashSet<String>();
         result.addAll(_expression.getVariableDependencies());
-        result.removeAll(_child.getBoundVariables());
+        result.removeAll(_child.getVariablesBoundInCurrentFLWORExpression());
         result.addAll(_child.getVariableDependencies());
         return result;
     }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -155,5 +155,6 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
         buffer.append(getClass().getName());
         buffer.append("\n");
         _child.print(buffer, indent + 1);
+        _expression.print(buffer, indent + 1);
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -145,4 +145,15 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
         result.addAll(_child.getVariableDependencies());
         return result;
     }
+    
+    public void print(StringBuffer buffer, int indent)
+    {
+        for (int i = 0; i < indent; ++i)
+        {
+            buffer.append("  ");
+        }
+        buffer.append(getClass().getName());
+        buffer.append("\n");
+        _child.print(buffer, indent + 1);
+    }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -30,7 +30,11 @@ import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.closures.ReturnFlatMapClosure;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
 
@@ -135,5 +139,11 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
         setNextLocalResult();
     }
 
-
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_expression.getVariableDependencies());
+        result.addAll(_child.getVariableDependencies());
+        return result;
+    }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -141,6 +141,7 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
     {
         Set<String> result = new HashSet<String>();
         result.addAll(_expression.getVariableDependencies());
+        result.removeAll(_child.getBoundVariables());
         result.addAll(_child.getVariableDependencies());
         return result;
     }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -30,10 +30,8 @@ import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.closures.ReturnFlatMapClosure;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class ReturnClauseSparkIterator extends HybridRuntimeIterator {

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -19,6 +19,9 @@
  */
 package sparksoniq.spark.iterator.flowr;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.spark.api.java.JavaRDD;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
@@ -107,5 +110,13 @@ public class WhereClauseSparkIterator extends SparkRuntimeTupleIterator {
             throw new SparksoniqRuntimeException("Invalid where clause.");
         }
         return _rdd;
+    }
+
+    public Set<String> getVariableDependencies()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_expression.getVariableDependencies());
+        result.addAll(_child.getVariableDependencies());
+        return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -116,15 +116,15 @@ public class WhereClauseSparkIterator extends SparkRuntimeTupleIterator {
     {
         Set<String> result = new HashSet<String>();
         result.addAll(_expression.getVariableDependencies());
-        result.removeAll(_child.getBoundVariables());
+        result.removeAll(_child.getVariablesBoundInCurrentFLWORExpression());
         result.addAll(_child.getVariableDependencies());
         return result;
     }
 
-    public Set<String> getBoundVariables()
+    public Set<String> getVariablesBoundInCurrentFLWORExpression()
     {
         Set<String> result = new HashSet<String>();
-        result.addAll(_child.getBoundVariables());
+        result.addAll(_child.getVariablesBoundInCurrentFLWORExpression());
         return result;
     }
     

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -116,7 +116,15 @@ public class WhereClauseSparkIterator extends SparkRuntimeTupleIterator {
     {
         Set<String> result = new HashSet<String>();
         result.addAll(_expression.getVariableDependencies());
+        result.remove(_child.getBoundVariables());
         result.addAll(_child.getVariableDependencies());
+        return result;
+    }
+
+    public Set<String> getBoundVariables()
+    {
+        Set<String> result = new HashSet<String>();
+        result.addAll(_child.getBoundVariables());
         return result;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -116,7 +116,7 @@ public class WhereClauseSparkIterator extends SparkRuntimeTupleIterator {
     {
         Set<String> result = new HashSet<String>();
         result.addAll(_expression.getVariableDependencies());
-        result.remove(_child.getBoundVariables());
+        result.removeAll(_child.getBoundVariables());
         result.addAll(_child.getVariableDependencies());
         return result;
     }
@@ -126,5 +126,11 @@ public class WhereClauseSparkIterator extends SparkRuntimeTupleIterator {
         Set<String> result = new HashSet<String>();
         result.addAll(_child.getBoundVariables());
         return result;
+    }
+    
+    public void print(StringBuffer buffer, int indent)
+    {
+        super.print(buffer,  indent);
+        _expression.print(buffer, indent + 1);
     }
 }


### PR DESCRIPTION
Adding a function to the runtime iterator APIs to get the list of variables that any expression or clauses depends on via the dynamic context. Based on this, we will be able, in the new DataFrames implementation, to only pass those variables that are actually needed to UDFs, and to project away columns that are not needed by subsequent clauses.