### PR TITLE
Improve naming for User defined function call classes

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/DynamicFunctionCallIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/DynamicFunctionCallIterator.java
@@ -27,18 +27,15 @@ import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.FunctionItem;
 import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
-import sparksoniq.jsoniq.runtime.iterator.functions.base.FunctionIdentifier;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.Functions;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
-import sparksoniq.semantics.types.SequenceType;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 public class DynamicFunctionCallIterator extends HybridRuntimeIterator {
+    // dynamic: functionIdentifier is not known at compile time
+    // it is known only after evaluating postfix expression at runtime
 
     private static final long serialVersionUID = 1L;
     // parametrized fields
@@ -153,7 +150,7 @@ public class DynamicFunctionCallIterator extends HybridRuntimeIterator {
                     getMetadata()
             );
         }
-        _functionCallIterator = Functions.buildUserDefinedFunctionIterator(
+        _functionCallIterator = Functions.buildUserDefinedFunctionCallIterator(
             _functionItem,
             getMetadata(),
             _functionArguments

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
@@ -22,7 +22,6 @@ package sparksoniq.jsoniq.runtime.iterator.functions.base;
 
 import sparksoniq.exceptions.DuplicateFunctionIdentifierException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
-import sparksoniq.exceptions.UnknownFunctionCallException;
 import sparksoniq.jsoniq.compiler.translator.metadata.ExpressionMetadata;
 import sparksoniq.jsoniq.item.FunctionItem;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -35,13 +34,29 @@ import sparksoniq.jsoniq.runtime.iterator.functions.arrays.ArraySizeFunctionIter
 import sparksoniq.jsoniq.runtime.iterator.functions.binaries.Base64BinaryFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.binaries.HexBinaryFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.booleans.BooleanFunctionIterator;
-import sparksoniq.jsoniq.runtime.iterator.functions.io.JsonDocFunctionIterator;
-import sparksoniq.jsoniq.runtime.iterator.functions.context.PositionFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.context.LastFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.context.PositionFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.datetime.DateFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.datetime.DateTimeFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.datetime.TimeFunctionIterator;
-import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.*;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.AdjustDateTimeToTimezone;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.AdjustDateToTimezone;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.AdjustTimeToTimezone;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.DayFromDateFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.DayFromDateTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.HoursFromDateTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.HoursFromTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.MinutesFromDateTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.MinutesFromTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.MonthFromDateFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.MonthFromDateTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.SecondsFromDateTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.SecondsFromTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.TimezoneFromDateFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.TimezoneFromDateTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.TimezoneFromTimeFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.YearFromDateFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.datetime.components.YearFromDateTimeFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.durations.DayTimeDurationFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.durations.DurationFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.durations.YearMonthDurationFunctionIterator;
@@ -51,6 +66,7 @@ import sparksoniq.jsoniq.runtime.iterator.functions.durations.components.Minutes
 import sparksoniq.jsoniq.runtime.iterator.functions.durations.components.MonthsFromDurationFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.durations.components.SecondsFromDurationFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.durations.components.YearsFromDurationFunctionIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.io.JsonDocFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.numerics.AbsFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.numerics.CeilingFunctionIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.numerics.FloorFunctionIterator;
@@ -111,9 +127,9 @@ import sparksoniq.jsoniq.runtime.iterator.functions.strings.SubstringFunctionIte
 import sparksoniq.jsoniq.runtime.iterator.functions.strings.TokenizeFunctionIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.spark.iterator.function.ParallelizeFunctionIterator;
+import sparksoniq.spark.iterator.function.ParquetFileFunctionIterator;
 import sparksoniq.spark.iterator.function.ParseJsonFunctionIterator;
 import sparksoniq.spark.iterator.function.ParseTextFunctionIterator;
-import sparksoniq.spark.iterator.function.ParquetFileFunctionIterator;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -123,8 +139,109 @@ import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.List;
 
-
-import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.*;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ABS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ACCUMULATE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ACOS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ADJUSTDATETIMETOTIMEZONE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ADJUSTDATETOTIMEZONE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ADJUSTTIMETOTIMEZONE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ASIN;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ATAN;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ATAN2;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.AVG;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.BASE64BINARY;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.BOOLEAN;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.CEILING;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.CONCAT;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.CONTAINS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.COS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.COUNT;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DATE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DATETIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DAYFROMDATE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DAYFROMDATETIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DAYSFROMDURATION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DAYTIMEDURATION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DEEPEQUAL;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DESCENDANTARRAYS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DESCENDANTOBJECTS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DESCENDANTPAIRS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DISTINCTVALUES;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.DURATION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.EMPTY;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ENDSWITH;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.EXACTLYONE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.EXISTS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.EXP;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.EXP10;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.FLATTEN;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.FLOOR;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.HEAD;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.HEXBINARY;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.HOURSFROMDATETIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.HOURSFROMDURATION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.HOURSFROMTIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.INDEXOF;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.INSERTBEFORE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.INTERSECT;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.JSON_DOC;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.JSON_FILE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.KEYS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.LAST;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.LOG;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.LOG10;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MATCHES;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MAX;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MEMBERS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MIN;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MINUTESFROMDATETIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MINUTESFROMDURATION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MINUTESFROMTIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MONTHFROMDATE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MONTHFROMDATETIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.MONTHSFROMDURATION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.NORMALIZESPACE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.NULL;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ONEORMORE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.PARALLELIZE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.PARQUET_FILE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.PI;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.POSITION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.POW;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.PROJECT;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.REMOVE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.REMOVEKEYS;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.REVERSE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ROUND;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ROUNDHALFTOEVEN;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SECONDSFROMDATETIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SECONDSFROMDURATION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SECONDSFROMTIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SIN;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SIZE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SQRT;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.STARTSWITH;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.STRINGJOIN;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.STRINGLENGTH;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SUBSEQUENCE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SUBSTRING;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SUBSTRING_AFTER;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SUBSTRING_BEFORE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.SUM;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.TAIL;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.TAN;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.TEXT_FILE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.TIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.TIMEZONEFROMDATE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.TIMEZONEFROMDATETIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.TIMEZONEFROMTIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.TOKENIZE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.VALUES;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.YEARFROMDATE;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.YEARFROMDATETIME;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.YEARMONTHDURATION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.YEARSFROMDURATION;
+import static sparksoniq.jsoniq.runtime.iterator.functions.base.Functions.FunctionNames.ZEROORONE;
 
 public class Functions {
     private static HashMap<FunctionIdentifier, Class<? extends RuntimeIterator>> builtInFunctions;
@@ -200,8 +317,9 @@ public class Functions {
         builtInFunctions.put(new FunctionIdentifier(SUBSTRING, 3), SubstringFunctionIterator.class);
         builtInFunctions.put(new FunctionIdentifier(SUBSTRING_BEFORE, 2), SubstringBeforeFunctionIterator.class);
         builtInFunctions.put(new FunctionIdentifier(SUBSTRING_AFTER, 2), SubstringAfterFunctionIterator.class);
-        for (int i = 0; i <= 100; i++)
+        for (int i = 0; i <= 100; i++) {
             builtInFunctions.put(new FunctionIdentifier(CONCAT, i), ConcatFunctionIterator.class);
+        }
 
         builtInFunctions.put(new FunctionIdentifier(ENDSWITH, 2), EndsWithFunctionIterator.class);
         builtInFunctions.put(new FunctionIdentifier(STRINGJOIN, 1), StringJoinFunction.class);
@@ -293,15 +411,15 @@ public class Functions {
         }
     }
 
-    public static RuntimeIterator getUserDefinedFunctionIterator(
+    public static RuntimeIterator getUserDefinedFunctionCallIterator(
             FunctionIdentifier identifier,
             IteratorMetadata metadata,
             List<RuntimeIterator> arguments
     ) {
-        return buildUserDefinedFunctionIterator(getUserDefinedFunction(identifier), metadata, arguments);
+        return buildUserDefinedFunctionCallIterator(getUserDefinedFunction(identifier), metadata, arguments);
     }
 
-    public static RuntimeIterator buildUserDefinedFunctionIterator(
+    public static RuntimeIterator buildUserDefinedFunctionCallIterator(
             FunctionItem functionItem,
             IteratorMetadata metadata,
             List<RuntimeIterator> arguments

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -94,9 +94,8 @@ import sparksoniq.jsoniq.runtime.iterator.control.SwitchRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.control.TypeSwitchCase;
 import sparksoniq.jsoniq.runtime.iterator.control.TypeSwitchRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.DynamicFunctionCallIterator;
-import sparksoniq.jsoniq.runtime.iterator.functions.DynamicallyResolvedFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.FunctionRuntimeIterator;
-import sparksoniq.jsoniq.runtime.iterator.functions.FunctionItemCallIterator;
+import sparksoniq.jsoniq.runtime.iterator.functions.StaticUserDefinedFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.FunctionIdentifier;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.Functions;
 import sparksoniq.jsoniq.runtime.iterator.operational.AdditiveOperationIterator;
@@ -141,7 +140,6 @@ import sparksoniq.spark.iterator.flowr.WhereClauseSparkIterator;
 import sparksoniq.spark.iterator.flowr.expression.GroupByClauseSparkIteratorExpression;
 import sparksoniq.spark.iterator.flowr.expression.OrderByClauseSparkIteratorExpression;
 
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -166,12 +164,14 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
     @Override
     public RuntimeIterator visitCommaExpression(CommaExpression expression, RuntimeIterator argument) {
         List<RuntimeIterator> result = new ArrayList<>();
-        for (Expression childExpr : expression.getExpressions())
+        for (Expression childExpr : expression.getExpressions()) {
             result.add(this.visit(childExpr, argument));
-        if (result.size() == 1)
+        }
+        if (result.size() == 1) {
             return result.get(0);
-        else
+        } else {
             return new CommaExpressionIterator(result, createIteratorMetadata(expression));
+        }
     }
 
     // region module
@@ -305,8 +305,9 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
     // region primary
     @Override
     public RuntimeIterator visitParenthesizedExpression(ParenthesizedExpression expression, RuntimeIterator argument) {
-        if (expression.getExpression() != null)
+        if (expression.getExpression() != null) {
             return defaultAction(expression, argument);
+        }
         return new EmptySequenceIterator(createIteratorMetadata(expression));
     }
 
@@ -363,8 +364,9 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
     @Override
     public RuntimeIterator visitArrayConstructor(ArrayConstructor expression, RuntimeIterator argument) {
         RuntimeIterator result = null;
-        if (expression.getExpression() != null)
+        if (expression.getExpression() != null) {
             result = this.visit(expression.getExpression(), argument);
+        }
         return new ArrayRuntimeIterator(result, createIteratorMetadata(expression));
     }
 
@@ -372,16 +374,19 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
     public RuntimeIterator visitObjectConstructor(ObjectConstructor expression, RuntimeIterator argument) {
         if (expression.isMergedConstructor()) {
             List<RuntimeIterator> childExpressions = new ArrayList<>();
-            for (Expression child : expression.getChildExpression().getExpressions())
+            for (Expression child : expression.getChildExpression().getExpressions()) {
                 childExpressions.add((this.visit(child, argument)));
+            }
             return new ObjectConstructorRuntimeIterator(childExpressions, createIteratorMetadata(expression));
         } else {
             List<RuntimeIterator> keys = new ArrayList<>();
             List<RuntimeIterator> values = new ArrayList<>();
-            for (Expression key : expression.getKeys())
+            for (Expression key : expression.getKeys()) {
                 keys.add(this.visit(key, argument));
-            for (Expression value : expression.getValues())
+            }
+            for (Expression value : expression.getValues()) {
                 values.add(this.visit(value, argument));
+            }
             return new ObjectConstructorRuntimeIterator(keys, values, createIteratorMetadata(expression));
         }
     }
@@ -443,7 +448,7 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
             }
             return Functions.getBuiltInFunctionIterator(identifier, iteratorMetadata, arguments);
         }
-        return new DynamicallyResolvedFunctionCallIterator(
+        return new StaticUserDefinedFunctionCallIterator(
                 identifier,
                 arguments,
                 iteratorMetadata
@@ -634,11 +639,12 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
 
     @Override
     public RuntimeIterator visitNotExpr(NotExpression expression, RuntimeIterator argument) {
-        if (expression.isActive())
+        if (expression.isActive()) {
             return new NotOperationIterator(
                     this.visit(expression.getMainExpression(), argument),
                     createIteratorMetadata(expression)
             );
+        }
         return defaultAction(expression, argument);
     }
 
@@ -647,9 +653,11 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
         if (expression.isActive()) {
             // compute +- final result
             int result = 1;
-            for (OperationalExpressionBase.Operator op : expression.getOperators())
-                if (op == OperationalExpressionBase.Operator.MINUS)
+            for (OperationalExpressionBase.Operator op : expression.getOperators()) {
+                if (op == OperationalExpressionBase.Operator.MINUS) {
                     result *= -1;
+                }
+            }
             return new UnaryOperationIterator(
                     this.visit(expression.getMainExpression(), argument),
                     result == -1 ? OperationalExpressionBase.Operator.MINUS : OperationalExpressionBase.Operator.PLUS,
@@ -665,8 +673,9 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
             RuntimeIterator left = this.visit(expression.getMainExpression(), argument);
             RuntimeIterator right = this.visit(expression.getRightExpression(), argument);
             return new RangeOperationIterator(left, right, createIteratorMetadata(expression));
-        } else
+        } else {
             return defaultAction(expression, argument);
+        }
     }
 
     @Override
@@ -680,8 +689,9 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
                     expression.getOperator(),
                     createIteratorMetadata(expression)
             );
-        } else
+        } else {
             return defaultAction(expression, argument);
+        }
     }
 
     @Override
@@ -723,8 +733,9 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
                     expression.getsequenceType().getSequence(),
                     createIteratorMetadata(expression)
             );
