### PR TITLE
Make sure that only one grouping key is taken when keys in the same group are different.

### DIFF
--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -229,7 +229,7 @@ public class DataFrameUtils {
                 queryColumnString.append(serializerUdfName);
                 queryColumnString.append("(");
                 queryColumnString.append("array(");
-                queryColumnString.append("first(");
+                queryColumnString.append("first(`");
             } else {
                 queryColumnString.append(serializerUdfName);
                 queryColumnString.append("(");
@@ -241,7 +241,7 @@ public class DataFrameUtils {
             if (applyCount) {
                 queryColumnString.append("`)");
             } else if (applyDistinct) {
-                queryColumnString.append(")");
+                queryColumnString.append("`)");
                 queryColumnString.append(")");
                 queryColumnString.append(")");
             } else {

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -225,27 +225,26 @@ public class DataFrameUtils {
             }
             if (applyCount) {
                 queryColumnString.append("count(`");
-            } else if (applyDistinct) {
-                queryColumnString.append(serializerUdfName);
-                queryColumnString.append("(");
-                queryColumnString.append("array(");
-                queryColumnString.append("first(`");
             } else {
                 queryColumnString.append(serializerUdfName);
                 queryColumnString.append("(");
-                queryColumnString.append("collect_list(`");
+                if (applyDistinct) {
+                    queryColumnString.append("array(");
+                    queryColumnString.append("first(`");
+                } else {
+                    queryColumnString.append("collect_list(`");
+                }
             }
 
             queryColumnString.append(columnName);
 
             if (applyCount) {
                 queryColumnString.append("`)");
-            } else if (applyDistinct) {
-                queryColumnString.append("`)");
-                queryColumnString.append(")");
-                queryColumnString.append(")");
             } else {
                 queryColumnString.append("`)");
+                if (applyDistinct) {
+                    queryColumnString.append(")");
+                }
                 queryColumnString.append(")");
             }
             queryColumnString.append(" as `");

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -165,8 +165,7 @@ public class DataFrameUtils {
     private static String COMMA = ",";
 
     /**
-     * @param inputSchema schema specifies the columns to be used in the query
-     * @param duplicateVariableIndex enables skipping a variable
+     * @param columnNames schema specifies the columns to be used in the query
      * @param trailingComma boolean field to have a trailing comma
      * @return comma separated variables to be used in spark SQL
      */

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -225,12 +225,14 @@ public class DataFrameUtils {
             }
             if (applyCount) {
                 queryColumnString.append("count(`");
+            } else if (applyDistinct) {
+                queryColumnString.append(serializerUdfName);
+                queryColumnString.append("(");
+                queryColumnString.append("array(");
+                queryColumnString.append("collect_list(`");
             } else {
                 queryColumnString.append(serializerUdfName);
                 queryColumnString.append("(");
-                if (applyDistinct) {
-                    queryColumnString.append("array_distinct(");
-                }
                 queryColumnString.append("collect_list(`");
             }
 
@@ -238,11 +240,12 @@ public class DataFrameUtils {
 
             if (applyCount) {
                 queryColumnString.append("`)");
+            } else if (applyDistinct) {
+                queryColumnString.append("`)[0]");
+                queryColumnString.append(")");
+                queryColumnString.append(")");
             } else {
                 queryColumnString.append("`)");
-                if (applyDistinct) {
-                    queryColumnString.append(")");
-                }
                 queryColumnString.append(")");
             }
             queryColumnString.append(" as `");

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -208,12 +208,12 @@ public class DataFrameUtils {
         for (int columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
             String columnName = columnNames[columnIndex];
 
-            boolean applyDistinct = false;
+            boolean groupingKey = false;
             if (columnIndex == duplicateVariableIndex) {
                 continue;
             }
             if (groupbyVariableNames.contains(columnName)) {
-                applyDistinct = true;
+                groupingKey = true;
             }
 
             boolean applyCount = false;
@@ -228,7 +228,7 @@ public class DataFrameUtils {
             } else {
                 queryColumnString.append(serializerUdfName);
                 queryColumnString.append("(");
-                if (applyDistinct) {
+                if (groupingKey) {
                     queryColumnString.append("array(");
                     queryColumnString.append("first(`");
                 } else {
@@ -242,7 +242,7 @@ public class DataFrameUtils {
                 queryColumnString.append("`)");
             } else {
                 queryColumnString.append("`)");
-                if (applyDistinct) {
+                if (groupingKey) {
                     queryColumnString.append(")");
                 }
                 queryColumnString.append(")");

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -228,8 +228,7 @@ public class DataFrameUtils {
             } else if (applyDistinct) {
                 queryColumnString.append(serializerUdfName);
                 queryColumnString.append("(");
-                queryColumnString.append("array(");
-                queryColumnString.append("collect_list(`");
+                queryColumnString.append("first(");
             } else {
                 queryColumnString.append(serializerUdfName);
                 queryColumnString.append("(");
@@ -241,7 +240,6 @@ public class DataFrameUtils {
             if (applyCount) {
                 queryColumnString.append("`)");
             } else if (applyDistinct) {
-                queryColumnString.append("`)[0]");
                 queryColumnString.append(")");
                 queryColumnString.append(")");
             } else {

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -228,6 +228,7 @@ public class DataFrameUtils {
             } else if (applyDistinct) {
                 queryColumnString.append(serializerUdfName);
                 queryColumnString.append("(");
+                queryColumnString.append("array(");
                 queryColumnString.append("first(");
             } else {
                 queryColumnString.append(serializerUdfName);
@@ -240,6 +241,7 @@ public class DataFrameUtils {
             if (applyCount) {
                 queryColumnString.append("`)");
             } else if (applyDistinct) {
+                queryColumnString.append(")");
                 queryColumnString.append(")");
                 queryColumnString.append(")");
             } else {

--- a/src/main/resources/test_files/runtime-spark/DataFrames/GroupbyClause11.jq
+++ b/src/main/resources/test_files/runtime-spark/DataFrames/GroupbyClause11.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="0" :)
+for $i in parallelize((0, 0.0))
+group by $i
+return $i


### PR DESCRIPTION
The current implementation was incorrectly assuming that all equivalent keys within a group would be exactly the same.

When this is not the case, one of the values should be arbitrarily picked.

Replacing in Spark SQL

array_distinct(...)

with array(first(...))

This problem is already present in the master with, for example, integers and decimals (see added test).