### PR TITLE
Add RDD support to FLWOR tuple

### DIFF
--- a/src/main/java/sparksoniq/JsoniqQueryExecutor.java
+++ b/src/main/java/sparksoniq/JsoniqQueryExecutor.java
@@ -296,6 +296,7 @@ public class JsoniqQueryExecutor {
         }
         if (resultCount > 1) {
             List<String> collectedOutput;
+
             if (SparkSessionManager.LIMIT_COLLECT()) {
                 collectedOutput = output.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
                 if (collectedOutput.size() == SparkSessionManager.COLLECT_ITEM_LIMIT) {

--- a/src/main/java/sparksoniq/JsoniqQueryExecutor.java
+++ b/src/main/java/sparksoniq/JsoniqQueryExecutor.java
@@ -295,28 +295,7 @@ public class JsoniqQueryExecutor {
             return output.collect().get(0);
         }
         if (resultCount > 1) {
-            List<String> collectedOutput;
-
-            if (SparkSessionManager.LIMIT_COLLECT()) {
-                collectedOutput = output.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
-                if (collectedOutput.size() == SparkSessionManager.COLLECT_ITEM_LIMIT) {
-                    if (Main.terminal == null) {
-                        System.out.println(
-                            "Results have been truncated to:"
-                                + SparkSessionManager.COLLECT_ITEM_LIMIT
-                                + " items. This value can be configured with the --result-size parameter at startup.\n"
-                        );
-                    } else {
-                        Main.terminal.output(
-                            "\nWarning: Results have been truncated to: "
-                                + SparkSessionManager.COLLECT_ITEM_LIMIT
-                                + " items. This value can be configured with the --result-size parameter at startup.\n"
-                        );
-                    }
-                }
-            } else {
-                collectedOutput = output.collect();
-            }
+            List<String> collectedOutput = SparkSessionManager.collectRDDwithLimit(output);
 
             StringBuilder sb = new StringBuilder();
             for (String item : collectedOutput) {

--- a/src/main/java/sparksoniq/Main.java
+++ b/src/main/java/sparksoniq/Main.java
@@ -119,4 +119,12 @@ public class Main {
         terminal.launch();
     }
 
+    public static void printMessageToLog(String message) {
+        if (Main.terminal == null) {
+            System.out.println(message);
+        } else {
+            Main.terminal.output(message);
+        }
+    }
+
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
@@ -99,26 +99,7 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
         if (result == null) {
             currentResultIndex = 0;
             JavaRDD<Item> rdd = this.getRDD(_currentDynamicContext);
-            if (SparkSessionManager.LIMIT_COLLECT()) {
-                result = rdd.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
-                if (result.size() == SparkSessionManager.COLLECT_ITEM_LIMIT) {
-                    if (Main.terminal == null) {
-                        System.out.println(
-                            "Results have been truncated to:"
-                                + SparkSessionManager.COLLECT_ITEM_LIMIT
-                                + " items. This value can be configured with the --result-size parameter at startup.\n"
-                        );
-                    } else {
-                        Main.terminal.output(
-                            "\nWarning: Results have been truncated to: "
-                                + SparkSessionManager.COLLECT_ITEM_LIMIT
-                                + " items. This value can be configured with the --result-size parameter at startup.\n"
-                        );
-                    }
-                }
-            } else {
-                result = rdd.collect();
-            }
+            result = SparkSessionManager.collectRDDwithLimit(rdd);
             _hasNext = !result.isEmpty();
         }
         return _hasNext;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/SparkRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/SparkRuntimeIterator.java
@@ -75,27 +75,8 @@ public abstract class SparkRuntimeIterator extends RuntimeIterator {
     public boolean hasNext() {
         if (result == null) {
             currentResultIndex = 0;
-            this._rdd = this.getRDD(_currentDynamicContext);
-            if (SparkSessionManager.LIMIT_COLLECT()) {
-                result = _rdd.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
-                if (result.size() == SparkSessionManager.COLLECT_ITEM_LIMIT) {
-                    if (Main.terminal == null) {
-                        System.out.println(
-                            "Results have been truncated to:"
-                                + SparkSessionManager.COLLECT_ITEM_LIMIT
-                                + " items. This value can be configured with the --result-size parameter at startup.\n"
-                        );
-                    } else {
-                        Main.terminal.output(
-                            "\nWarning: Results have been truncated to: "
-                                + SparkSessionManager.COLLECT_ITEM_LIMIT
-                                + " items. This value can be configured with the --result-size parameter at startup.\n"
-                        );
-                    }
-                }
-            } else {
-                result = _rdd.collect();
-            }
+            _rdd = this.getRDD(_currentDynamicContext);
+            result = SparkSessionManager.collectRDDwithLimit(_rdd);
             _hasNext = !result.isEmpty();
         }
         return _hasNext;

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
@@ -129,10 +129,12 @@ public class FlworTuple implements Serializable, KryoSerializable {
     }
 
     public void putValue(String key, List<Item> value) {
+        rddVariables.remove(key);
         localVariables.put(key, value);
     }
 
     public void putValue(String key, JavaRDD<Item> value) {
+        localVariables.remove(key);
         rddVariables.put(key, value);
     }
 

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
@@ -138,8 +138,8 @@ public class FlworTuple implements Serializable, KryoSerializable {
 
     public boolean contains(String key) {
         return localVariables.containsKey(key)
-                || rddVariables.containsKey(key)
-                || dfVariables.containsKey(key);
+            || rddVariables.containsKey(key)
+            || dfVariables.containsKey(key);
     }
 
     public boolean isRDD(String key, IteratorMetadata metadata) {
@@ -147,7 +147,7 @@ public class FlworTuple implements Serializable, KryoSerializable {
             throw new SparksoniqRuntimeException("Undeclared FLWOR variable", metadata.getExpressionMetadata());
         }
         return rddVariables.containsKey(key)
-                || dfVariables.containsKey(key);
+            || dfVariables.containsKey(key);
     }
 
     public boolean isDF(String key, IteratorMetadata metadata) {

--- a/src/main/java/sparksoniq/semantics/DynamicContext.java
+++ b/src/main/java/sparksoniq/semantics/DynamicContext.java
@@ -95,8 +95,7 @@ public class DynamicContext implements Serializable, KryoSerializable {
             return _variableCounts.get(varName);
         }
         if (_variableValues.containsKey(varName)) {
-            Item count = ItemFactory.getInstance().createIntegerItem(_variableValues.get(varName).size());
-            return count;
+            return ItemFactory.getInstance().createIntegerItem(_variableValues.get(varName).size());
         }
         if (_parent != null) {
             return _parent.getVariableCount(varName);
@@ -138,8 +137,8 @@ public class DynamicContext implements Serializable, KryoSerializable {
     }
 
     public void setPosition(long position) {
-        List<Item> list = new ArrayList<Item>();
-        Item item = null;
+        List<Item> list = new ArrayList<>();
+        Item item;
         if (position < Integer.MAX_VALUE) {
             item = ItemFactory.getInstance().createIntegerItem((int) position);
 
@@ -161,8 +160,8 @@ public class DynamicContext implements Serializable, KryoSerializable {
     }
 
     public void setLast(long last) {
-        List<Item> list = new ArrayList<Item>();
-        Item item = null;
+        List<Item> list = new ArrayList<>();
+        Item item;
         if (last < Integer.MAX_VALUE) {
             item = ItemFactory.getInstance().createIntegerItem((int) last);
         } else {

--- a/src/main/java/sparksoniq/semantics/DynamicContext.java
+++ b/src/main/java/sparksoniq/semantics/DynamicContext.java
@@ -24,6 +24,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import org.rumbledb.api.Item;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.ItemFactory;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -36,21 +37,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.rumbledb.api.Item;
-
 public class DynamicContext implements Serializable, KryoSerializable {
 
     private static final long serialVersionUID = 1L;
-
-    public enum VariableDependency {
-        FULL,
-        COUNT,
-        SUM,
-        AVG,
-        MAX,
-        MIN
-    }
-
     private Map<String, List<Item>> _variableValues;
     private Map<String, Item> _variableCounts;
     private DynamicContext _parent;
@@ -68,9 +57,11 @@ public class DynamicContext implements Serializable, KryoSerializable {
     }
 
     public void setBindingsFromTuple(FlworTuple tuple, IteratorMetadata metadata) {
-        for (String key : tuple.getLocalKeys())
-            if (!key.startsWith("."))
+        for (String key : tuple.getLocalKeys()) {
+            if (!key.startsWith(".")) {
                 this.addVariableValue(key, tuple.getLocalValue(key, metadata));
+            }
+        }
     }
 
     public void addVariableValue(String varName, List<Item> value) {
@@ -82,16 +73,19 @@ public class DynamicContext implements Serializable, KryoSerializable {
     }
 
     public List<Item> getVariableValue(String varName) {
-        if (_variableValues.containsKey(varName))
+        if (_variableValues.containsKey(varName)) {
             return _variableValues.get(varName);
+        }
 
-        if (_parent != null)
+        if (_parent != null) {
             return _parent.getVariableValue(varName);
+        }
 
-        if (_variableCounts.containsKey(varName))
+        if (_variableCounts.containsKey(varName)) {
             throw new SparksoniqRuntimeException(
                     "Runtime error retrieving variable " + varName + " value: only count available."
             );
+        }
 
         throw new SparksoniqRuntimeException("Runtime error retrieving variable " + varName + " value");
     }
@@ -137,8 +131,9 @@ public class DynamicContext implements Serializable, KryoSerializable {
         if (_variableValues.containsKey("$position")) {
             return _variableValues.get("$position").get(0);
         }
-        if (_parent != null)
+        if (_parent != null) {
             return _parent.getPosition();
+        }
         return null;
     }
 
@@ -159,8 +154,9 @@ public class DynamicContext implements Serializable, KryoSerializable {
         if (_variableValues.containsKey("$last")) {
             return _variableValues.get("$last").get(0);
         }
-        if (_parent != null)
+        if (_parent != null) {
             return _parent.getLast();
+        }
         return null;
     }
 
@@ -174,6 +170,15 @@ public class DynamicContext implements Serializable, KryoSerializable {
         }
         list.add(item);
         _variableValues.put("$last", list);
+    }
+
+    public enum VariableDependency {
+        FULL,
+        COUNT,
+        SUM,
+        AVG,
+        MAX,
+        MIN
     }
 }
 

--- a/src/main/java/sparksoniq/semantics/DynamicContext.java
+++ b/src/main/java/sparksoniq/semantics/DynamicContext.java
@@ -26,6 +26,7 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.ItemFactory;
+import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 
 import java.io.Serializable;
@@ -66,22 +67,10 @@ public class DynamicContext implements Serializable, KryoSerializable {
         this._variableCounts = new HashMap<>();
     }
 
-    public DynamicContext(FlworTuple tuple) {
-        this();
-        setBindingsFromTuple(tuple);
-    }
-
-    public DynamicContext(DynamicContext parent, FlworTuple tuple) {
-        this._parent = parent;
-        this._variableValues = new HashMap<>();
-        this._variableCounts = new HashMap<>();
-        setBindingsFromTuple(tuple);
-    }
-
-    public void setBindingsFromTuple(FlworTuple tuple) {
+    public void setBindingsFromTuple(FlworTuple tuple, IteratorMetadata metadata) {
         for (String key : tuple.getLocalKeys())
             if (!key.startsWith("."))
-                this.addVariableValue(key, tuple.getLocalValue(key));
+                this.addVariableValue(key, tuple.getLocalValue(key, metadata));
     }
 
     public void addVariableValue(String varName, List<Item> value) {

--- a/src/main/java/sparksoniq/semantics/DynamicContext.java
+++ b/src/main/java/sparksoniq/semantics/DynamicContext.java
@@ -79,9 +79,9 @@ public class DynamicContext implements Serializable, KryoSerializable {
     }
 
     public void setBindingsFromTuple(FlworTuple tuple) {
-        for (String key : tuple.getKeys())
+        for (String key : tuple.getLocalKeys())
             if (!key.startsWith("."))
-                this.addVariableValue(key, tuple.getValue(key));
+                this.addVariableValue(key, tuple.getLocalValue(key));
     }
 
     public void addVariableValue(String varName, List<Item> value) {
@@ -158,6 +158,7 @@ public class DynamicContext implements Serializable, KryoSerializable {
         Item item = null;
         if (position < Integer.MAX_VALUE) {
             item = ItemFactory.getInstance().createIntegerItem((int) position);
+
         } else {
             item = ItemFactory.getInstance().createDecimalItem(new BigDecimal(position));
         }

--- a/src/main/java/sparksoniq/spark/SparkSessionManager.java
+++ b/src/main/java/sparksoniq/spark/SparkSessionManager.java
@@ -138,14 +138,14 @@ public class SparkSessionManager {
         return javaSparkContext;
     }
 
-    public static <T> List<T> collectRDDwithLimit (JavaRDD<T> rdd) {
+    public static <T> List<T> collectRDDwithLimit(JavaRDD<T> rdd) {
         String truncationMessage = "Results have been truncated to:"
-                + SparkSessionManager.COLLECT_ITEM_LIMIT
-                + " items. This value can be configured with the --result-size parameter at startup.\n";
+            + SparkSessionManager.COLLECT_ITEM_LIMIT
+            + " items. This value can be configured with the --result-size parameter at startup.\n";
         return collectRDDwithLimit(rdd, truncationMessage);
     }
 
-    public static <T> List<T> collectRDDwithLimit (JavaRDD<T> rdd, String customTruncationMessage) {
+    public static <T> List<T> collectRDDwithLimit(JavaRDD<T> rdd, String customTruncationMessage) {
         if (SparkSessionManager.LIMIT_COLLECT()) {
             List<T> result = rdd.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
             if (result.size() == SparkSessionManager.COLLECT_ITEM_LIMIT) {

--- a/src/main/java/sparksoniq/spark/SparkSessionManager.java
+++ b/src/main/java/sparksoniq/spark/SparkSessionManager.java
@@ -138,16 +138,16 @@ public class SparkSessionManager {
         return javaSparkContext;
     }
 
-    public static List<Item> collectRDDwithLimit (JavaRDD<Item> rdd) {
+    public static <T> List<T> collectRDDwithLimit (JavaRDD<T> rdd) {
         String truncationMessage = "Results have been truncated to:"
                 + SparkSessionManager.COLLECT_ITEM_LIMIT
                 + " items. This value can be configured with the --result-size parameter at startup.\n";
         return collectRDDwithLimit(rdd, truncationMessage);
     }
 
-    public static List<Item> collectRDDwithLimit (JavaRDD<Item> rdd, String customTruncationMessage) {
+    public static <T> List<T> collectRDDwithLimit (JavaRDD<T> rdd, String customTruncationMessage) {
         if (SparkSessionManager.LIMIT_COLLECT()) {
-            List<Item> result = rdd.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
+            List<T> result = rdd.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
             if (result.size() == SparkSessionManager.COLLECT_ITEM_LIMIT) {
                 Main.printMessageToLog(customTruncationMessage);
             }

--- a/src/main/java/sparksoniq/spark/SparkSessionManager.java
+++ b/src/main/java/sparksoniq/spark/SparkSessionManager.java
@@ -23,10 +23,12 @@ package sparksoniq.spark;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.rumbledb.api.Item;
 
+import sparksoniq.Main;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.item.BooleanItem;
@@ -41,6 +43,8 @@ import sparksoniq.jsoniq.runtime.tupleiterator.RuntimeTupleIterator;
 import sparksoniq.jsoniq.tuple.FlworKey;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
+
+import java.util.List;
 
 public class SparkSessionManager {
 
@@ -132,5 +136,24 @@ public class SparkSessionManager {
             javaSparkContext = JavaSparkContext.fromSparkContext(this.getOrCreateSession().sparkContext());
         }
         return javaSparkContext;
+    }
+
+    public static List<Item> collectRDDwithLimit (JavaRDD<Item> rdd) {
+        String truncationMessage = "Results have been truncated to:"
+                + SparkSessionManager.COLLECT_ITEM_LIMIT
+                + " items. This value can be configured with the --result-size parameter at startup.\n";
+        return collectRDDwithLimit(rdd, truncationMessage);
+    }
+
+    public static List<Item> collectRDDwithLimit (JavaRDD<Item> rdd, String customTruncationMessage) {
+        if (SparkSessionManager.LIMIT_COLLECT()) {
+            List<Item> result = rdd.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
+            if (result.size() == SparkSessionManager.COLLECT_ITEM_LIMIT) {
+                Main.printMessageToLog(customTruncationMessage);
+            }
+            return result;
+        } else {
+            return rdd.collect();
+        }
     }
 }

--- a/src/main/java/sparksoniq/spark/closures/ForClauseLocalToRowClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/ForClauseLocalToRowClosure.java
@@ -28,6 +28,7 @@ import org.rumbledb.api.Item;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Output;
 
+import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.spark.DataFrameUtils;
 
@@ -40,12 +41,14 @@ public class ForClauseLocalToRowClosure implements Function<Item, Row> {
     private static final long serialVersionUID = 1L;
 
     private final FlworTuple _inputTuple;
+    private final IteratorMetadata _metadata;
 
     private transient Kryo _kryo;
     private transient Output _output;
 
-    public ForClauseLocalToRowClosure(FlworTuple inputTuple) {
+    public ForClauseLocalToRowClosure(FlworTuple inputTuple, IteratorMetadata metadata) {
         this._inputTuple = inputTuple;
+        this._metadata = metadata;
         _kryo = new Kryo();
         _kryo.setReferences(false);
         DataFrameUtils.registerKryoClassesKryo(_kryo);
@@ -55,7 +58,7 @@ public class ForClauseLocalToRowClosure implements Function<Item, Row> {
     @Override
     public Row call(Item item) throws Exception {
         List<List<Item>> rowColumns = new ArrayList<>();
-        _inputTuple.getLocalKeys().forEach(key -> rowColumns.add(_inputTuple.getLocalValue(key)));
+        _inputTuple.getLocalKeys().forEach(key -> rowColumns.add(_inputTuple.getLocalValue(key, _metadata)));
 
         List<Item> itemList = new ArrayList<>();
         itemList.add(item);

--- a/src/main/java/sparksoniq/spark/closures/ForClauseLocalToRowClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/ForClauseLocalToRowClosure.java
@@ -55,7 +55,7 @@ public class ForClauseLocalToRowClosure implements Function<Item, Row> {
     @Override
     public Row call(Item item) throws Exception {
         List<List<Item>> rowColumns = new ArrayList<>();
-        _inputTuple.getKeys().forEach(key -> rowColumns.add(_inputTuple.getValue(key)));
+        _inputTuple.getLocalKeys().forEach(key -> rowColumns.add(_inputTuple.getLocalValue(key)));
 
         List<Item> itemList = new ArrayList<>();
         itemList.add(item);

--- a/src/main/java/sparksoniq/spark/closures/ForClauseLocalToRowClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/ForClauseLocalToRowClosure.java
@@ -20,14 +20,12 @@
 
 package sparksoniq.spark.closures;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.rumbledb.api.Item;
-
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Output;
-
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.spark.DataFrameUtils;

--- a/src/main/java/sparksoniq/spark/closures/ForClauseLocalToRowClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/ForClauseLocalToRowClosure.java
@@ -54,7 +54,7 @@ public class ForClauseLocalToRowClosure implements Function<Item, Row> {
     }
 
     @Override
-    public Row call(Item item) throws Exception {
+    public Row call(Item item) {
         List<List<Item>> rowColumns = new ArrayList<>();
         _inputTuple.getLocalKeys().forEach(key -> rowColumns.add(_inputTuple.getLocalValue(key, _metadata)));
 

--- a/src/main/java/sparksoniq/spark/closures/ForClauseSerializeClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/ForClauseSerializeClosure.java
@@ -53,7 +53,7 @@ public class ForClauseSerializeClosure implements Function<Item, Row> {
      * @return Row object, containing byte array of a singleton list containing the given item
      */
     @Override
-    public Row call(Item item) throws Exception {
+    public Row call(Item item) {
         List<Item> itemList = new ArrayList<>();
         itemList.add(item);
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -117,7 +117,7 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
         while (_child.hasNext()) {
             _inputTuple = _child.next();
             _tupleContext.removeAllVariables(); // clear the previous variables
-            _tupleContext.setBindingsFromTuple(_inputTuple); // assign new variables from new tuple
+            _tupleContext.setBindingsFromTuple(_inputTuple, getMetadata()); // assign new variables from new tuple
 
             _expression.open(_tupleContext);
             if (setResultFromExpression()) {
@@ -226,7 +226,7 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
         while (_child.hasNext()) {
             _inputTuple = _child.next();
             _tupleContext.removeAllVariables(); // clear the previous variables
-            _tupleContext.setBindingsFromTuple(_inputTuple); // assign new variables from new tuple
+            _tupleContext.setBindingsFromTuple(_inputTuple, getMetadata()); // assign new variables from new tuple
 
             JavaRDD<Item> expressionRDD = _expression.getRDD(_tupleContext);
 
@@ -242,7 +242,7 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
             }
             StructType schema = DataTypes.createStructType(fields);
 
-            JavaRDD<Row> rowRDD = expressionRDD.map(new ForClauseLocalToRowClosure(_inputTuple));
+            JavaRDD<Row> rowRDD = expressionRDD.map(new ForClauseLocalToRowClosure(_inputTuple, getMetadata()));
 
             if (df == null) {
                 df = SparkSessionManager.getInstance().getOrCreateSession().createDataFrame(rowRDD, schema);

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -231,8 +231,9 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
             JavaRDD<Item> expressionRDD = _expression.getRDD(_tupleContext);
 
             // TODO - Optimization: Iterate schema creation only once
-            Set<String> oldColumnNames = _inputTuple.getKeys();
+            Set<String> oldColumnNames = _inputTuple.getLocalKeys();
             List<String> newColumnNames = new ArrayList<>(oldColumnNames);
+
             newColumnNames.add(_variableName);
             List<StructField> fields = new ArrayList<>();
             for (String columnName : newColumnNames) {

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -138,7 +138,7 @@ public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
             List<Item> results = new ArrayList<>();
             for (GroupByClauseSparkIteratorExpression expression : _expressions) {
                 tupleContext.removeAllVariables(); // clear the previous variables
-                tupleContext.setBindingsFromTuple(inputTuple); // assign new variables from new tuple
+                tupleContext.setBindingsFromTuple(inputTuple, getMetadata()); // assign new variables from new tuple
 
                 // if grouping on an expression
                 RuntimeIterator groupVariableExpression = expression.getExpression();
@@ -204,11 +204,11 @@ public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
         for (String tupleVariable : oldFirstTuple.getLocalKeys()) {
             iterator = keyTuplePairs.iterator();
             if (_expressions.stream().anyMatch(v -> v.getVariableReference().getVariableName().equals(tupleVariable))) {
-                newTuple.putValue(tupleVariable, oldFirstTuple.getLocalValue(tupleVariable));
+                newTuple.putValue(tupleVariable, oldFirstTuple.getLocalValue(tupleVariable, getMetadata()));
             } else {
                 List<Item> allValues = new ArrayList<>();
                 while (iterator.hasNext()) {
-                    allValues.addAll(iterator.next().getLocalValue(tupleVariable));
+                    allValues.addAll(iterator.next().getLocalValue(tupleVariable, getMetadata()));
                 }
                 newTuple.putValue(tupleVariable, allValues);
             }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -200,15 +200,15 @@ public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
     private void linearizeTuples(List<FlworTuple> keyTuplePairs) {
         Iterator<FlworTuple> iterator = keyTuplePairs.iterator();
         FlworTuple oldFirstTuple = iterator.next();
-        FlworTuple newTuple = new FlworTuple(oldFirstTuple.getKeys().size());
-        for (String tupleVariable : oldFirstTuple.getKeys()) {
+        FlworTuple newTuple = new FlworTuple(oldFirstTuple.getLocalKeys().size());
+        for (String tupleVariable : oldFirstTuple.getLocalKeys()) {
             iterator = keyTuplePairs.iterator();
             if (_expressions.stream().anyMatch(v -> v.getVariableReference().getVariableName().equals(tupleVariable))) {
-                newTuple.putValue(tupleVariable, oldFirstTuple.getValue(tupleVariable));
+                newTuple.putValue(tupleVariable, oldFirstTuple.getLocalValue(tupleVariable));
             } else {
                 List<Item> allValues = new ArrayList<>();
                 while (iterator.hasNext()) {
-                    allValues.addAll(iterator.next().getValue(tupleVariable));
+                    allValues.addAll(iterator.next().getLocalValue(tupleVariable));
                 }
                 newTuple.putValue(tupleVariable, allValues);
             }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -95,7 +95,7 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
         if (_child.hasNext()) {
             FlworTuple inputTuple = _child.next();
             _tupleContext.removeAllVariables(); // clear the previous variables
-            _tupleContext.setBindingsFromTuple(inputTuple); // assign new variables from new tuple
+            _tupleContext.setBindingsFromTuple(inputTuple, getMetadata()); // assign new variables from new tuple
 
             List<Item> results = new ArrayList<>();
             _expression.open(_tupleContext);

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -99,8 +99,9 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
 
             List<Item> results = new ArrayList<>();
             _expression.open(_tupleContext);
-            while (_expression.hasNext())
+            while (_expression.hasNext()) {
                 results.add(_expression.next());
+            }
             _expression.close();
 
             _nextLocalTupleResult = new FlworTuple(inputTuple, _variableName, results);
@@ -123,8 +124,9 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
             // expression is materialized
             List<Item> results = new ArrayList<>();
             _expression.open(this._currentDynamicContext);
-            while (_expression.hasNext())
+            while (_expression.hasNext()) {
                 results.add(_expression.next());
+            }
             _expression.close();
 
             _nextLocalTupleResult = new FlworTuple(_variableName, results);

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -145,7 +145,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             List<Item> results = new ArrayList<>(); // results from the expressions will become a key
             for (OrderByClauseSparkIteratorExpression orderByExpression : _expressions) {
                 tupleContext.removeAllVariables(); // clear the previous variables
-                tupleContext.setBindingsFromTuple(inputTuple); // assign new variables from new tuple
+                tupleContext.setBindingsFromTuple(inputTuple, getMetadata()); // assign new variables from new tuple
 
                 boolean isFieldEmpty = true;
                 RuntimeIterator expression = orderByExpression.getExpression();

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -102,7 +102,7 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
         while (_child.hasNext()) {
             FlworTuple tuple = _child.next();
             _tupleContext.removeAllVariables(); // clear the previous variables
-            _tupleContext.setBindingsFromTuple(tuple); // assign new variables from new tuple
+            _tupleContext.setBindingsFromTuple(tuple, getMetadata()); // assign new variables from new tuple
 
             _expression.open(_tupleContext);
             boolean isResultSet = setResultFromExpression();

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -76,7 +76,7 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
 
     @Override
     protected Item nextLocal() {
-        if (_hasNext == true) {
+        if (_hasNext) {
             Item result = _nextResult; // save the result to be returned
             setNextResult(); // calculate and store the next result
             return result;

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -97,7 +97,7 @@ public class WhereClauseSparkIterator extends RuntimeTupleIterator {
             // tuple received from child, used for tuple creation
             inputTuple = _child.next();
             _tupleContext.removeAllVariables(); // clear the previous variables
-            _tupleContext.setBindingsFromTuple(inputTuple); // assign new variables from new tuple
+            _tupleContext.setBindingsFromTuple(inputTuple, getMetadata()); // assign new variables from new tuple
 
             _expression.open(_tupleContext);
             boolean effectiveBooleanValue = RuntimeIterator.getEffectiveBooleanValue(_expression);

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -44,7 +44,7 @@ public class WhereClauseSparkIterator extends RuntimeTupleIterator {
 
 
     private static final long serialVersionUID = 1L;
-    Map<String, DynamicContext.VariableDependency> _dependencies;
+    private Map<String, DynamicContext.VariableDependency> _dependencies;
     private RuntimeIterator _expression;
     private DynamicContext _tupleContext; // re-use same DynamicContext object for efficiency
     private FlworTuple _nextLocalTupleResult;

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -44,10 +44,10 @@ public class WhereClauseSparkIterator extends RuntimeTupleIterator {
 
 
     private static final long serialVersionUID = 1L;
+    Map<String, DynamicContext.VariableDependency> _dependencies;
     private RuntimeIterator _expression;
     private DynamicContext _tupleContext; // re-use same DynamicContext object for efficiency
     private FlworTuple _nextLocalTupleResult;
-    Map<String, DynamicContext.VariableDependency> _dependencies;
 
     public WhereClauseSparkIterator(
             RuntimeTupleIterator child,


### PR DESCRIPTION
RDD and DF support added to FLWOR tuples with individual maps.
DF -> RDD -> Local fallback implemented (IteratorMetadata used for DF -> Fallback)
Both data structures have their own get and put methods. These methods also benefit from iteratormetadata for better error messages.
Collecting an RDD is extracted to a method in SparkContextManager.
Logging messages extracted to a method in the Main class.