### PR TITLE
Refactor function catalog

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
@@ -261,6 +261,14 @@ public class Functions {
         builtInFunctions.put(new FunctionIdentifier(VALUES, 1), ObjectValuesFunctionIterator.class);
     }
 
+    public static boolean checkBuiltInFunctionExists(FunctionIdentifier identifier) {
+        return builtInFunctions.containsKey(identifier);
+    }
+
+    public static Class<? extends RuntimeIterator> getBuiltInFunction(FunctionIdentifier identifier, IteratorMetadata metadata) {
+        return builtInFunctions.get(identifier);
+    }
+
     public static void clearUserDefinedFunctions() {
         userDefinedFunctions.clear();
     }
@@ -273,29 +281,24 @@ public class Functions {
         userDefinedFunctions.put(function.getIdentifier(), function);
     }
 
-    public static Class<? extends RuntimeIterator> getBuiltInFunction(FunctionIdentifier identifier, IteratorMetadata metadata) {
-        if (builtInFunctions.containsKey(identifier))
-            return builtInFunctions.get(identifier);
-        throw new UnknownFunctionCallException(identifier.getName(), identifier.getArity(), metadata);
+    public static boolean checkUserDefinedFunctionExists(FunctionIdentifier identifier) {
+        return userDefinedFunctions.containsKey(identifier);
     }
 
     public static FunctionItem getUserDefinedFunction(FunctionIdentifier identifier, IteratorMetadata metadata) {
-        if (userDefinedFunctions.containsKey(identifier)) {
-            FunctionItem fnItem = userDefinedFunctions.get(identifier);
-            try {
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                ObjectOutputStream oos = new ObjectOutputStream(bos);
-                oos.writeObject(fnItem);
-                oos.flush();
-                byte[] data = bos.toByteArray();
-                ByteArrayInputStream bis = new ByteArrayInputStream(data);
-                ObjectInputStream ois = new ObjectInputStream(bis);
-                return (FunctionItem) ois.readObject();
-            } catch (Exception e) {
-                throw new SparksoniqRuntimeException("Error while deep copying the function body runtimeIterator");
-            }
+        FunctionItem fnItem = userDefinedFunctions.get(identifier);
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
+            oos.writeObject(fnItem);
+            oos.flush();
+            byte[] data = bos.toByteArray();
+            ByteArrayInputStream bis = new ByteArrayInputStream(data);
+            ObjectInputStream ois = new ObjectInputStream(bis);
+            return (FunctionItem) ois.readObject();
+        } catch (Exception e) {
+            throw new SparksoniqRuntimeException("Error while deep copying the function body runtimeIterator");
         }
-        throw new UnknownFunctionCallException(identifier.getName(), identifier.getArity(), metadata);
     }
 
     public static class FunctionNames {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
@@ -116,7 +116,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
 import java.util.HashMap;
+import java.util.List;
 
 
 import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.*;
@@ -265,8 +267,14 @@ public class Functions {
         return builtInFunctions.containsKey(identifier);
     }
 
-    public static Class<? extends RuntimeIterator> getBuiltInFunction(FunctionIdentifier identifier, IteratorMetadata metadata) {
-        return builtInFunctions.get(identifier);
+    public static RuntimeIterator getBuiltInFunctionIterator(FunctionIdentifier identifier, IteratorMetadata metadata, List<RuntimeIterator> arguments) {
+        Class<? extends RuntimeIterator> functionClass = builtInFunctions.get(identifier);
+        try {
+            Constructor<? extends RuntimeIterator> ctor = functionClass.getConstructor(List.class, IteratorMetadata.class);
+            return ctor.newInstance(arguments, metadata);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
     }
 
     public static void clearUserDefinedFunctions() {

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -375,28 +375,20 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
         int arity = arguments.size();
         FunctionIdentifier identifier = new FunctionIdentifier(fnName, arity);
 
-        try {
-            if (Functions.checkBuiltInFunctionExists(identifier)) {
-                Class<? extends RuntimeIterator> functionClass = Functions.getBuiltInFunction(identifier, createIteratorMetadata(expression));
-                if (isPartialApplication) {
-                    throw new UnsupportedFeatureException(
-                            "Partial application on built-in functions are not supported.",
-                            expression.getMetadata()
-                    );
-                }
-                Constructor<? extends RuntimeIterator> ctor = functionClass.getConstructor(List.class, IteratorMetadata.class);
-                return ctor.newInstance(arguments, iteratorMetadata);
+        if (Functions.checkBuiltInFunctionExists(identifier)) {
+            if (isPartialApplication) {
+                throw new UnsupportedFeatureException(
+                        "Partial application on built-in functions are not supported.",
+                        expression.getMetadata()
+                );
             }
-            return new UserDefinedFunctionCallIterator(
-                    identifier,
-                    arguments,
-                    iteratorMetadata
-            );
-        } catch (UnsupportedFeatureException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage());
+            return Functions.getBuiltInFunctionIterator(identifier, iteratorMetadata, arguments);
         }
+        return new UserDefinedFunctionCallIterator(
+                identifier,
+                arguments,
+                iteratorMetadata
+        );
     }
 
     @Override


### PR DESCRIPTION
- Use checks for function existence rather than exceptions
- Extract RuntimeIterator generation for built-in functions to getBuiltInFunctionIterator()in the Functions Catalog