### PR TITLE
Throw UnknownFunctionCallException if non-existing function is called

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
@@ -22,6 +22,7 @@ package sparksoniq.jsoniq.runtime.iterator.functions.base;
 
 import sparksoniq.exceptions.DuplicateFunctionIdentifierException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
+import sparksoniq.exceptions.UnknownFunctionCallException;
 import sparksoniq.jsoniq.compiler.translator.metadata.ExpressionMetadata;
 import sparksoniq.jsoniq.item.FunctionItem;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -419,7 +420,15 @@ public class Functions {
             IteratorMetadata metadata,
             List<RuntimeIterator> arguments
     ) {
-        return buildUserDefinedFunctionCallIterator(getUserDefinedFunction(identifier), metadata, arguments);
+        if (Functions.checkUserDefinedFunctionExists(identifier)) {
+            return buildUserDefinedFunctionCallIterator(getUserDefinedFunction(identifier), metadata, arguments);
+        }
+        throw new UnknownFunctionCallException(
+                identifier.getName(),
+                identifier.getArity(),
+                metadata
+        );
+
     }
 
     public static RuntimeIterator buildUserDefinedFunctionCallIterator(
@@ -449,11 +458,11 @@ public class Functions {
     }
 
     public static FunctionItem getUserDefinedFunction(FunctionIdentifier identifier) {
-        FunctionItem fnItem = userDefinedFunctions.get(identifier);
+        FunctionItem functionItem = userDefinedFunctions.get(identifier);
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             ObjectOutputStream oos = new ObjectOutputStream(bos);
-            oos.writeObject(fnItem);
+            oos.writeObject(functionItem);
             oos.flush();
             byte[] data = bos.toByteArray();
             ByteArrayInputStream bis = new ByteArrayInputStream(data);

--- a/src/main/resources/test_files/runtime/FunctionUserDefinedStatic/FunctionUserDefinedStatic-Error4.jq
+++ b/src/main/resources/test_files/runtime/FunctionUserDefinedStatic/FunctionUserDefinedStatic-Error4.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldCrash; ErrorCode="XPST0017"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+nonExistingFn("hello")
+
+(: Undefined function call :)


### PR DESCRIPTION
The current master is throwing a NullPointerException if a non-existing function is called. For example, when evaluating `nonExistingFunction("hello")`, the following is the stacktrace of the exception. 

> java.lang.NullPointerException
	at sparksoniq.jsoniq.runtime.iterator.functions.FunctionItemCallIterator.initIsRDD(FunctionItemCallIterator.java:212)
	at sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator.isRDD(HybridRuntimeIterator.java:56)
	at sparksoniq.jsoniq.runtime.iterator.functions.StaticUserDefinedFunctionCallIterator.initIsRDD(StaticUserDefinedFunctionCallIterator.java:126)
	at sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator.isRDD(HybridRuntimeIterator.java:56)
...