### PR TITLE
Refactor static methods of Item class

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/item/BooleanItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/BooleanItem.java
@@ -49,6 +49,11 @@ public class BooleanItem extends AtomicItem {
     }
 
     @Override
+    public boolean getEffectiveBooleanValue() {
+        return this.getBooleanValue();
+    }
+
+    @Override
     public boolean isBoolean() {
         return true;
     }

--- a/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
@@ -52,6 +52,16 @@ public class DecimalItem extends AtomicItem {
     }
 
     @Override
+    public <T> T getNumericValue(Class<T> type) {
+        BigDecimal result = this.getDecimalValue();
+        if (type.equals(Integer.class))
+            return (T) new Integer(result.intValue());
+        if (type.equals(Double.class))
+            return (T) new Double(result.doubleValue());
+        return (T) result;
+    }
+
+    @Override
     public boolean isDecimal() {
         return true;
     }
@@ -77,37 +87,29 @@ public class DecimalItem extends AtomicItem {
     public void read(Kryo kryo, Input input) {
         this._value = kryo.readObject(input, BigDecimal.class);
     }
-    
-    public boolean equals(Object otherItem)
-    {
-        if(!(otherItem instanceof Item))
-        {
+
+    public boolean equals(Object otherItem) {
+        if (!(otherItem instanceof Item)) {
             return false;
         }
-        Item o = (Item)otherItem;
-        if(o.isInteger())
-        {
-            if(getDecimalValue().stripTrailingZeros().scale() > 0)
-            {
+        Item o = (Item) otherItem;
+        if (o.isInteger()) {
+            if (getDecimalValue().stripTrailingZeros().scale() > 0) {
                 return false;
             }
             return getDecimalValue().intValueExact() == o.getIntegerValue();
         }
-        if(o.isDecimal())
-        {
+        if (o.isDecimal()) {
             return (getDecimalValue().equals(o.getDecimalValue()));
         }
-        if(o.isDouble())
-        {
+        if (o.isDouble()) {
             return (o.getDoubleValue() == getDecimalValue().doubleValue());
         }
         return false;
     }
-    
-    public int hashCode()
-    {
-        if(getDecimalValue().stripTrailingZeros().scale() == 0)
-        {
+
+    public int hashCode() {
+        if (getDecimalValue().stripTrailingZeros().scale() == 0) {
             return getDecimalValue().intValue();
         }
         return getDecimalValue().hashCode();

--- a/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
@@ -52,6 +52,11 @@ public class DecimalItem extends AtomicItem {
     }
 
     @Override
+    public boolean getEffectiveBooleanValue() {
+        return !this.getDecimalValue().equals(0);
+    }
+
+    @Override
     public <T> T getNumericValue(Class<T> type) {
         BigDecimal result = this.getDecimalValue();
         if (type.equals(Integer.class))

--- a/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
@@ -51,6 +51,11 @@ public class DoubleItem extends AtomicItem {
     }
 
     @Override
+    public boolean getEffectiveBooleanValue() {
+        return this.getDoubleValue() != 0;
+    }
+
+    @Override
     public <T> T getNumericValue(Class<T> type) {
         Double result = this.getDoubleValue();
         if (type.equals(BigDecimal.class))

--- a/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
@@ -26,6 +26,8 @@ import com.esotericsoftware.kryo.io.Output;
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 
+import java.math.BigDecimal;
+
 public class DoubleItem extends AtomicItem {
 
     private double _value;
@@ -46,6 +48,16 @@ public class DoubleItem extends AtomicItem {
     @Override
     public double getDoubleValue() {
         return _value;
+    }
+
+    @Override
+    public <T> T getNumericValue(Class<T> type) {
+        Double result = this.getDoubleValue();
+        if (type.equals(BigDecimal.class))
+            return (T) BigDecimal.valueOf(result);
+        if (type.equals(Integer.class))
+            return (T) new Integer(result.intValue());
+        return (T) result;
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
@@ -51,6 +51,11 @@ public class IntegerItem extends AtomicItem {
     }
 
     @Override
+    public boolean getEffectiveBooleanValue() {
+        return this.getIntegerValue() != 0;
+    }
+
+    @Override
     public <T> T getNumericValue(Class<T> type) {
         Integer result = this.getIntegerValue();
         if (type.equals(BigDecimal.class))

--- a/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
@@ -26,6 +26,8 @@ import com.esotericsoftware.kryo.io.Output;
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 
+import java.math.BigDecimal;
+
 public class IntegerItem extends AtomicItem {
 
     private int _value;
@@ -46,6 +48,16 @@ public class IntegerItem extends AtomicItem {
     @Override
     public int getIntegerValue() {
         return _value;
+    }
+
+    @Override
+    public <T> T getNumericValue(Class<T> type) {
+        Integer result = this.getIntegerValue();
+        if (type.equals(BigDecimal.class))
+            return (T) BigDecimal.valueOf(result);
+        if (type.equals(Double.class))
+            return (T) new Double(result.doubleValue());
+        return (T) result;
     }
 
     @Override
@@ -75,35 +87,28 @@ public class IntegerItem extends AtomicItem {
     public void read(Kryo kryo, Input input) {
         this._value = input.readInt();
     }
-    
-    public boolean equals(Object otherItem)
-    {
-        if(!(otherItem instanceof Item))
-        {
+
+    public boolean equals(Object otherItem) {
+        if (!(otherItem instanceof Item)) {
             return false;
         }
-        Item o = (Item)otherItem;
-        if(o.isInteger())
-        {
+        Item o = (Item) otherItem;
+        if (o.isInteger()) {
             return getIntegerValue() == o.getIntegerValue();
         }
-        if(o.isDecimal())
-        {
-            if(o.getDecimalValue().stripTrailingZeros().scale() > 0)
-            {
+        if (o.isDecimal()) {
+            if (o.getDecimalValue().stripTrailingZeros().scale() > 0) {
                 return false;
             }
             return o.getDecimalValue().intValueExact() == getIntegerValue();
         }
-        if(o.isDouble())
-        {
-            return (o.getDoubleValue() == (double)getIntegerValue());
+        if (o.isDouble()) {
+            return (o.getDoubleValue() == (double) getIntegerValue());
         }
         return false;
     }
-    
-    public int hashCode()
-    {
+
+    public int hashCode() {
         return getIntegerValue();
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/item/Item.java
+++ b/src/main/java/sparksoniq/jsoniq/item/Item.java
@@ -37,8 +37,8 @@ public abstract class Item implements SerializableItem {
     protected Item() {
     }
 
-    public static boolean isNumeric(Item item) {
-        return item.isInteger() || item.isDecimal() || item.isDouble();
+    public boolean isNumeric() {
+        return this.isInteger() || this.isDecimal() || this.isDouble();
     }
 
     //performs conversions for binary operations with a numeric return type
@@ -55,26 +55,26 @@ public abstract class Item implements SerializableItem {
         return IntegerItem.class;
     }
 
-    public static <T> T getNumericValue(Item item, Class<T> type) {
-        if (isNumeric(item)) {
-            if (item.isDouble()) {
-                Double result = item.getDoubleValue();
+    public <T> T getNumericValue(Class<T> type) {
+        if (this.isNumeric()) {
+            if (this.isDouble()) {
+                Double result = this.getDoubleValue();
                 if (type.equals(BigDecimal.class))
                     return (T) BigDecimal.valueOf(result);
                 if (type.equals(Integer.class))
                     return (T) new Integer(result.intValue());
                 return (T) result;
             }
-            if (item.isInteger()) {
-                Integer result = item.getIntegerValue();
+            if (this.isInteger()) {
+                Integer result = this.getIntegerValue();
                 if (type.equals(BigDecimal.class))
                     return (T) BigDecimal.valueOf(result);
                 if (type.equals(Double.class))
                     return (T) new Double(result.doubleValue());
                 return (T) result;
             }
-            if (item.isDecimal()) {
-                BigDecimal result = item.getDecimalValue();
+            if (this.isDecimal()) {
+                BigDecimal result = this.getDecimalValue();
                 if (type.equals(Integer.class))
                     return (T) new Integer(result.intValue());
                 if (type.equals(Double.class))
@@ -87,25 +87,23 @@ public abstract class Item implements SerializableItem {
     }
 
     //returns an effective boolean value of any item type
-    public static boolean getEffectiveBooleanValue(Item item) {
-        if (item == null)
+    public boolean getEffectiveBooleanValue() {
+        if (this.isBoolean())
+            return this.getBooleanValue();
+        else if (this.isNumeric()) {
+            if (this.isInteger())
+                return this.getIntegerValue() != 0;
+            else if (this.isDouble())
+                return this.getDoubleValue() != 0;
+            else if (this.isDecimal())
+                return !this.getDecimalValue().equals(0);
+        } else if (this.isNull())
             return false;
-        else if (item.isBoolean())
-            return item.getBooleanValue();
-        else if (isNumeric(item)) {
-            if (item.isInteger())
-                return item.getIntegerValue() != 0;
-            else if (item.isDouble())
-                return item.getDoubleValue() != 0;
-            else if (item.isDecimal())
-                return !item.getDecimalValue().equals(0);
-        } else if (item.isNull())
-            return false;
-        else if (item.isString())
-            return !item.getStringValue().isEmpty();
-        else if (item.isObject())
+        else if (this.isString())
+            return !this.getStringValue().isEmpty();
+        else if (this.isObject())
             return true;
-        else if (item.isArray())
+        else if (this.isArray())
             return true;
 
         return true;
@@ -116,33 +114,33 @@ public abstract class Item implements SerializableItem {
      * Non-atomics can't be compared.
      * Items have to be of the same type or one them has to be null.
      *
-     * @return -1 if v1 < v2; 0 if v1 == v2; 1 if v1 > v2;
+     * @return -1 if this < other; 0 if this == other; 1 if this > other;
      */
-    public static int compareItems(Item v1, Item v2) {
+    public int compareTo(Item other) {
         int result;
-        if (Item.isNumeric(v1) && Item.isNumeric(v2)) {
-            BigDecimal value1 = Item.getNumericValue(v1, BigDecimal.class);
-            BigDecimal value2 = Item.getNumericValue(v2, BigDecimal.class);
+        if (this.isNumeric() && other.isNumeric()) {
+            BigDecimal value1 = this.getNumericValue(BigDecimal.class);
+            BigDecimal value2 = other.getNumericValue(BigDecimal.class);
             result = value1.compareTo(value2);
-        } else if (v1.isBoolean() && v2.isBoolean()) {
-            Boolean value1 = new Boolean(v1.getBooleanValue());
-            Boolean value2 = new Boolean(v2.getBooleanValue());
+        } else if (this.isBoolean() && other.isBoolean()) {
+            Boolean value1 = this.getBooleanValue();
+            Boolean value2 = other.getBooleanValue();
             result = value1.compareTo(value2);
-        } else if (v1.isString() && v2.isString()) {
-            String value1 = v1.getStringValue();
-            String value2 = v2.getStringValue();
+        } else if (this.isString() && other.isString()) {
+            String value1 = this.getStringValue();
+            String value2 = other.getStringValue();
             result = value1.compareTo(value2);
-        } else if (v1.isNull() || v2.isNull()) {
+        } else if (this.isNull() || other.isNull()) {
             // null equals null
-            if (v1.isNull() && v2.isNull()) {
+            if (this.isNull() && other.isNull()) {
                 result = 0;
-            } else if (v1.isNull()) {
+            } else if (this.isNull()) {
                 result = -1;
             } else {
                 result = 1;
             }
         } else {
-            result = v1.serialize().compareTo(v2.serialize());
+            result = this.serialize().compareTo(other.serialize());
         }
         return result;
     }

--- a/src/main/java/sparksoniq/jsoniq/item/Item.java
+++ b/src/main/java/sparksoniq/jsoniq/item/Item.java
@@ -60,27 +60,7 @@ public abstract class Item implements SerializableItem {
     }
 
     //returns an effective boolean value of any item type
-    public boolean getEffectiveBooleanValue() {
-        if (this.isBoolean())
-            return this.getBooleanValue();
-        else if (this.isNumeric()) {
-            if (this.isInteger())
-                return this.getIntegerValue() != 0;
-            else if (this.isDouble())
-                return this.getDoubleValue() != 0;
-            else if (this.isDecimal())
-                return !this.getDecimalValue().equals(0);
-        } else if (this.isNull())
-            return false;
-        else if (this.isString())
-            return !this.getStringValue().isEmpty();
-        else if (this.isObject())
-            return true;
-        else if (this.isArray())
-            return true;
-
-        return true;
-    }
+    public abstract boolean getEffectiveBooleanValue();
 
     /**
      * Function that compares 2 items.

--- a/src/main/java/sparksoniq/jsoniq/item/Item.java
+++ b/src/main/java/sparksoniq/jsoniq/item/Item.java
@@ -56,33 +56,6 @@ public abstract class Item implements SerializableItem {
     }
 
     public <T> T getNumericValue(Class<T> type) {
-        if (this.isNumeric()) {
-            if (this.isDouble()) {
-                Double result = this.getDoubleValue();
-                if (type.equals(BigDecimal.class))
-                    return (T) BigDecimal.valueOf(result);
-                if (type.equals(Integer.class))
-                    return (T) new Integer(result.intValue());
-                return (T) result;
-            }
-            if (this.isInteger()) {
-                Integer result = this.getIntegerValue();
-                if (type.equals(BigDecimal.class))
-                    return (T) BigDecimal.valueOf(result);
-                if (type.equals(Double.class))
-                    return (T) new Double(result.doubleValue());
-                return (T) result;
-            }
-            if (this.isDecimal()) {
-                BigDecimal result = this.getDecimalValue();
-                if (type.equals(Integer.class))
-                    return (T) new Integer(result.intValue());
-                if (type.equals(Double.class))
-                    return (T) new Double(result.doubleValue());
-                return (T) result;
-            }
-
-        }
         throw new IteratorFlowException("Cannot call getNumericValue on non numeric");
     }
 

--- a/src/main/java/sparksoniq/jsoniq/item/ItemComparatorForSequences.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ItemComparatorForSequences.java
@@ -36,9 +36,9 @@ public class ItemComparatorForSequences implements Comparator<Item>, Serializabl
      */
     public int compare(Item v1, Item v2) {
         int result;
-        if (Item.isNumeric(v1) && Item.isNumeric(v2)) {
-            BigDecimal value1 = Item.getNumericValue(v1, BigDecimal.class);
-            BigDecimal value2 = Item.getNumericValue(v2, BigDecimal.class);
+        if (v1.isNumeric() && v2.isNumeric()) {
+            BigDecimal value1 = v1.getNumericValue(BigDecimal.class);
+            BigDecimal value2 = v2.getNumericValue(BigDecimal.class);
             result = value1.compareTo(value2);
         } else if (v1.isBoolean() && v2.isBoolean()) {
             Boolean value1 = new Boolean(v1.getBooleanValue());

--- a/src/main/java/sparksoniq/jsoniq/item/JsonItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/JsonItem.java
@@ -30,6 +30,11 @@ public abstract class JsonItem extends Item {
     }
 
     @Override
+    public boolean getEffectiveBooleanValue() {
+        return true;
+    }
+
+    @Override
     public boolean isAtomic() {
         return false;
     }

--- a/src/main/java/sparksoniq/jsoniq/item/NullItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/NullItem.java
@@ -41,6 +41,11 @@ public class NullItem extends AtomicItem {
     }
 
     @Override
+    public boolean getEffectiveBooleanValue() {
+        return false;
+    }
+
+    @Override
     public void write(Kryo kryo, Output output) {
         kryo.writeObjectOrNull(output, null, Item.class);
     }

--- a/src/main/java/sparksoniq/jsoniq/item/StringItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/StringItem.java
@@ -49,6 +49,11 @@ public class StringItem extends AtomicItem {
     }
 
     @Override
+    public boolean getEffectiveBooleanValue() {
+        return !this.getStringValue().isEmpty();
+    }
+
+    @Override
     public boolean isTypeOf(ItemType type) {
         if (type.getType().equals(ItemTypes.StringItem) || super.isTypeOf(type))
             return true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -24,7 +24,6 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-
 import org.apache.spark.api.java.JavaRDD;
 import sparksoniq.exceptions.InvalidArgumentTypeException;
 import sparksoniq.exceptions.IteratorFlowException;
@@ -38,8 +37,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static sparksoniq.jsoniq.item.Item.isNumeric;
 
 public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoSerializable {
     protected static final String FLOW_EXCEPTION_MESSAGE = "Invalid next() call; ";
@@ -73,7 +70,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
             boolean result;
             if (item.isBoolean())
                 result = item.getBooleanValue();
-            else if (isNumeric(item)) {
+            else if (item.isNumeric()) {
                 if (item.isInteger())
                     result = item.getIntegerValue() != 0;
                 else if (item.isDouble())

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -57,9 +57,9 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
+            if (value.isNumeric()) {
                 try {
-                    Double result = Math.abs(Item.getNumericValue(value, Double.class));
+                    Double result = Math.abs(value.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
                 } catch (IteratorFlowException e) {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
@@ -57,9 +57,9 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
+            if (value.isNumeric()) {
                 try {
-                    Double result = Math.ceil(Item.getNumericValue(value, Double.class));
+                    Double result = Math.ceil(value.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
 
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -57,9 +57,9 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
+            if (value.isNumeric()) {
                 try {
-                    Double result = Math.floor(Item.getNumericValue(value, Double.class));
+                    Double result = Math.floor(value.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
 
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
@@ -73,11 +73,11 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
             else {
                 precision = ItemFactory.getInstance().createIntegerItem(0);
             }
-            if (Item.isNumeric(value) && Item.isNumeric(precision)) {
+            if (value.isNumeric() && precision.isNumeric()) {
                 try {
 
-                    Double val = Item.getNumericValue(value, Double.class);
-                    Integer prec = Item.getNumericValue(precision, Integer.class);
+                    Double val = value.getNumericValue(Double.class);
+                    Integer prec = precision.getNumericValue(Integer.class);
 
                     BigDecimal bd = new BigDecimal(val);
                     bd = bd.setScale(prec, RoundingMode.HALF_UP);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -73,11 +73,11 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
             else {
                 precision = ItemFactory.getInstance().createIntegerItem(0);
             }
-            if (Item.isNumeric(value) && Item.isNumeric(precision)) {
+            if (value.isNumeric() && precision.isNumeric()) {
 
                 try {
-                    Double val = Item.getNumericValue(value, Double.class);
-                    Integer prec = Item.getNumericValue(precision, Integer.class);
+                    Double val = value.getNumericValue(Double.class);
+                    Integer prec = precision.getNumericValue(Integer.class);
 
                     BigDecimal bd = new BigDecimal(val);
                     bd = bd.setScale(prec, RoundingMode.HALF_EVEN);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -57,9 +57,9 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item exponent = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(exponent)) {
+            if (exponent.isNumeric()) {
                 try {
-                    Double result = Math.pow(10.0, Item.getNumericValue(exponent, Double.class));
+                    Double result = Math.pow(10.0, exponent.getNumericValue(Double.class));
 
                     return ItemFactory.getInstance().createDoubleItem(result);
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
@@ -57,9 +57,9 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item exponent = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(exponent)) {
+            if (exponent.isNumeric()) {
                 try {
-                    Double result = Math.exp(Item.getNumericValue(exponent, Double.class));
+                    Double result = Math.exp(exponent.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
 
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -57,9 +57,9 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
+            if (value.isNumeric()) {
                 try {
-                    Double result = Math.log10(Item.getNumericValue(value, Double.class));
+                    Double result = Math.log10(value.getNumericValue(Double.class));
 
                     return ItemFactory.getInstance().createDoubleItem(result);
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -57,9 +57,9 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
+            if (value.isNumeric()) {
                 try {
-                    Double result = Math.log(Item.getNumericValue(value, Double.class));
+                    Double result = Math.log(value.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
 
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -64,10 +64,10 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
             } else {
                 throw new UnexpectedTypeException("Type error; Exponent parameter can't be empty sequence ", getMetadata());
             }
-            if (Item.isNumeric(base) && Item.isNumeric(exponent)) {
+            if (base.isNumeric() && exponent.isNumeric()) {
                 try {
-                    Double result = Math.pow(Item.getNumericValue(base, Double.class)
-                            , Item.getNumericValue(exponent, Double.class));
+                    Double result = Math.pow(base.getNumericValue(Double.class)
+                            , exponent.getNumericValue(Double.class));
                     this._hasNext = false;
                     return ItemFactory.getInstance().createDoubleItem(result);
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -56,9 +56,9 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
     public Item next() {
         if (this._hasNext) {
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(value)) {
+            if (value.isNumeric()) {
                 try {
-                    Double result = Math.sqrt(Item.getNumericValue(value, Double.class));
+                    Double result = Math.sqrt(value.getNumericValue(Double.class));
                     this._hasNext = false;
                     return ItemFactory.getInstance().createDoubleItem(result);
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -57,9 +57,9 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
+            if (radians.isNumeric()) {
                 try {
-                    Double result = Math.acos(Item.getNumericValue(radians, Double.class));
+                    Double result = Math.acos(radians.getNumericValue(Double.class));
 
                     return ItemFactory.getInstance().createDoubleItem(result);
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -57,9 +57,9 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
+            if (radians.isNumeric()) {
                 try {
-                    Double result = Math.asin(Item.getNumericValue(radians, Double.class));
+                    Double result = Math.asin(radians.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
 
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -56,10 +56,10 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
                 throw new UnexpectedTypeException("Type error; x parameter can't be empty sequence ", getMetadata());
             }
 
-            if (Item.isNumeric(y) && Item.isNumeric(x)) {
+            if (y.isNumeric() && x.isNumeric()) {
                 try {
-                    Double result = Math.atan2(Item.getNumericValue(y, Double.class)
-                            , Item.getNumericValue(x, Double.class));
+                    Double result = Math.atan2(y.getNumericValue(Double.class)
+                            , x.getNumericValue(Double.class));
                     this._hasNext = false;
                     return ItemFactory.getInstance().createDoubleItem(result);
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -57,9 +57,9 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
+            if (radians.isNumeric()) {
                 try {
-                    Double result = Math.atan(Item.getNumericValue(radians, Double.class));
+                    Double result = Math.atan(radians.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
 
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -57,9 +57,9 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
+            if (radians.isNumeric()) {
                 try {
-                    Double result = Math.cos(Item.getNumericValue(radians, Double.class));
+                    Double result = Math.cos(radians.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
 
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -57,9 +57,9 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
+            if (radians.isNumeric()) {
                 try {
-                    Double result = Math.sin(Item.getNumericValue(radians, Double.class));
+                    Double result = Math.sin(radians.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
 
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -57,9 +57,9 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
-            if (Item.isNumeric(radians)) {
+            if (radians.isNumeric()) {
                 try {
-                    Double result = Math.tan(Item.getNumericValue(radians, Double.class));
+                    Double result = Math.tan(radians.getNumericValue(Double.class));
                     return ItemFactory.getInstance().createDoubleItem(result);
 
                 } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -59,7 +59,7 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
             List<Item> results = getItemsFromIteratorWithCurrentContext(_iterator);
             this._hasNext = false;
             results.forEach(r -> {
-                if (!Item.isNumeric(r))
+                if (!r.isNumeric())
                     throw new InvalidArgumentTypeException("Average expression has non numeric args " +
                             r.serialize(), getMetadata());
             });
@@ -67,7 +67,8 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
                 //TODO check numeric types conversions
                 BigDecimal sum = new BigDecimal(0);
                 for (Item r : results)
-                    sum = sum.add(Item.getNumericValue(r, BigDecimal.class));
+                    sum = sum.add(r.getNumericValue(BigDecimal.class));
+
                 return ItemFactory.getInstance().createDecimalItem(sum.divide(new BigDecimal(results.size())));
 
             } catch (IteratorFlowException e) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
@@ -78,7 +78,7 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
             }
 
             results.forEach(r -> {
-                if (!Item.isNumeric(r))
+                if (!r.isNumeric())
                     throw new InvalidArgumentTypeException("Sum expression has non numeric args " +
                             r.serialize(), getMetadata());
             });
@@ -86,7 +86,7 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
                 // if input is empty sequence and _zeroItem is not given 0 is returned
                 BigDecimal sumResult = new BigDecimal(0);
                 for (Item r : results) {
-                    BigDecimal current = Item.getNumericValue(r, BigDecimal.class);
+                    BigDecimal current = r.getNumericValue(BigDecimal.class);
                     sumResult = sumResult.add(current);
                 }
                 return ItemFactory.getInstance().createDecimalItem(sumResult);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -73,7 +73,7 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
                 throw new NonAtomicKeyException(
                         "Invalid args. subsequence can't be performed with an object parameter as the length",
                         getMetadata().getExpressionMetadata());
-            } else if (!(Item.isNumeric(lengthItem))) {
+            } else if (!(lengthItem.isNumeric())) {
                 throw new UnexpectedTypeException(
                         "Invalid args. Length parameter should be an numeric(Integer/Decimal/Double)",
                         getMetadata());
@@ -81,7 +81,7 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
             lengthIterator.close();
             // round double to nearest int
             try {
-                _length = (int) Math.round((Item.getNumericValue(lengthItem, Double.class)));
+                _length = (int) Math.round((lengthItem.getNumericValue(Double.class)));
 
             } catch (IteratorFlowException e) {
                 throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
@@ -105,14 +105,14 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
             throw new NonAtomicKeyException(
                     "Invalid args. subsequence can't be performed with an object parameter as the position",
                     getMetadata().getExpressionMetadata());
-        } else if (!(Item.isNumeric(positionItem))) {
+        } else if (!(positionItem.isNumeric())) {
             throw new UnexpectedTypeException(
                     "Invalid args. Position parameter should be a numeric(Integer/Decimal/Double)",
                     getMetadata());
         }
         positionIterator.close();
         // round double to nearest int
-        _startPosition = (int) Math.round((Item.getNumericValue(positionItem, Double.class)));
+        _startPosition = (int) Math.round((positionItem.getNumericValue(Double.class)));
 
         // first, perform all parameter checks (above)
         // if length is 0, just return empty sequence

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/value/IndexOfFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/value/IndexOfFunctionIterator.java
@@ -88,7 +88,7 @@ public class IndexOfFunctionIterator extends LocalFunctionCallIterator {
             if (!item.isAtomic()) {
                 throw new NonAtomicKeyException("Invalid args. index-of can't be performed with a non-atomic in the input sequence", getMetadata().getExpressionMetadata());
             } else {
-                if (Item.compareItems(item, _search) == 0) {
+                if (item.compareTo(_search) == 0) {
                     _nextResult = ItemFactory.getInstance().createIntegerItem(_currentIndex);
                     break;
                 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
@@ -55,8 +55,8 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
             Type returnType = Item.getNumericResultType(_left, _right);
             if (returnType.equals(IntegerItem.class)) {
                 try {
-                    int l = Item.<Integer>getNumericValue(_left, Integer.class);
-                    int r = Item.<Integer>getNumericValue(_right, Integer.class);
+                    int l = _left.getNumericValue(Integer.class);
+                    int r = _right.getNumericValue(Integer.class);
                     return this._operator == OperationalExpressionBase.Operator.PLUS ?
                             ItemFactory.getInstance().createIntegerItem(l + r) :
                             ItemFactory.getInstance().createIntegerItem(l - r);
@@ -66,8 +66,8 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
                 }
             } else if (returnType.equals(DoubleItem.class)) {
                 try {
-                    double l = Item.<Double>getNumericValue(_left, Double.class);
-                    double r = Item.<Double>getNumericValue(_right, Double.class);
+                    double l = _left.getNumericValue(Double.class);
+                    double r = _right.getNumericValue(Double.class);
                     return this._operator == OperationalExpressionBase.Operator.PLUS ?
                             ItemFactory.getInstance().createDoubleItem(l + r) :
                             ItemFactory.getInstance().createDoubleItem(l - r);
@@ -77,8 +77,8 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
                 }
             } else if (returnType.equals(DecimalItem.class)) {
                 try {
-                    BigDecimal l = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
-                    BigDecimal r = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
+                    BigDecimal l = _left.getNumericValue(BigDecimal.class);
+                    BigDecimal r = _right.getNumericValue(BigDecimal.class);
                     return this._operator == OperationalExpressionBase.Operator.PLUS ?
                             ItemFactory.getInstance().createDecimalItem(l.add(r)) :
                             ItemFactory.getInstance().createDecimalItem(l.subtract(r));
@@ -106,7 +106,7 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
         } else {
             _left = _leftIterator.next();
             _right = _rightIterator.next();
-            if (_leftIterator.hasNext() || _rightIterator.hasNext() || !Item.isNumeric(_left) || !Item.isNumeric(_right))
+            if (_leftIterator.hasNext() || _rightIterator.hasNext() || !_left.isNumeric() || !_right.isNumeric())
                 throw new UnexpectedTypeException("Additive expression has non numeric args " +
                         _left.serialize() + ", " + _right.serialize(), getMetadata());
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
@@ -140,8 +140,8 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
         }
         if (left.isNull() || right.isNull()) {
             return compareItems(left, right);
-        } else if (Item.isNumeric(left)) {
-            if (!Item.isNumeric(right))
+        } else if (left.isNumeric()) {
+            if (!right.isNumeric())
                 throw new UnexpectedTypeException("Invalid args for numerics comparison " + left.serialize() +
                         ", " + right.serialize(), getMetadata());
             return compareItems(left, right);
@@ -161,7 +161,7 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
     }
 
     public Item compareItems(Item left, Item right) {
-        int comparison = Item.compareItems(left, right);
+        int comparison = left.compareTo(right);
         switch (this._operator) {
             case VC_EQ:
             case GC_EQ:

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -59,7 +59,7 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
         } else {
             _left = _leftIterator.next();
             _right = _rightIterator.next();
-            if (_leftIterator.hasNext() || _rightIterator.hasNext() || !Item.isNumeric(_left) || !Item.isNumeric(_right))
+            if (_leftIterator.hasNext() || _rightIterator.hasNext() || !_left.isNumeric() || !_right.isNumeric())
                 throw new UnexpectedTypeException("Multiplicative expression has non numeric args " +
                         _left.serialize() + ", " + _right.serialize(), getMetadata());
 
@@ -77,14 +77,14 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
             Type returnType = Item.getNumericResultType(_left, _right);
             if (returnType.equals(IntegerItem.class)) {
                 try {
-                    int l = Item.<Integer>getNumericValue(_left, Integer.class);
-                    int r = Item.<Integer>getNumericValue(_right, Integer.class);
+                    int l = _left.getNumericValue(Integer.class);
+                    int r = _right.getNumericValue(Integer.class);
                     switch (this._operator) {
                         case MUL:
                             return ItemFactory.getInstance().createIntegerItem(l * r);
                         case DIV:
-                            BigDecimal decLeft = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
-                            BigDecimal decRight = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
+                            BigDecimal decLeft = _left.getNumericValue(BigDecimal.class);
+                            BigDecimal decRight = _right.getNumericValue(BigDecimal.class);
                             BigDecimal bdResult = decLeft.divide(decRight, 10, BigDecimal.ROUND_HALF_UP);
                             // if the result contains no decimal part, convert to integer
                             if (bdResult.stripTrailingZeros().scale() <= 0) {
@@ -109,8 +109,8 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
                 }
             } else if (returnType.equals(DoubleItem.class)) {
-                double l = Item.<Double>getNumericValue(_left, Double.class);
-                double r = Item.<Double>getNumericValue(_right, Double.class);
+                double l = _left.getNumericValue(Double.class);
+                double r = _right.getNumericValue(Double.class);
                 switch (this._operator) {
                     case MUL:
                         return ItemFactory.getInstance().createDoubleItem(l * r);
@@ -124,8 +124,8 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                         new IteratorFlowException("Non recognized multicative operator.", getMetadata());
                 }
             } else if (returnType.equals(DecimalItem.class)) {
-                BigDecimal l = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
-                BigDecimal r = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
+                BigDecimal l = _left.getNumericValue(BigDecimal.class);
+                BigDecimal r = _right.getNumericValue(BigDecimal.class);
                 switch (this._operator) {
                     case MUL:
                         return ItemFactory.getInstance().createDecimalItem(l.multiply(r));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
@@ -68,8 +68,8 @@ public class RangeOperationIterator extends BinaryOperationBaseIterator {
                 throw new UnexpectedTypeException("Range expression has non numeric args " +
                         left.serialize() + ", " + right.serialize(), getMetadata());
             try {
-                _left = Item.getNumericValue(left, Integer.class);
-                _right = Item.getNumericValue(right, Integer.class);
+                _left = left.getNumericValue(Integer.class);
+                _right = right.getNumericValue(Integer.class);
             } catch (IteratorFlowException e) {
                 throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
@@ -48,7 +48,7 @@ public class UnaryOperationIterator extends UnaryOperationBaseIterator {
             _child.close();
 
             if (this._operator == OperationalExpressionBase.Operator.MINUS) {
-                if (Item.isNumeric(child)) {
+                if (child.isNumeric()) {
                     if (child.isInteger())
                         return ItemFactory.getInstance().createIntegerItem(-1 * child.getIntegerValue());
                     if (child.isDouble())

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -26,6 +26,7 @@ import sparksoniq.exceptions.InvalidSelectorException;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.ArrayItem;
+import sparksoniq.jsoniq.item.IntegerItem;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -83,13 +84,13 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
         if (lookupIterator.hasNext())
             throw new InvalidSelectorException("\"Invalid Lookup Key; Array lookup can't be performed with multiple keys: "
                     + lookupExpression.serialize(), getMetadata());
-        if (!Item.isNumeric(lookupExpression)) {
+        if (!lookupExpression.isNumeric()) {
             throw new UnexpectedTypeException("Type error; Non numeric array lookup for : "
                     + lookupExpression.serialize(), getMetadata());
         }
         lookupIterator.close();
         try {
-            _lookup = Item.getNumericValue(lookupExpression, Integer.class);
+            _lookup = lookupExpression.getNumericValue(Integer.class);
         } catch (IteratorFlowException e) {
             throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
@@ -113,7 +113,7 @@ public class PredicateIterator extends HybridRuntimeIterator {
                     _nextResult = sequence.get(index - 1);
                 }
                 break;
-            } else if (Item.getEffectiveBooleanValue(fil)) {
+            } else if (fil != null && fil.getEffectiveBooleanValue()) {
                 _nextResult = item;
                 break;
             }

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
@@ -86,7 +86,7 @@ public class FlworKey implements KryoSerializable {
             }
             if ((currentItem != null && comparisonItem != null)
                     && (!currentItem.getClass().getSimpleName().equals(comparisonItem.getClass().getSimpleName()))
-                    && ((!Item.isNumeric(comparisonItem) || !Item.isNumeric(currentItem)))) {
+                    && ((!comparisonItem.isNumeric() || !currentItem.isNumeric()))) {
                 throw new SparksoniqRuntimeException("Invalid sort key: Item types can't be different.");
             }
 
@@ -101,7 +101,7 @@ public class FlworKey implements KryoSerializable {
                     result = 1;
                 }
             } else {
-                result = Item.compareItems(currentItem, comparisonItem);
+                result = currentItem.compareTo(comparisonItem);
             }
 
             // Simplify comparison result to -1/0/1

--- a/src/main/java/sparksoniq/spark/udf/OrderClauseCreateColumnsUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/OrderClauseCreateColumnsUDF.java
@@ -128,11 +128,11 @@ public class OrderClauseCreateColumnsUDF implements UDF1<WrappedArray, Row> {
                     } else if (typeName.equals("string")) {
                         _results.add(nextItem.getStringValue());
                     } else if (typeName.equals("integer")) {
-                        _results.add(Item.getNumericValue(nextItem, Integer.class));
+                        _results.add(nextItem.getNumericValue(Integer.class));
                     } else if (typeName.equals("double")) {
-                        _results.add(Item.getNumericValue(nextItem, Double.class));
+                        _results.add(nextItem.getNumericValue(Double.class));
                     } else if (typeName.equals("decimal")) {
-                        _results.add(Item.getNumericValue(nextItem, BigDecimal.class));
+                        _results.add(nextItem.getNumericValue(BigDecimal.class));
                     } else {
                         throw new SparksoniqRuntimeException("Unexpected ordering type found while creating columns.");
                     }


### PR DESCRIPTION
I have kept 'getNumericResultType' as a static method as I felt it semantically lives on the Item class rather than a specific object