### PR TITLE
HybridRuntimeIterator - openLocal() simplified

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
@@ -22,7 +22,6 @@ package sparksoniq.jsoniq.runtime.iterator;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.rumbledb.api.Item;
-
 import sparksoniq.Main;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.SparkRuntimeException;
@@ -35,9 +34,8 @@ import java.util.List;
 
 public abstract class HybridRuntimeIterator extends RuntimeIterator {
 
-
-	private static final long serialVersionUID = 1L;
-	protected JiqsItemParser parser;
+    private static final long serialVersionUID = 1L;
+    protected JiqsItemParser parser;
     protected JavaRDD<Item> _rdd;
     protected boolean isRDDInitialized = false;
     protected boolean _isRDD;
@@ -69,10 +67,10 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
     }
 
     @Override
-    public void open(DynamicContext context){
+    public void open(DynamicContext context) {
         super.open(context);
         if (!isRDD()) {
-            openLocal(context);
+            openLocal();
         }
     }
 
@@ -144,7 +142,7 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
 
     protected abstract boolean initIsRDD();
 
-    protected abstract void openLocal(DynamicContext context);
+    protected abstract void openLocal();
 
     protected abstract void closeLocal();
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
@@ -20,6 +20,9 @@
 
 package sparksoniq.jsoniq.runtime.iterator.functions.object;
 
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.rumbledb.api.Item;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.ItemFactory;
 import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
@@ -32,26 +35,21 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.function.FlatMapFunction;
-import org.rumbledb.api.Item;
-
 public class ObjectKeysFunctionIterator extends HybridRuntimeIterator {
 
-
-	private static final long serialVersionUID = 1L;
-	private RuntimeIterator _iterator;
+    private static final long serialVersionUID = 1L;
+    private RuntimeIterator _iterator;
     private Queue<Item> _nextResults;   // queue that holds the results created by the current item in inspection
     private List<Item> _prevResults;
 
     public ObjectKeysFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
-        super(arguments,iteratorMetadata);
+        super(arguments, iteratorMetadata);
         _iterator = arguments.get(0);
     }
 
     @Override
-    public void openLocal(DynamicContext context) {
-        _iterator.open(context);
+    public void openLocal() {
+        _iterator.open(_currentDynamicContext);
         _prevResults = new ArrayList<>();
         _nextResults = new LinkedList<>();
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectValuesFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectValuesFunctionIterator.java
@@ -20,6 +20,9 @@
 
 package sparksoniq.jsoniq.runtime.iterator.functions.object;
 
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.rumbledb.api.Item;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -30,15 +33,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.function.FlatMapFunction;
-import org.rumbledb.api.Item;
-
 public class ObjectValuesFunctionIterator extends HybridRuntimeIterator {
 
-
-	private static final long serialVersionUID = 1L;
-	private RuntimeIterator _iterator;
+    private static final long serialVersionUID = 1L;
+    private RuntimeIterator _iterator;
     private Queue<Item> _nextResults;   // queue that holds the results created by the current item in inspection
 
     public ObjectValuesFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
@@ -47,8 +45,8 @@ public class ObjectValuesFunctionIterator extends HybridRuntimeIterator {
     }
 
     @Override
-    public void openLocal(DynamicContext context) {
-        _iterator.open(context);
+    public void openLocal() {
+        _iterator.open(_currentDynamicContext);
         _nextResults = new LinkedList<>();
 
         setNextResult();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -23,7 +23,6 @@ package sparksoniq.jsoniq.runtime.iterator.postfix;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.rumbledb.api.Item;
-
 import sparksoniq.exceptions.InvalidSelectorException;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.UnexpectedTypeException;
@@ -38,8 +37,8 @@ import java.util.Arrays;
 public class ArrayLookupIterator extends HybridRuntimeIterator {
 
 
-	private static final long serialVersionUID = 1L;
-	private RuntimeIterator _iterator;
+    private static final long serialVersionUID = 1L;
+    private RuntimeIterator _iterator;
     private Integer _lookup;
     private Item _nextResult;
 
@@ -99,11 +98,8 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
     }
 
     @Override
-    public void openLocal(DynamicContext context) {
-        this._currentDynamicContext = context;
-
+    public void openLocal() {
         initLookupPosition();
-
         _iterator.open(_currentDynamicContext);
         setNextResult();
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayUnboxingIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayUnboxingIterator.java
@@ -23,7 +23,6 @@ package sparksoniq.jsoniq.runtime.iterator.postfix;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.rumbledb.api.Item;
-
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
@@ -37,9 +36,8 @@ import java.util.Queue;
 
 public class ArrayUnboxingIterator extends HybridRuntimeIterator {
 
-
-	private static final long serialVersionUID = 1L;
-	private RuntimeIterator _iterator;
+    private static final long serialVersionUID = 1L;
+    private RuntimeIterator _iterator;
     private Queue<Item> _nextResults;   // queue that holds the results created by the current item in inspection
 
     public ArrayUnboxingIterator(RuntimeIterator arrayIterator, IteratorMetadata iteratorMetadata) {
@@ -48,10 +46,9 @@ public class ArrayUnboxingIterator extends HybridRuntimeIterator {
     }
 
     @Override
-    public void openLocal(DynamicContext context) {
-        _iterator.open(context);
+    public void openLocal() {
+        _iterator.open(_currentDynamicContext);
         _nextResults = new LinkedList<>();
-
         setNextResult();
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupIterator.java
@@ -23,7 +23,6 @@ package sparksoniq.jsoniq.runtime.iterator.postfix;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.rumbledb.api.Item;
-
 import sparksoniq.exceptions.InvalidSelectorException;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.UnexpectedTypeException;
@@ -44,9 +43,8 @@ import java.util.Arrays;
 
 public class ObjectLookupIterator extends HybridRuntimeIterator {
 
-
-	private static final long serialVersionUID = 1L;
-	private RuntimeIterator _iterator;
+    private static final long serialVersionUID = 1L;
+    private RuntimeIterator _iterator;
     private Item _lookupKey;
     private boolean _contextLookup;
     private Item _nextResult;
@@ -105,9 +103,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
     }
 
     @Override
-    public void openLocal(DynamicContext context) {
-        this._currentDynamicContext = context;
-
+    public void openLocal() {
         initLookupKey();
         _iterator.open(_currentDynamicContext);
         setNextResult();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
@@ -23,7 +23,6 @@ package sparksoniq.jsoniq.runtime.iterator.postfix;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
 import org.rumbledb.api.Item;
-
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.IntegerItem;
@@ -31,6 +30,7 @@ import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -39,9 +39,8 @@ import java.util.TreeMap;
 
 public class PredicateIterator extends HybridRuntimeIterator {
 
-
-	private static final long serialVersionUID = 1L;
-	private RuntimeIterator _iterator;
+    private static final long serialVersionUID = 1L;
+    private RuntimeIterator _iterator;
     private RuntimeIterator _filter;
     private Item _nextResult;
 
@@ -79,13 +78,11 @@ public class PredicateIterator extends HybridRuntimeIterator {
     }
 
     @Override
-    protected void openLocal(DynamicContext context) {
+    protected void openLocal() {
         if (this._children.size() < 2) {
             throw new SparksoniqRuntimeException("Invalid Predicate! Must initialize filter before calling next");
         }
-
         _iterator.open(_currentDynamicContext);
-
         setNextResult();
     }
 
@@ -148,8 +145,7 @@ public class PredicateIterator extends HybridRuntimeIterator {
         return this._iterator.isRDD();
     }
 
-    public Map<String, DynamicContext.VariableDependency> getVariableDependencies()
-    {
+    public Map<String, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<String, DynamicContext.VariableDependency> result = new TreeMap<String, DynamicContext.VariableDependency>();
         result.putAll(_filter.getVariableDependencies());
         result.remove("$");

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -25,7 +25,6 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.StructType;
 import org.rumbledb.api.Item;
-
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -42,8 +41,8 @@ import java.util.TreeMap;
 public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
 
 
-	private static final long serialVersionUID = 1L;
-	private RuntimeTupleIterator _child;
+    private static final long serialVersionUID = 1L;
+    private RuntimeTupleIterator _child;
     private DynamicContext _tupleContext;   // re-use same DynamicContext object for efficiency
     private RuntimeIterator _expression;
     private Item _nextLocalResult;
@@ -83,8 +82,8 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
     }
 
     @Override
-    protected void openLocal(DynamicContext context) {
-        _child.open(context);
+    protected void openLocal() {
+        _child.open(_currentDynamicContext);
         _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
         setNextLocalResult();
     }
@@ -143,22 +142,18 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
         setNextLocalResult();
     }
 
-    public Map<String, DynamicContext.VariableDependency> getVariableDependencies()
-    {
+    public Map<String, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<String, DynamicContext.VariableDependency> result = new TreeMap<String, DynamicContext.VariableDependency>();
         result.putAll(_expression.getVariableDependencies());
-        for (String variable : _child.getVariablesBoundInCurrentFLWORExpression())
-        {
+        for (String variable : _child.getVariablesBoundInCurrentFLWORExpression()) {
             result.remove(variable);
         }
         result.putAll(_child.getVariableDependencies());
         return result;
     }
-    
-    public void print(StringBuffer buffer, int indent)
-    {
-        for (int i = 0; i < indent; ++i)
-        {
+
+    public void print(StringBuffer buffer, int indent) {
+        for (int i = 0; i < indent; ++i) {
             buffer.append("  ");
         }
         buffer.append(getClass().getName());


### PR DESCRIPTION
This PR simplifies the openLocal() method of HybridRuntimeIterators by removing the context parameter while providing the same functionality.

It seems to me that the openLocal() method is only used after the open() method is called on the hybrid iterator. This operation always sets the _currentDynamicContext to the given dynamic context on open(DynamicContext context) call. Hence, passing the same parameter again to openLocal seems redundant as this is already accessible in the member field _currentDynamicContext. Furthermore, this caused various redundant assignments in openLocal() method implementations. These are now cleaned up.