-        } else
+        } else {
             return defaultAction(expression, argument);
+        }
     }
 
     @Override
@@ -736,8 +747,9 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
                     expression.getsequenceType().getSequence(),
                     createIteratorMetadata(expression)
             );
-        } else
+        } else {
             return defaultAction(expression, argument);
+        }
     }
 
     @Override
@@ -749,8 +761,9 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
                     expression.get_atomicType().getSingleType(),
                     createIteratorMetadata(expression)
             );
-        } else
+        } else {
             return defaultAction(expression, argument);
+        }
     }
 
     @Override
@@ -762,8 +775,9 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
                     expression.getFlworVarSingleType().getSingleType(),
                     createIteratorMetadata(expression)
             );
-        } else
+        } else {
             return defaultAction(expression, argument);
+        }
     }
     // endregion
 
@@ -809,11 +823,12 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
     @Override
     public RuntimeIterator visitSwitchExpression(SwitchExpression expression, RuntimeIterator argument) {
         Map<RuntimeIterator, RuntimeIterator> cases = new LinkedHashMap<>();
-        for (SwitchCaseExpression caseExpression : expression.getCases())
+        for (SwitchCaseExpression caseExpression : expression.getCases()) {
             cases.put(
                 this.visit(caseExpression.getCondition(), argument),
                 this.visit(caseExpression.getReturnExpression(), argument)
             );
+        }
         return new SwitchRuntimeIterator(
                 this.visit(expression.getTestCondition(), argument),
                 cases,


### PR DESCRIPTION
I tried to improve the naming of classes for the PR #377 . Please feel free to address anything that doesn't suit you as it's mostly a matter of preference in the road to clarity.

The issues I tried to address mainly were
- The duality of DynamicallyResolvedFunctionCallIterator and DynamicFunctionCallIterator as I assumed the difference would not be immediately clear in my opinion for a new pair of eyes. These are now renamed to StaticUserDefinedFunctionCallIterator and DynamicUserDefinedFunctionCallIterator respectively.
- The ambiguity of functionItemCalliterator and the name of the iterator  field of this class . I believe naming these UserDefinedFunctionCallIterator and functionBodyIterator makes the intention of the class much more clearer. 

There could be a new issue with the new class names (UserDefinedFunctionCallIterator, StaticUserDefinedFunctionCallIterator, DynamicUserDefinedFunctionCallIterator) as to making the developer expect that there is some sort of a class hierarchy. In order to address this, the names could be made even more explicit such as "UserDefinedFunctionCallStaticResolutionIterator" and "UserDefinedFunctionCallDynamicResolutionIterator". This would outline the main objective of these two classes which is handling the function resolution, however I didn't proceed with this as I was not sure if it would be over-explaining/ too long names :)