### PR TITLE
Treat as operator

### DIFF
--- a/src/main/java/sparksoniq/exceptions/TreatException.java
+++ b/src/main/java/sparksoniq/exceptions/TreatException.java
@@ -1,0 +1,13 @@
+package sparksoniq.exceptions;
+
+import sparksoniq.exceptions.codes.ErrorCodes;
+import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+
+public class TreatException extends SparksoniqRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TreatException(String message, IteratorMetadata metadata) {
+        super(message, ErrorCodes.DynamicTypeTreatErrorCode, metadata.getExpressionMetadata());
+    }
+}

--- a/src/main/java/sparksoniq/jsoniq/compiler/JsoniqExpressionTreeVisitor.java
+++ b/src/main/java/sparksoniq/jsoniq/compiler/JsoniqExpressionTreeVisitor.java
@@ -55,6 +55,7 @@ import sparksoniq.jsoniq.compiler.translator.expr.operational.NotExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.OrExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.RangeExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.StringConcatExpression;
+import sparksoniq.jsoniq.compiler.translator.expr.operational.TreatExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.UnaryExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.base.OperationalExpressionBase;
 import sparksoniq.jsoniq.compiler.translator.expr.postfix.PostFixExpression;
@@ -554,11 +555,11 @@ public class JsoniqExpressionTreeVisitor extends sparksoniq.jsoniq.compiler.pars
 
     @Override
     public Void visitInstanceOfExpr(JsoniqParser.InstanceOfExprContext ctx) {
-        UnaryExpression mainExpression;
+        TreatExpression mainExpression;
         FlworVarSequenceType sequenceType;
         InstanceOfExpression node;
         this.visitTreatExpr(ctx.mainExpr);
-        mainExpression = (UnaryExpression) this.currentExpression;
+        mainExpression = (TreatExpression) this.currentExpression;
         if (ctx.seq != null && !ctx.seq.isEmpty()) {
             JsoniqParser.SequenceTypeContext child = ctx.seq;
             this.visitSequenceType(child);
@@ -566,6 +567,25 @@ public class JsoniqExpressionTreeVisitor extends sparksoniq.jsoniq.compiler.pars
             node = new InstanceOfExpression(mainExpression, sequenceType, createMetadataFromContext(ctx));
         } else {
             node = new InstanceOfExpression(mainExpression, createMetadataFromContext(ctx));
+        }
+        this.currentExpression = node;
+        return null;
+    }
+
+    @Override
+    public Void visitTreatExpr(JsoniqParser.TreatExprContext ctx) {
+        UnaryExpression mainExpression;
+        FlworVarSequenceType sequenceType;
+        TreatExpression node;
+        this.visitCastableExpr(ctx.mainExpr);
+        mainExpression = (UnaryExpression) this.currentExpression;
+        if (ctx.seq != null && !ctx.seq.isEmpty()) {
+            JsoniqParser.SequenceTypeContext child = ctx.seq;
+            this.visitSequenceType(child);
+            sequenceType = (FlworVarSequenceType) this.currentExpression;
+            node = new TreatExpression(mainExpression, sequenceType, createMetadataFromContext(ctx));
+        } else {
+            node = new TreatExpression(mainExpression, createMetadataFromContext(ctx));
         }
         this.currentExpression = node;
         return null;

--- a/src/main/java/sparksoniq/jsoniq/compiler/parser/Jsoniq.g4
+++ b/src/main/java/sparksoniq/jsoniq/compiler/parser/Jsoniq.g4
@@ -99,7 +99,7 @@ multiplicativeExpr
 instanceOfExpr
          : mainExpr=treatExpr ( Kinstance Kof seq=sequenceType)?;
 treatExpr
-         : mainExpr=castableExpr ( Ktreat Kas sequenceType )?;
+         : mainExpr=castableExpr ( Ktreat Kas seq=sequenceType )?;
 castableExpr
          : mainExpr=castExpr ( Kcastable Kas atomicType '?'? )?;
 castExpr : mainExpr=unaryExpr ( Kcast Kas atomicType '?'? )?;

--- a/src/main/java/sparksoniq/jsoniq/compiler/parser/JsoniqParser.java
+++ b/src/main/java/sparksoniq/jsoniq/compiler/parser/JsoniqParser.java
@@ -3444,6 +3444,7 @@ public class JsoniqParser extends Parser {
 
 	public static class TreatExprContext extends ParserRuleContext {
 		public CastableExprContext mainExpr;
+		public SequenceTypeContext seq;
 		public CastableExprContext castableExpr() {
 			return getRuleContext(CastableExprContext.class,0);
 		}
@@ -3481,7 +3482,7 @@ public class JsoniqParser extends Parser {
 				setState(605);
 				match(Kas);
 				setState(606);
-				sequenceType();
+				((TreatExprContext)_localctx).seq = sequenceType();
 				}
 				break;
 			}
@@ -3634,7 +3635,7 @@ public class JsoniqParser extends Parser {
 		public Token s47;
 		public List<Token> op = new ArrayList<Token>();
 		public Token s46;
-		public Token _tset1271;
+		public Token _tset1273;
 		public SimpleMapExprContext mainExpr;
 		public SimpleMapExprContext simpleMapExpr() {
 			return getRuleContext(SimpleMapExprContext.class,0);
@@ -3664,17 +3665,17 @@ public class JsoniqParser extends Parser {
 				{
 				{
 				setState(627);
-				((UnaryExprContext)_localctx)._tset1271 = _input.LT(1);
+				((UnaryExprContext)_localctx)._tset1273 = _input.LT(1);
 				_la = _input.LA(1);
 				if ( !(_la==T__45 || _la==T__46) ) {
-					((UnaryExprContext)_localctx)._tset1271 = (Token)_errHandler.recoverInline(this);
+					((UnaryExprContext)_localctx)._tset1273 = (Token)_errHandler.recoverInline(this);
 				}
 				else {
 					if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
 					_errHandler.reportMatch(this);
 					consume();
 				}
-				((UnaryExprContext)_localctx).op.add(((UnaryExprContext)_localctx)._tset1271);
+				((UnaryExprContext)_localctx).op.add(((UnaryExprContext)_localctx)._tset1273);
 				}
 				}
 				setState(632);

--- a/src/main/java/sparksoniq/jsoniq/compiler/translator/expr/operational/TreatExpression.java
+++ b/src/main/java/sparksoniq/jsoniq/compiler/translator/expr/operational/TreatExpression.java
@@ -1,0 +1,48 @@
+package sparksoniq.jsoniq.compiler.translator.expr.operational;
+
+import sparksoniq.jsoniq.compiler.translator.expr.Expression;
+import sparksoniq.jsoniq.compiler.translator.expr.flowr.FlworVarSequenceType;
+import sparksoniq.jsoniq.compiler.translator.expr.operational.base.UnaryExpressionBase;
+import sparksoniq.jsoniq.compiler.translator.metadata.ExpressionMetadata;
+import sparksoniq.semantics.visitor.AbstractExpressionOrClauseVisitor;
+
+
+public class TreatExpression extends UnaryExpressionBase {
+
+    private FlworVarSequenceType _sequenceType;
+
+    public TreatExpression(Expression _mainExpression, ExpressionMetadata metadata) {
+        super(_mainExpression, metadata);
+        this._isActive = false;
+    }
+
+    public TreatExpression(Expression _mainExpression, FlworVarSequenceType sequenceType,
+                           ExpressionMetadata metadata) {
+        super(_mainExpression, Operator.TREAT, true, metadata);
+        this._sequenceType = sequenceType;
+    }
+
+    public FlworVarSequenceType getsequenceType() {
+        return _sequenceType;
+    }
+
+    @Override
+    public boolean isActive() {
+        return this._isActive;
+    }
+
+    @Override
+    public <T> T accept(AbstractExpressionOrClauseVisitor<T> visitor, T argument) {
+        return visitor.visitTreatExpression(this, argument);
+    }
+
+    @Override
+    public String serializationString(boolean prefix) {
+        String result = "(treatExpr ";
+        result += _mainExpression.serializationString(true);
+        result += _sequenceType != null ? " treat as " + _sequenceType.serializationString(prefix) : "";
+        result += ")";
+        return result;
+    }
+
+}

--- a/src/main/java/sparksoniq/jsoniq/compiler/translator/expr/operational/base/OperationalExpressionBase.java
+++ b/src/main/java/sparksoniq/jsoniq/compiler/translator/expr/operational/base/OperationalExpressionBase.java
@@ -108,6 +108,8 @@ public abstract class OperationalExpressionBase extends Expression {
                 return Operator.CONCAT;
             case "INSTANCE OF":
                 return Operator.INSTANCE_OF;
+            case "TREAT":
+                return Operator.TREAT;
         }
 
         return Operator.NONE;
@@ -126,6 +128,8 @@ public abstract class OperationalExpressionBase extends Expression {
                 return "||";
             case INSTANCE_OF:
                 return "instance of";
+            case TREAT:
+                return "treat as";
             default:
                 return operator.toString().toLowerCase();
         }
@@ -189,7 +193,7 @@ public abstract class OperationalExpressionBase extends Expression {
         CONCAT,
         INSTANCE_OF,
         COMMA,
-
+        TREAT,
 
         NONE,
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TreatIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TreatIterator.java
@@ -4,7 +4,6 @@ import org.rumbledb.api.Item;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.TreatException;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.base.OperationalExpressionBase;
-import sparksoniq.jsoniq.item.*;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
@@ -51,16 +50,21 @@ public class TreatIterator extends UnaryOperationIterator {
             items.add(_child.next());
         _child.close();
 
+        //... treat as ()
+        if (!items.isEmpty() && _sequenceType.isEmptySequence())
+            throw new TreatException(" " + ItemTypes.getItemTypeName(items.get(0).getClass().getSimpleName()) + " cannot be treated as type empty-sequence()", getMetadata());
+
         ItemType itemType = _sequenceType.getItemType();
         String sequenceTypeName = ItemTypes.getItemTypeName(itemType.getType().toString());
+
         //Empty sequence, more items
         if (items.isEmpty() && (_sequenceType.getArity() == SequenceType.Arity.One ||
                 _sequenceType.getArity() == SequenceType.Arity.OneOrMore)) {
-            throw new TreatException(" Empty list cannot be treated as type " + sequenceTypeName, getMetadata());
+            throw new TreatException(" Empty sequence cannot be treated as type " + sequenceTypeName + _sequenceType.getArity().getSymbol(), getMetadata());
         }
         if (items.size() > 1 && (_sequenceType.getArity() == SequenceType.Arity.One ||
                 _sequenceType.getArity() == SequenceType.Arity.OneOrZero)) {
-            throw new TreatException(" Sequences of more than one item cannot be treated as type " + sequenceTypeName, getMetadata());
+            throw new TreatException(" Sequences of more than one item cannot be treated as type " + sequenceTypeName + _sequenceType.getArity().getSymbol(), getMetadata());
         }
 
         results = new ArrayList<>();
@@ -70,7 +74,7 @@ public class TreatIterator extends UnaryOperationIterator {
                 results.add(item);
             } else {
                 results.clear();
-                throw new TreatException(" " + ItemTypes.getItemTypeName(item.getClass().getSimpleName()) + " cannot be treated as type " + sequenceTypeName, getMetadata());
+                throw new TreatException(" " + ItemTypes.getItemTypeName(item.getClass().getSimpleName()) + " cannot be treated as type " + sequenceTypeName + _sequenceType.getArity().getSymbol(), getMetadata());
             }
         }
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TreatIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TreatIterator.java
@@ -1,0 +1,86 @@
+package sparksoniq.jsoniq.runtime.iterator.operational;
+
+import org.rumbledb.api.Item;
+import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.exceptions.TreatException;
+import sparksoniq.jsoniq.compiler.translator.expr.operational.base.OperationalExpressionBase;
+import sparksoniq.jsoniq.item.*;
+import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
+import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
+import sparksoniq.semantics.types.ItemType;
+import sparksoniq.semantics.types.ItemTypes;
+import sparksoniq.semantics.types.SequenceType;
+
+import java.util.*;
+
+public class TreatIterator extends UnaryOperationIterator {
+
+    private static final long serialVersionUID = 1L;
+    private List<Item> results;
+    private final SequenceType _sequenceType;
+    private int _currentIndex = 0;
+
+    public TreatIterator(RuntimeIterator child, SequenceType sequenceType, IteratorMetadata iteratorMetadata) {
+        super(child, OperationalExpressionBase.Operator.TREAT, iteratorMetadata);
+        this._sequenceType = sequenceType;
+    }
+
+    @Override
+    public Item next() {
+        if (this._hasNext) {
+            return getResult();
+        } else
+            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());
+    }
+
+    public Item getResult() {
+        if (results == null || results.size() == 0) {
+            throw new IteratorFlowException("getResult called on an empty list of results", getMetadata());
+        }
+        if (_currentIndex == results.size() - 1)
+            _hasNext = false;
+        return results.get(_currentIndex++);
+    }
+
+    private void compute_treat_as() {
+        List<Item> items = new ArrayList<>();
+        _child.open(_currentDynamicContext);
+
+        while (_child.hasNext())
+            items.add(_child.next());
+        _child.close();
+
+        ItemType itemType = _sequenceType.getItemType();
+        String sequenceTypeName = ItemTypes.getItemTypeName(itemType.getType().toString());
+        //Empty sequence, more items
+        if (items.isEmpty() && (_sequenceType.getArity() == SequenceType.Arity.One ||
+                _sequenceType.getArity() == SequenceType.Arity.OneOrMore)) {
+            throw new TreatException(" Empty list cannot be treated as type " + sequenceTypeName, getMetadata());
+        }
+        if (items.size() > 1 && (_sequenceType.getArity() == SequenceType.Arity.One ||
+                _sequenceType.getArity() == SequenceType.Arity.OneOrZero)) {
+            throw new TreatException(" Sequences of more than one item cannot be treated as type " + sequenceTypeName, getMetadata());
+        }
+
+        results = new ArrayList<>();
+
+        for (Item item : items) {
+            if (item.isTypeOf(itemType)) {
+                results.add(item);
+            } else {
+                results.clear();
+                throw new TreatException(" " + ItemTypes.getItemTypeName(item.getClass().getSimpleName()) + " cannot be treated as type " + sequenceTypeName, getMetadata());
+            }
+        }
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        super.open(context);
+        this._currentIndex = 0;
+
+        this.compute_treat_as();
+        this._hasNext = results.size() != 0;
+    }
+}

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TreatIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TreatIterator.java
@@ -16,9 +16,9 @@ import java.util.*;
 public class TreatIterator extends UnaryOperationIterator {
 
     private static final long serialVersionUID = 1L;
-    private List<Item> results;
     private final SequenceType _sequenceType;
-    private int _currentIndex = 0;
+    private Item _nextResult;
+    private int _childIndex;
 
     public TreatIterator(RuntimeIterator child, SequenceType sequenceType, IteratorMetadata iteratorMetadata) {
         super(child, OperationalExpressionBase.Operator.TREAT, iteratorMetadata);
@@ -28,63 +28,51 @@ public class TreatIterator extends UnaryOperationIterator {
     @Override
     public Item next() {
         if (this._hasNext) {
-            return getResult();
+            Item result = _nextResult;
+            setNextResult();
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());
     }
 
-    public Item getResult() {
-        if (results == null || results.size() == 0) {
-            throw new IteratorFlowException("getResult called on an empty list of results", getMetadata());
-        }
-        if (_currentIndex == results.size() - 1)
-            _hasNext = false;
-        return results.get(_currentIndex++);
-    }
-
-    private void compute_treat_as() {
-        List<Item> items = new ArrayList<>();
-        _child.open(_currentDynamicContext);
-
-        while (_child.hasNext())
-            items.add(_child.next());
-        _child.close();
-
-        //... treat as ()
-        if (!items.isEmpty() && _sequenceType.isEmptySequence())
-            throw new TreatException(" " + ItemTypes.getItemTypeName(items.get(0).getClass().getSimpleName()) + " cannot be treated as type empty-sequence()", getMetadata());
-
+    private void setNextResult() {
         ItemType itemType = _sequenceType.getItemType();
         String sequenceTypeName = ItemTypes.getItemTypeName(itemType.getType().toString());
 
-        //Empty sequence, more items
-        if (items.isEmpty() && (_sequenceType.getArity() == SequenceType.Arity.One ||
-                _sequenceType.getArity() == SequenceType.Arity.OneOrMore)) {
-            throw new TreatException(" Empty sequence cannot be treated as type " + sequenceTypeName + _sequenceType.getArity().getSymbol(), getMetadata());
+        _nextResult = null;
+        if (_child.hasNext()) {
+            _nextResult = _child.next();
+        } else {
+            _child.close();
+            if (_childIndex == 0 && (_sequenceType.getArity() == SequenceType.Arity.One ||
+                    _sequenceType.getArity() == SequenceType.Arity.OneOrMore)) {
+                throw new TreatException(" Empty sequence cannot be treated as type " + sequenceTypeName + _sequenceType.getArity().getSymbol(), getMetadata());
+            }
         }
-        if (items.size() > 1 && (_sequenceType.getArity() == SequenceType.Arity.One ||
+
+        //... treat as ()
+        if (_nextResult != null && _sequenceType.isEmptySequence())
+            throw new TreatException(" " + ItemTypes.getItemTypeName(_nextResult.getClass().getSimpleName()) + " cannot be treated as type empty-sequence()", getMetadata());
+
+        //More items
+        if (_childIndex > 1 && (_sequenceType.getArity() == SequenceType.Arity.One ||
                 _sequenceType.getArity() == SequenceType.Arity.OneOrZero)) {
             throw new TreatException(" Sequences of more than one item cannot be treated as type " + sequenceTypeName + _sequenceType.getArity().getSymbol(), getMetadata());
         }
 
-        results = new ArrayList<>();
-
-        for (Item item : items) {
-            if (item.isTypeOf(itemType)) {
-                results.add(item);
-            } else {
-                results.clear();
-                throw new TreatException(" " + ItemTypes.getItemTypeName(item.getClass().getSimpleName()) + " cannot be treated as type " + sequenceTypeName + _sequenceType.getArity().getSymbol(), getMetadata());
-            }
+        if (_nextResult != null && !_nextResult.isTypeOf(itemType)) {
+            throw new TreatException(" " + ItemTypes.getItemTypeName(_nextResult.getClass().getSimpleName()) + " cannot be treated as type " + sequenceTypeName + _sequenceType.getArity().getSymbol(), getMetadata());
         }
+
+        this._hasNext = _nextResult != null;
+        _childIndex++;
     }
 
     @Override
     public void open(DynamicContext context) {
         super.open(context);
-        this._currentIndex = 0;
-
-        this.compute_treat_as();
-        this._hasNext = results.size() != 0;
+        this._childIndex = 0;
+        _child.open(_currentDynamicContext);
+        this.setNextResult();
     }
 }

--- a/src/main/java/sparksoniq/semantics/types/ItemTypes.java
+++ b/src/main/java/sparksoniq/semantics/types/ItemTypes.java
@@ -35,5 +35,13 @@ public enum ItemTypes {
     DoubleItem,
     BooleanItem,
 
-    NullItem
+    NullItem;
+
+    public static String getItemTypeName(String fullTypeName){
+        String itemPostfix = "Item";
+        if (fullTypeName.endsWith("Item")) {
+            return fullTypeName.toLowerCase().substring(0, fullTypeName.length()-itemPostfix.length());
+        }
+        return fullTypeName;
+    }
 }

--- a/src/main/java/sparksoniq/semantics/types/SequenceType.java
+++ b/src/main/java/sparksoniq/semantics/types/SequenceType.java
@@ -66,9 +66,31 @@ public class SequenceType implements Serializable {
                 this._arity == superType._arity;
     }
     public enum Arity {
-        OneOrZero,
-        OneOrMore,
-        ZeroOrMore,
-        One
+        OneOrZero {
+            @Override
+            public String getSymbol() {
+                return "?";
+            }
+        },
+        OneOrMore {
+            @Override
+            public String getSymbol() {
+                return "+";
+            }
+        },
+        ZeroOrMore {
+            @Override
+            public String getSymbol() {
+                return "*";
+            }
+        },
+        One {
+            @Override
+            public String getSymbol() {
+                return "";
+            }
+        };
+
+        public abstract String getSymbol();
     }
 }

--- a/src/main/java/sparksoniq/semantics/visitor/AbstractExpressionOrClauseVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/AbstractExpressionOrClauseVisitor.java
@@ -46,6 +46,7 @@ import sparksoniq.jsoniq.compiler.translator.expr.operational.NotExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.OrExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.RangeExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.StringConcatExpression;
+import sparksoniq.jsoniq.compiler.translator.expr.operational.TreatExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.UnaryExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.postfix.PostFixExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.primary.ArrayConstructor;
@@ -229,6 +230,9 @@ public abstract class AbstractExpressionOrClauseVisitor<T> {
         return defaultAction(expression, argument);
     }
 
+    public T visitTreatExpression(TreatExpression expression, T argument) {
+        return defaultAction(expression, argument);
+    }
 
     public T visitIfExpression(IfExpression expression, T argument) {
         return defaultAction(expression, argument);

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -50,6 +50,7 @@ import sparksoniq.jsoniq.compiler.translator.expr.operational.NotExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.OrExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.RangeExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.StringConcatExpression;
+import sparksoniq.jsoniq.compiler.translator.expr.operational.TreatExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.UnaryExpression;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.base.OperationalExpressionBase;
 import sparksoniq.jsoniq.compiler.translator.expr.postfix.PostFixExpression;
@@ -87,6 +88,7 @@ import sparksoniq.jsoniq.runtime.iterator.operational.NotOperationIterator;
 import sparksoniq.jsoniq.runtime.iterator.operational.OrOperationIterator;
 import sparksoniq.jsoniq.runtime.iterator.operational.RangeOperationIterator;
 import sparksoniq.jsoniq.runtime.iterator.operational.StringConcatIterator;
+import sparksoniq.jsoniq.runtime.iterator.operational.TreatIterator;
 import sparksoniq.jsoniq.runtime.iterator.operational.UnaryOperationIterator;
 import sparksoniq.jsoniq.runtime.iterator.postfix.ArrayLookupIterator;
 import sparksoniq.jsoniq.runtime.iterator.postfix.ArrayUnboxingIterator;
@@ -518,6 +520,16 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
         if (expression.isActive()) {
             RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
             return new InstanceOfIterator(childExpression, expression.getsequenceType().getSequence(),
+                    createIteratorMetadata(expression));
+        } else
+            return defaultAction(expression, argument);
+    }
+
+    @Override
+    public RuntimeIterator visitTreatExpression(TreatExpression expression, RuntimeIterator argument) {
+        if (expression.isActive()) {
+            RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
+            return new TreatIterator(childExpression, expression.getsequenceType().getSequence(),
                     createIteratorMetadata(expression));
         } else
             return defaultAction(expression, argument);

--- a/src/main/resources/test_files/runtime/Treat.jq
+++ b/src/main/resources/test_files/runtime/Treat.jq
@@ -1,0 +1,18 @@
+(:JIQS: ShouldRun; Output="(1, 2.14, 1, aa, 1, { "a" : "b" }, 1, 2, 3, false, null, [ 1, 2, 3 ], { "aa" : "bb" }, { "cc" : "dd" })" :)
+1 treat as integer,
+2.14 treat as decimal,
+1 treat as decimal,
+"aa" treat as string+,
+1 treat as item,
+{"a": "b"} treat as object,
+(1,2,3) treat as integer*,
+false treat as boolean,
+null treat as null,
+[1,2,3] treat as array,
+({"aa": "bb"}, {"cc": "dd"}) treat as json-item+,
+() treat as string?,
+() treat as string*,
+() treat as ()
+
+(: general tests :)
+

--- a/src/main/resources/test_files/runtime/TreatError1.jq
+++ b/src/main/resources/test_files/runtime/TreatError1.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPDY0050"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+3.4 treat as double
+
+(: decimal cannot be treated as type double :)

--- a/src/main/resources/test_files/runtime/TreatError2.jq
+++ b/src/main/resources/test_files/runtime/TreatError2.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPDY0050"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+"aa" treat as integer
+
+(: string cannot be treated as type integer :)

--- a/src/main/resources/test_files/runtime/TreatError3.jq
+++ b/src/main/resources/test_files/runtime/TreatError3.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPDY0050"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+("aa", 1) treat as string*
+
+(: integer cannot be treated as type string* :)

--- a/src/main/resources/test_files/runtime/TreatError4.jq
+++ b/src/main/resources/test_files/runtime/TreatError4.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPDY0050"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(4 + 2.3e5) treat as decimal
+
+(: double cannot be treated as type decimal :)

--- a/src/main/resources/test_files/runtime/TreatError5.jq
+++ b/src/main/resources/test_files/runtime/TreatError5.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPDY0050"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+2 treat as boolean
+
+(: integer cannot be treated as type boolean :)

--- a/src/main/resources/test_files/runtime/TreatError6.jq
+++ b/src/main/resources/test_files/runtime/TreatError6.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPDY0050"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+null treat as string?
+
+(: null cannot be treated as type string? :)

--- a/src/main/resources/test_files/runtime/TreatError7.jq
+++ b/src/main/resources/test_files/runtime/TreatError7.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPDY0050"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+[1,2,3] treat as integer+
+
+(: array cannot be treated as type integer+ :)

--- a/src/main/resources/test_files/runtime/TreatError8.jq
+++ b/src/main/resources/test_files/runtime/TreatError8.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPDY0050"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+3 treat as ()
+
+(: integer cannot be treated as type empty-sequence :)

--- a/src/main/resources/test_files/runtime/TreatError9.jq
+++ b/src/main/resources/test_files/runtime/TreatError9.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPDY0050"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+() treat as string
+
+(: Empty sequence cannot be treated as type string :)


### PR DESCRIPTION
This branch includes the implementation for the **treat as** operator (iterator and expression).

From the W3C documentation:
>  
    The semantics of expr1 treat as type1 are as follows:

    - During static analysis:

       The static type of the treat expression is type1. This enables the expression to be used as an argument of a function that requires a parameter of type1.

    - During expression evaluation:

       If expr1 matches type1, using the rules for SequenceType matching, the treat expression returns the value of expr1; otherwise, it raises a dynamic error [err:XPDY0050]. 
       If the value of expr1 is returned, its identity is preserved. The treat expression ensures that the value of its expression operand conforms to the expected type at run-time.