### PR TITLE
Fix count optimization with let group

### DIFF
--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -72,19 +72,9 @@ import static org.apache.spark.sql.functions.udf;
 
 public class DataFrameUtils {
 
-    private static ThreadLocal<byte[]> lastBytesCache = new ThreadLocal<byte[]>() {
-        @Override
-        protected byte[] initialValue() {
-            return null;
-        }
-    };
+    private static ThreadLocal<byte[]> lastBytesCache = ThreadLocal.withInitial(() -> null);
 
-    private static ThreadLocal<List<Item>> lastObjectItemCache = new ThreadLocal<List<Item>>() {
-        @Override
-        protected List<Item> initialValue() {
-            return null;
-        }
-    };
+    private static ThreadLocal<List<Item>> lastObjectItemCache = ThreadLocal.withInitial(() -> null);
 
     public static void registerKryoClassesKryo(Kryo kryo) {
         kryo.register(Item.class);
@@ -145,7 +135,7 @@ public class DataFrameUtils {
             int duplicateVariableIndex,
             Map<String, DynamicContext.VariableDependency> dependencies
     ) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         String[] columnNames = inputSchema.fieldNames();
         for (int columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
             if (columnIndex == duplicateVariableIndex) {
@@ -170,7 +160,7 @@ public class DataFrameUtils {
             int duplicateVariableIndex,
             Map<String, DynamicContext.VariableDependency> dependencies
     ) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         String[] columnNames = inputSchema.fieldNames();
         for (int columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
             if (columnIndex == duplicateVariableIndex) {
@@ -199,7 +189,7 @@ public class DataFrameUtils {
             int duplicateVariableIndex,
             Map<String, DynamicContext.VariableDependency> dependencies
     ) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         String[] columnNames = inputSchema.fieldNames();
         for (int columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
             if (columnIndex == duplicateVariableIndex) {
@@ -232,7 +222,6 @@ public class DataFrameUtils {
             List<String> columnNames,
             List<List<Item>> deserializedParams
     ) {
-        // prepare dynamic context
         for (int columnIndex = 0; columnIndex < columnNames.size(); columnIndex++) {
             context.addVariableValue(columnNames.get(columnIndex), deserializedParams.get(columnIndex));
         }
@@ -245,11 +234,9 @@ public class DataFrameUtils {
             List<List<Item>> deserializedParams,
             List<Item> counts
     ) {
-        // prepare dynamic context
         for (int columnIndex = 0; columnIndex < binaryColumnNames.size(); columnIndex++) {
             context.addVariableValue(binaryColumnNames.get(columnIndex), deserializedParams.get(columnIndex));
         }
-        // prepare dynamic context
         for (int columnIndex = 0; columnIndex < countColumnNames.size(); columnIndex++) {
             context.addVariableCount(countColumnNames.get(columnIndex), counts.get(columnIndex));
         }
@@ -349,12 +336,11 @@ public class DataFrameUtils {
         return queryColumnString.toString();
     }
 
-    public static Object deserializeByteArray(byte[] toDeserialize, Kryo kryo, Input input) {
+    private static Object deserializeByteArray(byte[] toDeserialize, Kryo kryo, Input input) {
         byte[] bytes = lastBytesCache.get();
         if (bytes != null) {
             if (Arrays.equals(bytes, toDeserialize)) {
-                List<Item> deserializedParam = lastObjectItemCache.get();
-                return deserializedParam;
+                return lastObjectItemCache.get();
             }
         }
         input.setBuffer(toDeserialize);
@@ -400,7 +386,7 @@ public class DataFrameUtils {
     public static List<Item> deserializeRowField(Row row, int columnIndex, Kryo kryo, Input input) {
         Object o = row.get(columnIndex);
         if (o instanceof Long) {
-            List<Item> result = new ArrayList<Item>(1);
+            List<Item> result = new ArrayList<>(1);
             result.add(ItemFactory.getInstance().createIntegerItem(((Long) o).intValue()));
             return result;
         } else {
@@ -451,12 +437,12 @@ public class DataFrameUtils {
             .collect();
         Row[] partitionOffsetsArray = ((Row[]) partitionOffsetsObject);
         Map<Integer, Long> partitionOffsets = new HashMap<>();
-        for (int i = 0; i < partitionOffsetsArray.length; i++) {
-            partitionOffsets.put(partitionOffsetsArray[i].getInt(0), partitionOffsetsArray[i].getLong(1));
+        for (Row row : partitionOffsetsArray) {
+            partitionOffsets.put(row.getInt(0), row.getLong(1));
         }
 
         UserDefinedFunction getPartitionOffset = udf(
-            (partitionId) -> partitionOffsets.get((Integer) partitionId),
+            (partitionId) -> partitionOffsets.get(partitionId),
             DataTypes.LongType
         );
 

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -161,6 +161,56 @@ public class DataFrameUtils {
 
     /**
      * @param inputSchema schema specifies the columns to be used in the query
+     * @param duplicateVariableIndex enables skipping a variable
+     * @param dependencies restriction of the results to within a specified set
+     * @return list of SQL column names in the schema
+     */
+    public static List<String> getBinaryColumnNames(
+            StructType inputSchema,
+            int duplicateVariableIndex,
+            Map<String, DynamicContext.VariableDependency> dependencies
+    ) {
+        List<String> result = new ArrayList<String>();
+        String[] columnNames = inputSchema.fieldNames();
+        for (int columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
+            if (columnIndex == duplicateVariableIndex) {
+                continue;
+            }
+            String var = columnNames[columnIndex];
+            if (dependencies == null || (dependencies.containsKey(var) && !dependencies.get(var).equals(DynamicContext.VariableDependency.COUNT))) {
+                result.add(columnNames[columnIndex]);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @param inputSchema schema specifies the columns to be used in the query
+     * @param duplicateVariableIndex enables skipping a variable
+     * @param dependencies restriction of the results to within a specified set
+     * @return list of SQL column names in the schema
+     */
+    public static List<String> getLongColumnNames(
+            StructType inputSchema,
+            int duplicateVariableIndex,
+            Map<String, DynamicContext.VariableDependency> dependencies
+    ) {
+        List<String> result = new ArrayList<String>();
+        String[] columnNames = inputSchema.fieldNames();
+        for (int columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
+            if (columnIndex == duplicateVariableIndex) {
+                continue;
+            }
+            String var = columnNames[columnIndex];
+            if (dependencies != null && dependencies.containsKey(var) && dependencies.get(var).equals(DynamicContext.VariableDependency.COUNT)) {
+                result.add(columnNames[columnIndex]);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @param inputSchema schema specifies the columns to be used in the query
      * @return list of SQL column names in the schema
      */
     public static List<String> getColumnNames(

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -241,17 +241,17 @@ public class DataFrameUtils {
     public static void prepareDynamicContext(
             DynamicContext context,
             List<String> binaryColumnNames,
-            List<String> longColumnNames,
+            List<String> countColumnNames,
             List<List<Item>> deserializedParams,
-            List<Item> longParams
+            List<Item> counts
     ) {
         // prepare dynamic context
         for (int columnIndex = 0; columnIndex < binaryColumnNames.size(); columnIndex++) {
             context.addVariableValue(binaryColumnNames.get(columnIndex), deserializedParams.get(columnIndex));
         }
         // prepare dynamic context
-        for (int columnIndex = 0; columnIndex < longColumnNames.size(); columnIndex++) {
-            context.addVariableCount(longColumnNames.get(columnIndex), longParams.get(columnIndex));
+        for (int columnIndex = 0; columnIndex < countColumnNames.size(); columnIndex++) {
+            context.addVariableCount(countColumnNames.get(columnIndex), counts.get(columnIndex));
         }
     }
 

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -165,7 +165,7 @@ public class DataFrameUtils {
      * @param dependencies restriction of the results to within a specified set
      * @return list of SQL column names in the schema
      */
-    public static List<String> getBinaryColumnNames(
+    public static List<String> getColumnNamesExceptPrecomputedCounts(
             StructType inputSchema,
             int duplicateVariableIndex,
             Map<String, DynamicContext.VariableDependency> dependencies
@@ -194,7 +194,7 @@ public class DataFrameUtils {
      * @param dependencies restriction of the results to within a specified set
      * @return list of SQL column names in the schema
      */
-    public static List<String> getLongColumnNames(
+    public static List<String> getPrecomputedCountColumnNames(
             StructType inputSchema,
             int duplicateVariableIndex,
             Map<String, DynamicContext.VariableDependency> dependencies

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -177,7 +177,11 @@ public class DataFrameUtils {
                 continue;
             }
             String var = columnNames[columnIndex];
-            if (dependencies == null || (dependencies.containsKey(var) && !dependencies.get(var).equals(DynamicContext.VariableDependency.COUNT))) {
+            if (
+                dependencies == null
+                    || (dependencies.containsKey(var)
+                        && !dependencies.get(var).equals(DynamicContext.VariableDependency.COUNT))
+            ) {
                 result.add(columnNames[columnIndex]);
             }
         }
@@ -202,7 +206,11 @@ public class DataFrameUtils {
                 continue;
             }
             String var = columnNames[columnIndex];
-            if (dependencies != null && dependencies.containsKey(var) && dependencies.get(var).equals(DynamicContext.VariableDependency.COUNT)) {
+            if (
+                dependencies != null
+                    && dependencies.containsKey(var)
+                    && dependencies.get(var).equals(DynamicContext.VariableDependency.COUNT)
+            ) {
                 result.add(columnNames[columnIndex]);
             }
         }
@@ -227,6 +235,23 @@ public class DataFrameUtils {
         // prepare dynamic context
         for (int columnIndex = 0; columnIndex < columnNames.size(); columnIndex++) {
             context.addVariableValue(columnNames.get(columnIndex), deserializedParams.get(columnIndex));
+        }
+    }
+
+    public static void prepareDynamicContext(
+            DynamicContext context,
+            List<String> binaryColumnNames,
+            List<String> longColumnNames,
+            List<List<Item>> deserializedParams,
+            List<Item> longParams
+    ) {
+        // prepare dynamic context
+        for (int columnIndex = 0; columnIndex < binaryColumnNames.size(); columnIndex++) {
+            context.addVariableValue(binaryColumnNames.get(columnIndex), deserializedParams.get(columnIndex));
+        }
+        // prepare dynamic context
+        for (int columnIndex = 0; columnIndex < longColumnNames.size(); columnIndex++) {
+            context.addVariableCount(longColumnNames.get(columnIndex), longParams.get(columnIndex));
         }
     }
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -244,8 +244,8 @@ public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
                 int duplicateVariableIndex = columnNames.indexOf(newVariableName);
 
                 List<String> allColumns = DataFrameUtils.getColumnNames(inputSchema, duplicateVariableIndex, null);
-                List<String> UDFbinarycolumns = DataFrameUtils.getBinaryColumnNames(inputSchema, -1, _dependencies);
-                List<String> UDFlongcolumns = DataFrameUtils.getLongColumnNames(inputSchema, -1, _dependencies);
+                List<String> UDFbinarycolumns = DataFrameUtils.getColumnNamesExceptPrecomputedCounts(inputSchema, -1, _dependencies);
+                List<String> UDFlongcolumns = DataFrameUtils.getPrecomputedCountColumnNames(inputSchema, -1, _dependencies);
 
                 df.sparkSession()
                     .udf()

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -244,8 +244,16 @@ public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
                 int duplicateVariableIndex = columnNames.indexOf(newVariableName);
 
                 List<String> allColumns = DataFrameUtils.getColumnNames(inputSchema, duplicateVariableIndex, null);
-                List<String> UDFbinarycolumns = DataFrameUtils.getColumnNamesExceptPrecomputedCounts(inputSchema, -1, _dependencies);
-                List<String> UDFlongcolumns = DataFrameUtils.getPrecomputedCountColumnNames(inputSchema, -1, _dependencies);
+                List<String> UDFbinarycolumns = DataFrameUtils.getColumnNamesExceptPrecomputedCounts(
+                    inputSchema,
+                    -1,
+                    _dependencies
+                );
+                List<String> UDFlongcolumns = DataFrameUtils.getPrecomputedCountColumnNames(
+                    inputSchema,
+                    -1,
+                    _dependencies
+                );
 
                 df.sparkSession()
                     .udf()

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -163,7 +163,11 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
             int duplicateVariableIndex = Arrays.asList(inputSchema.fieldNames()).indexOf(_variableName);
 
             List<String> allColumns = DataFrameUtils.getColumnNames(inputSchema, duplicateVariableIndex, null);
-            List<String> UDFbinarycolumns = DataFrameUtils.getColumnNamesExceptPrecomputedCounts(inputSchema, -1, _dependencies);
+            List<String> UDFbinarycolumns = DataFrameUtils.getColumnNamesExceptPrecomputedCounts(
+                inputSchema,
+                -1,
+                _dependencies
+            );
             List<String> UDFlongcolumns = DataFrameUtils.getPrecomputedCountColumnNames(inputSchema, -1, _dependencies);
 
             df.sparkSession()

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -163,8 +163,8 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
             int duplicateVariableIndex = Arrays.asList(inputSchema.fieldNames()).indexOf(_variableName);
 
             List<String> allColumns = DataFrameUtils.getColumnNames(inputSchema, duplicateVariableIndex, null);
-            List<String> UDFbinarycolumns = DataFrameUtils.getBinaryColumnNames(inputSchema, -1, _dependencies);
-            List<String> UDFlongcolumns = DataFrameUtils.getLongColumnNames(inputSchema, -1, _dependencies);
+            List<String> UDFbinarycolumns = DataFrameUtils.getColumnNamesExceptPrecomputedCounts(inputSchema, -1, _dependencies);
+            List<String> UDFlongcolumns = DataFrameUtils.getPrecomputedCountColumnNames(inputSchema, -1, _dependencies);
 
             df.sparkSession()
                 .udf()

--- a/src/main/java/sparksoniq/spark/udf/LetClauseUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/LetClauseUDF.java
@@ -87,9 +87,10 @@ public class LetClauseUDF implements UDF2<WrappedArray<byte[]>, WrappedArray<Lon
 
         DataFrameUtils.deserializeWrappedParameters(wrappedParameters, _deserializedParams, _kryo, _input);
 
+        // Long parameters correspond to pre-computed counts, when a materialization of the
+        // actual sequence was avoided upfront.
         Object[] longParams = (Object[]) wrappedParametersLong.array();
         for (Object longParam : longParams) {
-            System.out.println("Found " + ((Long) longParam).intValue());
             Item count = ItemFactory.getInstance().createIntegerItem(((Long) longParam).intValue());
             _longParams.add(count);
         }

--- a/src/main/resources/test_files/runtime-spark/DataFrames/GroupbyClause12.jq
+++ b/src/main/resources/test_files/runtime-spark/DataFrames/GroupbyClause12.jq
@@ -1,0 +1,6 @@
+(:JIQS: ShouldRun; Output="(2, 1, 1, 1)" :)
+for $i in json-file("./src/main/resources/queries/conf-ex.json")
+group by $y := $i.country, $t := $i.target
+let $c := count($i)
+order by $c descending
+return $c


### PR DESCRIPTION
@CanBerker this is a bug found in class. It would be nice if we can review/merge today and I will do an interim release also with the bugs solved last week. Thanks!

This partially solves https://github.com/RumbleDB/rumble/issues/410 for the let clause (and potentially group clauses, untested). Other clauses can be fixed later, with all needed tests.

Also, this opens the way to the treatment of FLWOR dataframes with other types than binaries in UDFs. I am afraid we have no choice but to pass an array for each type to the UDFs (and will need to extend this to all types), except if we discover that Spark SQL supports polymorphic UDFs in some way...