### PR TITLE
Fix order clause empty df handling

### DIFF
--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -187,6 +187,9 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             throw new SparksoniqRuntimeException("Invalid orderby clause.");
         }
         Dataset<Row> df = _child.getDataFrame(context, getProjection(parentProjection));
+        if (df.count() == 0) {
+            return df;
+        }
         StructType inputSchema = df.schema();
 
         List<String> allColumns = DataFrameUtils.getColumnNames(inputSchema);

--- a/src/main/resources/test_files/runtime-spark/Pushdown/KeysDF3.jq
+++ b/src/main/resources/test_files/runtime-spark/Pushdown/KeysDF3.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="" :)
+for $k in keys(keys(structured-json-file("./src/main/resources/queries/conf-ex.json")))
+group by $k
+return $k

--- a/src/main/resources/test_files/runtime-spark/Pushdown/KeysRDD3.jq
+++ b/src/main/resources/test_files/runtime-spark/Pushdown/KeysRDD3.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="" :)
+for $k in keys(keys(parallelize(for $i in 1 to 10000 return { "foo" : "bar", "bar" : "foobar"})))
+order by $k
+return $k


### PR DESCRIPTION
Based on #393. This PR introduces a tiny change that fixes the crashes caused by empty dataframe being passed as input to order by clause. This would result in an empty sql statement which causes the crash.

Tests added.

@ghislainfourny Should the short circuit mentioned above (seen in OrderByClauseSparkIterator.java file) be added to other FLWOR clauses as well? It could save a bit of unnecessary computation and querying when operating on empty sequences. However this introduces an additional count() action which might be costly.