### PR TITLE
Add caching to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,7 @@ script:
   - mvn -Dtest=RuntimeTests test
   - mvn -Dtest=SparkRuntimeTests test
   - mvn -Dtest=JavaAPITest test
-
+cache:
+  directories:
+    - $HOME/.m2
 


### PR DESCRIPTION
I was considering adding caching for maven imports in order to improve the speed of our travis builds. Do you see any potential problems with this addition @wscsprint3r ?