### PR TITLE
Use EBV in where clauses and predicates when pushing down to DF.

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -71,26 +71,34 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
      * Singleton atomic values are evaluated to their effective boolean value.
      * Multiple atomic values throw an exception.
      *
+     * If the sequence is a single numeric item and a non-null position is supplied, then instead
+     * it is checked whether the numeric item is equal to the position.
+     * 
      * @param iterator has to be opened before calling this function
+     * @param position the context position, or null if none
      * @return
      */
-    public static boolean getEffectiveBooleanValue(RuntimeIterator iterator) {
+    public static boolean getEffectiveBooleanValueOrCheckPosition(RuntimeIterator iterator, Item position) {
         if (iterator.hasNext()) {
             Item item = iterator.next();
             boolean result;
             if (item.isBoolean())
                 result = item.getBooleanValue();
             else if (item.isNumeric()) {
-                if (item.isInteger())
-                    result = item.getIntegerValue() != 0;
-                else if (item.isDouble())
-                    result = item.getDoubleValue() != 0;
-                else if (item.isDecimal())
-                    result = !item.getDecimalValue().equals(BigDecimal.ZERO);
-                else {
-                    throw new SparksoniqRuntimeException(
-                            "Unexpected numeric type found while calculating effective boolean value."
-                    );
+                if (position == null) {
+                    if (item.isInteger())
+                        result = item.getIntegerValue() != 0;
+                    else if (item.isDouble())
+                        result = item.getDoubleValue() != 0;
+                    else if (item.isDecimal())
+                        result = !item.getDecimalValue().equals(BigDecimal.ZERO);
+                    else {
+                        throw new SparksoniqRuntimeException(
+                                "Unexpected numeric type found while calculating effective boolean value."
+                        );
+                    }
+                } else {
+                    result = item.equals(position);
                 }
             } else if (item.isNull())
                 result = false;
@@ -124,6 +132,20 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
             return false;
         }
 
+    }
+
+    /**
+     * This function calculates the effective boolean value of the sequence given by iterator.
+     * Non-empty objects and arrays always return true.
+     * Empty sequence returns false.
+     * Singleton atomic values are evaluated to their effective boolean value.
+     * Multiple atomic values throw an exception.
+     *
+     * @param iterator has to be opened before calling this function
+     * @return
+     */
+    public static boolean getEffectiveBooleanValue(RuntimeIterator iterator) {
+        return getEffectiveBooleanValueOrCheckPosition(iterator, null);
     }
 
     public void open(DynamicContext context) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TypePromotionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TypePromotionIterator.java
@@ -53,7 +53,6 @@ public class TypePromotionIterator extends HybridRuntimeIterator {
     @Override
     public void resetLocal(DynamicContext context) {
         _iterator.reset(_currentDynamicContext);
-        this._childIndex = 0;
         setNextResult();
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TypePromotionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/TypePromotionIterator.java
@@ -53,6 +53,7 @@ public class TypePromotionIterator extends HybridRuntimeIterator {
     @Override
     public void resetLocal(DynamicContext context) {
         _iterator.reset(_currentDynamicContext);
+        this._childIndex = 0;
         setNextResult();
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosure.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosure.java
@@ -49,12 +49,11 @@ public class PredicateClosure implements Function<Item, Boolean> {
         dynamicContext.addVariableValue("$$", currentItems);
 
         _expression.open(dynamicContext);
-        if(_expression.hasNext()) {
+        if (_expression.hasNext()) {
             Item result = _expression.next();
             _expression.close();
             return result.getBooleanValue();
-        }
-        else {
+        } else {
             _expression.close();
             return false;
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosure.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosure.java
@@ -23,7 +23,6 @@ package sparksoniq.jsoniq.runtime.iterator.postfix;
 import org.apache.spark.api.java.function.Function;
 import org.rumbledb.api.Item;
 
-import sparksoniq.jsoniq.item.ItemFactory;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.semantics.DynamicContext;
 
@@ -49,14 +48,10 @@ public class PredicateClosure implements Function<Item, Boolean> {
         dynamicContext.addVariableValue("$$", currentItems);
 
         _expression.open(dynamicContext);
-        if (_expression.hasNext()) {
-            Item result = _expression.next();
-            _expression.close();
-            return result.getBooleanValue();
-        } else {
-            _expression.close();
-            return false;
-        }
+        boolean result = RuntimeIterator.getEffectiveBooleanValue(_expression);
+        _expression.close();
+        return result;
+
     }
 
 };

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosureZipped.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosureZipped.java
@@ -53,21 +53,12 @@ public class PredicateClosureZipped implements Function<Tuple2<Item, Long>, Bool
         dynamicContext.setLast(_contextSize);
 
         _expression.open(dynamicContext);
-        if (_expression.hasNext()) {
-            Item value = _expression.next();
-            if (value.isNumeric() && !_expression.hasNext()) {
-                _expression.close();
-                return new Boolean(value.equals(dynamicContext.getPosition()));
-            } else {
-                _expression.reset(dynamicContext);
-                boolean result = RuntimeIterator.getEffectiveBooleanValue(_expression);
-                _expression.close();
-                return result;
-            }
-        } else {
-            _expression.close();
-            return false;
-        }
+        boolean result = RuntimeIterator.getEffectiveBooleanValueOrCheckPosition(
+            _expression,
+            dynamicContext.getPosition()
+        );
+        _expression.close();
+        return result;
     }
 
 };

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosureZipped.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosureZipped.java
@@ -53,7 +53,7 @@ public class PredicateClosureZipped implements Function<Tuple2<Item, Long>, Bool
         dynamicContext.setLast(_contextSize);
 
         _expression.open(dynamicContext);
-        if(_expression.hasNext()) {
+        if (_expression.hasNext()) {
             Item result = _expression.next();
             _expression.close();
             if (result.isNumeric()) {
@@ -61,8 +61,7 @@ public class PredicateClosureZipped implements Function<Tuple2<Item, Long>, Bool
             } else {
                 return result.getBooleanValue();
             }
-        }
-        else {
+        } else {
             _expression.close();
             return false;
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosureZipped.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateClosureZipped.java
@@ -54,12 +54,15 @@ public class PredicateClosureZipped implements Function<Tuple2<Item, Long>, Bool
 
         _expression.open(dynamicContext);
         if (_expression.hasNext()) {
-            Item result = _expression.next();
-            _expression.close();
-            if (result.isNumeric()) {
-                return new Boolean(result.equals(dynamicContext.getPosition()));
+            Item value = _expression.next();
+            if (value.isNumeric() && !_expression.hasNext()) {
+                _expression.close();
+                return new Boolean(value.equals(dynamicContext.getPosition()));
             } else {
-                return result.getBooleanValue();
+                _expression.reset(dynamicContext);
+                boolean result = RuntimeIterator.getEffectiveBooleanValue(_expression);
+                _expression.close();
+                return result;
             }
         } else {
             _expression.close();

--- a/src/main/java/sparksoniq/spark/udf/WhereClauseUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/WhereClauseUDF.java
@@ -83,12 +83,11 @@ public class WhereClauseUDF implements UDF1<WrappedArray<byte[]>, Boolean> {
 
         // apply expression in the dynamic context
         _expression.open(_context);
-        if(_expression.hasNext()) {
+        if (_expression.hasNext()) {
             Item nextItem = _expression.next();
             _expression.close();
             return ((BooleanItem) nextItem).getBooleanValue();
-        }
-        else {
+        } else {
             _expression.close();
             return false;
         }

--- a/src/main/java/sparksoniq/spark/udf/WhereClauseUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/WhereClauseUDF.java
@@ -83,14 +83,9 @@ public class WhereClauseUDF implements UDF1<WrappedArray<byte[]>, Boolean> {
 
         // apply expression in the dynamic context
         _expression.open(_context);
-        if (_expression.hasNext()) {
-            Item nextItem = _expression.next();
-            _expression.close();
-            return ((BooleanItem) nextItem).getBooleanValue();
-        } else {
-            _expression.close();
-            return false;
-        }
+        boolean result = RuntimeIterator.getEffectiveBooleanValue(_expression);
+        _expression.close();
+        return result;
     }
 
     private void readObject(java.io.ObjectInputStream in)

--- a/src/main/resources/test_files/runtime-spark/DataFrames/WhereClause10.jq
+++ b/src/main/resources/test_files/runtime-spark/DataFrames/WhereClause10.jq
@@ -1,2 +1,2 @@
-(:JIQS: ShouldRun; Output="(1, 2, 3, 4)" :)
+(:JIQS: ShouldCrash; ErrorCode="FORG0006"; ErrorMetadata="LINE:2:COLUMN:43:" :)
 for $i in parallelize((1, 2, 3, 4)) where (1, 2) return $i

--- a/src/main/resources/test_files/runtime-spark/DataFrames/WhereClause10.jq
+++ b/src/main/resources/test_files/runtime-spark/DataFrames/WhereClause10.jq
@@ -1,0 +1,2 @@
+(:JIQS: ShouldRun; Output="(1, 2, 3, 4)" :)
+for $i in parallelize((1, 2, 3, 4)) where (1, 2) return $i

--- a/src/main/resources/test_files/runtime-spark/PositionPredicate7.jq
+++ b/src/main/resources/test_files/runtime-spark/PositionPredicate7.jq
@@ -1,0 +1,3 @@
+(:JIQS: ShouldRun; Output="(foo, 5)" :)
+parallelize(("foo", "", 1, 0, 5))[$$]
+

--- a/src/main/resources/test_files/runtime-spark/PositionPredicate8.jq
+++ b/src/main/resources/test_files/runtime-spark/PositionPredicate8.jq
@@ -1,0 +1,2 @@
+(:JIQS: ShouldCrash; ErrorCode="FORG0006"; ErrorMetadata="LINE:2:COLUMN:23:" :)
+parallelize((1, 2, 3))[0, 1]


### PR DESCRIPTION
The EBV was not considered, although where clauses and predicates should.

https://www.w3.org/TR/xquery-30/#id-ebv

For predicates, there is the special case where the sequence is a single numeric item. Then the EBV is not taken, but the position is checked instead.

https://www.w3.org/TR/xquery-30/#id-filter-expression