### PR TITLE
Fix bug and trigger clear message asking for bug-reports when it's our fault

### DIFF
--- a/src/main/java/org/rumbledb/cli/JsoniqQueryExecutor.java
+++ b/src/main/java/org/rumbledb/cli/JsoniqQueryExecutor.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaRDD;
 import org.rumbledb.api.Item;
 import org.rumbledb.config.SparksoniqRuntimeConfiguration;
+
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.ParsingException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.compiler.JsoniqExpressionTreeVisitor;
@@ -138,7 +140,7 @@ public class JsoniqQueryExecutor {
             // else write from Spark RDD
         } else {
             if (!result.isRDD())
-                throw new SparksoniqRuntimeException("Could not find any RDD iterators in executor");
+                throw new OurBadException("Could not find any RDD iterators in executor");
             JavaRDD<Item> rdd = result.getRDD(new DynamicContext());
             JavaRDD<String> output = rdd.map(o -> o.serialize());
             output.saveAsTextFile(outputPath);
@@ -304,6 +306,6 @@ public class JsoniqQueryExecutor {
 
             return sb.toString();
         }
-        throw new SparksoniqRuntimeException("Unexpected rdd result count in getRDDResults()");
+        throw new OurBadException("Unexpected rdd result count in getRDDResults()");
     }
 }

--- a/src/main/java/org/rumbledb/cli/Main.java
+++ b/src/main/java/org/rumbledb/cli/Main.java
@@ -77,18 +77,18 @@ public class Main {
                 );
             }
         } catch (Exception ex) {
-            handleException(ex, sparksoniqConf.getErrorInfo());
+            handleException(ex, sparksoniqConf.getShowErrorInfo());
         }
     }
 
-    private static void handleException(Throwable ex, boolean errorInfo) {
+    private static void handleException(Throwable ex, boolean showErrorInfo) {
         if (ex != null) {
             if (ex instanceof SparkException) {
                 Throwable sparkExceptionCause = ex.getCause();
-                handleException(sparkExceptionCause, errorInfo);
+                handleException(sparkExceptionCause, showErrorInfo);
             } else if (ex instanceof SparksoniqRuntimeException && !(ex instanceof OurBadException)) {
                 System.err.println("⚠️  ️" + ex.getMessage());
-                if (errorInfo) {
+                if (showErrorInfo) {
                     ex.printStackTrace();
                 }
             } else {
@@ -97,7 +97,7 @@ public class Main {
                     "We should investigate this 🙈. Please contact us or file an issue on GitHub with your query."
                 );
                 System.out.println("Link: https://github.com/RumbleDB/rumble/issues");
-                if (errorInfo) {
+                if (showErrorInfo) {
                     ex.printStackTrace();
                 }
             }

--- a/src/main/java/org/rumbledb/cli/Main.java
+++ b/src/main/java/org/rumbledb/cli/Main.java
@@ -74,17 +74,20 @@ public class Main {
                 );
             }
         } catch (Exception ex) {
-            handleException(ex);
+            handleException(ex, sparksoniqConf.getErrorInfo());
         }
     }
 
-    private static void handleException(Throwable ex) {
+    private static void handleException(Throwable ex, boolean errorInfo) {
         if (ex != null) {
             if (ex instanceof SparkException) {
                 Throwable sparkExceptionCause = ex.getCause();
-                handleException(sparkExceptionCause);;
+                handleException(sparkExceptionCause, errorInfo);
             } else if (ex instanceof SparksoniqRuntimeException) {
                 System.err.println("⚠️  ️" + ex.getMessage());
+                if(errorInfo) {
+                	ex.printStackTrace();
+                }
             } else {
                 System.out.println("An error has occured: " + ex.getMessage());
                 System.out.println(

--- a/src/main/java/org/rumbledb/cli/Main.java
+++ b/src/main/java/org/rumbledb/cli/Main.java
@@ -22,6 +22,9 @@ package org.rumbledb.cli;
 
 import org.apache.spark.SparkException;
 import org.rumbledb.config.SparksoniqRuntimeConfiguration;
+
+import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.io.shell.JiqsJLineShell;
 import sparksoniq.spark.SparkSessionManager;
@@ -83,10 +86,10 @@ public class Main {
             if (ex instanceof SparkException) {
                 Throwable sparkExceptionCause = ex.getCause();
                 handleException(sparkExceptionCause, errorInfo);
-            } else if (ex instanceof SparksoniqRuntimeException) {
+            } else if (ex instanceof SparksoniqRuntimeException && !(ex instanceof OurBadException)) {
                 System.err.println("⚠️  ️" + ex.getMessage());
-                if(errorInfo) {
-                	ex.printStackTrace();
+                if (errorInfo) {
+                    ex.printStackTrace();
                 }
             } else {
                 System.out.println("An error has occured: " + ex.getMessage());
@@ -94,7 +97,9 @@ public class Main {
                     "We should investigate this 🙈. Please contact us or file an issue on GitHub with your query."
                 );
                 System.out.println("Link: https://github.com/RumbleDB/rumble/issues");
-                ex.printStackTrace();
+                if (errorInfo) {
+                    ex.printStackTrace();
+                }
             }
         }
     }

--- a/src/main/java/org/rumbledb/config/SparksoniqRuntimeConfiguration.java
+++ b/src/main/java/org/rumbledb/config/SparksoniqRuntimeConfiguration.java
@@ -62,9 +62,9 @@ public class SparksoniqRuntimeConfiguration {
             return false;
     }
 
-    public boolean getErrorInfo() {
-        if (this._arguments.containsKey("error-info"))
-            return this._arguments.get("error-info").equals("yes");
+    public boolean getShowErrorInfo() {
+        if (this._arguments.containsKey("show-error-info"))
+            return this._arguments.get("show-error-info").equals("yes");
         else
             return false;
     }

--- a/src/main/java/org/rumbledb/config/SparksoniqRuntimeConfiguration.java
+++ b/src/main/java/org/rumbledb/config/SparksoniqRuntimeConfiguration.java
@@ -68,7 +68,7 @@ public class SparksoniqRuntimeConfiguration {
         else
             return false;
     }
-    
+
     public String getLogPath() {
         if (this._arguments.containsKey("log-path"))
             return this._arguments.get("log-path");

--- a/src/main/java/org/rumbledb/config/SparksoniqRuntimeConfiguration.java
+++ b/src/main/java/org/rumbledb/config/SparksoniqRuntimeConfiguration.java
@@ -62,6 +62,13 @@ public class SparksoniqRuntimeConfiguration {
             return false;
     }
 
+    public boolean getErrorInfo() {
+        if (this._arguments.containsKey("error-info"))
+            return this._arguments.get("error-info").equals("yes");
+        else
+            return false;
+    }
+    
     public String getLogPath() {
         if (this._arguments.containsKey("log-path"))
             return this._arguments.get("log-path");

--- a/src/main/java/sparksoniq/exceptions/OurBadException.java
+++ b/src/main/java/sparksoniq/exceptions/OurBadException.java
@@ -20,17 +20,18 @@
 
 package sparksoniq.exceptions;
 
+import sparksoniq.exceptions.codes.ErrorCodes;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 
-public class IteratorFlowException extends OurBadException {
+public class OurBadException extends SparksoniqRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
-    public IteratorFlowException(String message, IteratorMetadata metadata) {
-        super(message, metadata);
+    public OurBadException(String message, IteratorMetadata metadata) {
+        super(message, ErrorCodes.OurBadErrorCode, metadata.getExpressionMetadata());
     }
 
-    public IteratorFlowException(String message) {
-        super(message);
+    public OurBadException(String message) {
+        super(message, ErrorCodes.OurBadErrorCode);
     }
 }

--- a/src/main/java/sparksoniq/exceptions/codes/ErrorCodes.java
+++ b/src/main/java/sparksoniq/exceptions/codes/ErrorCodes.java
@@ -49,6 +49,7 @@ public class ErrorCodes {
     public static final String CliErrorCode = "RBST0001";
     public static final String UnimplementedErrorCode = "RBST0002";
     public static final String JobWithinAJobErrorCode = "RBST0003";
+    public static final String OurBadErrorCode = "RBST0004";
 
 
     public static final String AbsentPartOfDynamicContextCode = "XPDY0002";

--- a/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
+++ b/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
@@ -78,7 +78,7 @@ public class JiqsJLineShell {
                 }
                 previousLine = currentLine;
             } catch (Exception ex) {
-                handleException(ex);
+                handleException(ex, _configuration.getShowErrorInfo());
             }
         }
     }
@@ -94,7 +94,7 @@ public class JiqsJLineShell {
                 output("[EXEC TIME]: " + time);
             removeQueryFile(file);
         } catch (Exception ex) {
-            handleException(ex);
+            handleException(ex, _configuration.getShowErrorInfo());
             removeQueryFile(file);
         }
         queryStarted = false;
@@ -125,22 +125,27 @@ public class JiqsJLineShell {
         jsoniqQueryExecutor = new JsoniqQueryExecutor(false, _configuration);
     }
 
-    private void handleException(Throwable ex) {
+    private void handleException(Throwable ex, boolean showErrorInfo) {
         if (ex != null) {
             if (ex instanceof EndOfFileException) {
                 this.currentLine = JiqsJLineShell.EXIT_COMMAND;
             } else if (ex instanceof SparkException) {
                 Throwable sparkExceptionCause = ex.getCause();
-                handleException(sparkExceptionCause);;
+                handleException(sparkExceptionCause, showErrorInfo);;
             } else if (ex instanceof SparksoniqRuntimeException) {
-                System.err.println(ex.getMessage());
+                System.err.println("⚠️  ️" + ex.getMessage());
+                if (showErrorInfo) {
+                    ex.printStackTrace();
+                }
             } else if (!(ex instanceof UserInterruptException)) {
                 System.out.println("An error has occured: " + ex.getMessage());
                 System.out.println(
                     "We should investigate this 🙈. Please contact us or file an issue on GitHub with your query."
                 );
                 System.out.println("Link: https://github.com/RumbleDB/rumble/issues");
-                ex.printStackTrace();
+                if (showErrorInfo) {
+                    ex.printStackTrace();
+                }
             }
         }
     }

--- a/src/main/java/sparksoniq/jsoniq/item/FunctionItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/FunctionItem.java
@@ -25,6 +25,7 @@ import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.rumbledb.api.Item;
 import sparksoniq.exceptions.FunctionsNonSerializableException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.FunctionIdentifier;
@@ -166,7 +167,7 @@ public class FunctionItem extends Item {
             output.writeInt(data.length);
             output.writeBytes(data);
         } catch (Exception e) {
-            throw new SparksoniqRuntimeException(
+            throw new OurBadException(
                     "Error converting functionItem-bodyRuntimeIterator to byte[]:" + e.getMessage()
             );
         }
@@ -190,7 +191,7 @@ public class FunctionItem extends Item {
             ObjectInputStream ois = new ObjectInputStream(bis);
             this.bodyIterator = (RuntimeIterator) ois.readObject();
         } catch (Exception e) {
-            throw new SparksoniqRuntimeException(
+            throw new OurBadException(
                     "Error converting functionItem-bodyRuntimeIterator to functionItem:" + e.getMessage()
             );
         }

--- a/src/main/java/sparksoniq/jsoniq/item/ItemComparatorForSequences.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ItemComparatorForSequences.java
@@ -21,6 +21,8 @@
 package sparksoniq.jsoniq.item;
 
 import org.rumbledb.api.Item;
+
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 
 import java.io.Serializable;
@@ -53,7 +55,7 @@ public class ItemComparatorForSequences implements Comparator<Item>, Serializabl
             String value2 = v2.getStringValue();
             result = value1.compareTo(value2);
         } else {
-            throw new SparksoniqRuntimeException(v1.serialize() + " " + v2.serialize());
+            throw new OurBadException(v1.serialize() + " " + v2.serialize());
         }
         return result;
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -30,6 +30,7 @@ import org.apache.spark.sql.Row;
 import org.rumbledb.api.Item;
 import sparksoniq.exceptions.InvalidArgumentTypeException;
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
@@ -91,7 +92,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
                     else if (item.isDecimal())
                         result = !item.getDecimalValue().equals(BigDecimal.ZERO);
                     else {
-                        throw new SparksoniqRuntimeException(
+                        throw new OurBadException(
                                 "Unexpected numeric type found while calculating effective boolean value."
                         );
                     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
@@ -21,6 +21,7 @@
 package sparksoniq.jsoniq.runtime.iterator.functions.base;
 
 import sparksoniq.exceptions.DuplicateFunctionIdentifierException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.exceptions.UnknownFunctionCallException;
 import sparksoniq.jsoniq.compiler.translator.metadata.ExpressionMetadata;
@@ -707,7 +708,7 @@ public class Functions {
             ObjectInputStream ois = new ObjectInputStream(bis);
             return (FunctionItem) ois.readObject();
         } catch (IOException | ClassNotFoundException e) {
-            throw new SparksoniqRuntimeException("Error while deep copying the function body runtimeIterator");
+            throw new OurBadException("Error while deep copying the function body runtimeIterator");
         }
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/CountFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/CountFunctionIterator.java
@@ -22,6 +22,7 @@ package sparksoniq.jsoniq.runtime.iterator.functions.sequences.aggregate;
 
 import org.rumbledb.api.Item;
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.ItemFactory;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -73,7 +74,7 @@ public class CountFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             if (count > (long) Integer.MAX_VALUE) {
                 // TODO: handle too big x values
-                throw new SparksoniqRuntimeException("The count value is too big to convert to integer type.");
+                throw new OurBadException("The count value is too big to convert to integer type.");
             } else {
                 return ItemFactory.getInstance().createIntegerItem((int) count);
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -181,7 +181,7 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
                     _nextResult = _sequenceIterator.next();
                 } else {
                     throw new OurBadException(
-                            "Unexpected length value found. Please report the bug with subsequence function iterator."
+                            "Unexpected length value found."
                     );
                 }
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -23,6 +23,7 @@ package sparksoniq.jsoniq.runtime.iterator.functions.sequences.general;
 import org.rumbledb.api.Item;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.NonAtomicKeyException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.ObjectItem;
@@ -179,7 +180,7 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
                 } else if (_length == -1) { // _length not specified -> take all items until the end
                     _nextResult = _sequenceIterator.next();
                 } else {
-                    throw new SparksoniqRuntimeException(
+                    throw new OurBadException(
                             "Unexpected length value found. Please report the bug with subsequence function iterator."
                     );
                 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
@@ -26,6 +26,7 @@ import org.apache.spark.api.java.function.Function;
 import org.rumbledb.api.Item;
 import scala.Tuple2;
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.IntegerItem;
 import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
@@ -104,7 +105,7 @@ public class PredicateIterator extends HybridRuntimeIterator {
     @Override
     protected void openLocal() {
         if (this._children.size() < 2) {
-            throw new SparksoniqRuntimeException("Invalid Predicate! Must initialize filter before calling next");
+            throw new OurBadException("Invalid Predicate! Must initialize filter before calling next");
         }
         _filterDynamicContext = new DynamicContext(_currentDynamicContext);
         if (_filter.getVariableDependencies().containsKey("$last")) {

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
@@ -25,6 +25,8 @@ import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.rumbledb.api.Item;
+
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.semantics.types.ItemTypes;
 
@@ -69,7 +71,7 @@ public class FlworKey implements KryoSerializable {
      */
     public int compareWithFlworKey(FlworKey flworKey) {
         if (this.keyItems.size() != flworKey.keyItems.size()) {
-            throw new SparksoniqRuntimeException("Invalid sort key: Key sizes can't be different.");
+            throw new OurBadException("Invalid sort key: Key sizes can't be different.");
         }
 
         int result = 0;

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
@@ -28,6 +28,8 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.rumbledb.api.Item;
+
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.io.json.RowToItemMapper;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -96,7 +98,7 @@ public class FlworTuple implements Serializable, KryoSerializable {
 
     public boolean isRDD(String key, IteratorMetadata metadata) {
         if (!contains(key)) {
-            throw new SparksoniqRuntimeException("Undeclared FLWOR variable", metadata.getExpressionMetadata());
+            throw new OurBadException("Undeclared FLWOR variable", metadata);
         }
         return rddVariables.containsKey(key)
             || dfVariables.containsKey(key);
@@ -104,7 +106,7 @@ public class FlworTuple implements Serializable, KryoSerializable {
 
     public boolean isDF(String key, IteratorMetadata metadata) {
         if (!contains(key)) {
-            throw new SparksoniqRuntimeException("Undeclared FLWOR variable", metadata.getExpressionMetadata());
+            throw new OurBadException("Undeclared FLWOR variable", metadata);
         }
         return dfVariables.containsKey(key);
     }
@@ -118,7 +120,7 @@ public class FlworTuple implements Serializable, KryoSerializable {
             return SparkSessionManager.collectRDDwithLimit(rdd);
         }
 
-        throw new SparksoniqRuntimeException("Undeclared FLOWR variable", metadata.getExpressionMetadata());
+        throw new OurBadException("Undeclared FLOWR variable", metadata);
     }
 
     public JavaRDD<Item> getRDDValue(String key, IteratorMetadata metadata) {
@@ -130,14 +132,14 @@ public class FlworTuple implements Serializable, KryoSerializable {
             JavaRDD<Row> rowRDD = df.javaRDD();
             return rowRDD.map(new RowToItemMapper(metadata));
         }
-        throw new SparksoniqRuntimeException("Undeclared FLOWR variable", metadata.getExpressionMetadata());
+        throw new OurBadException("Undeclared FLOWR variable", metadata);
     }
 
     public Dataset<Row> getDFValue(String key, IteratorMetadata metadata) {
         if (dfVariables.containsKey(key)) {
             return dfVariables.get(key);
         }
-        throw new SparksoniqRuntimeException("Undeclared FLOWR variable", metadata.getExpressionMetadata());
+        throw new OurBadException("Undeclared FLOWR variable", metadata);
     }
 
     public void putValue(String key, Item value) {

--- a/src/main/java/sparksoniq/semantics/DynamicContext.java
+++ b/src/main/java/sparksoniq/semantics/DynamicContext.java
@@ -28,6 +28,8 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.rumbledb.api.Item;
+
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.io.json.RowToItemMapper;
 import sparksoniq.jsoniq.item.ItemFactory;
@@ -100,9 +102,9 @@ public class DynamicContext implements Serializable, KryoSerializable {
 
     public boolean isRDD(String varName, IteratorMetadata metadata) {
         if (!contains(varName)) {
-            throw new SparksoniqRuntimeException(
+            throw new OurBadException(
                     "Runtime error retrieving variable " + varName + " value.",
-                    metadata.getExpressionMetadata()
+                    metadata
             );
         }
         return _rddVariableValues.containsKey(varName)
@@ -111,9 +113,9 @@ public class DynamicContext implements Serializable, KryoSerializable {
 
     public boolean isDF(String varName, IteratorMetadata metadata) {
         if (!contains(varName)) {
-            throw new SparksoniqRuntimeException(
+            throw new OurBadException(
                     "Runtime error retrieving variable " + varName + " value.",
-                    metadata.getExpressionMetadata()
+                    metadata
             );
         }
         return _dfVariableValues.containsKey(varName);
@@ -150,9 +152,9 @@ public class DynamicContext implements Serializable, KryoSerializable {
         }
 
         if (_localVariableCounts.containsKey(varName)) {
-            throw new SparksoniqRuntimeException(
+            throw new OurBadException(
                     "Runtime error retrieving variable " + varName + " value: only count available.",
-                    metadata.getExpressionMetadata()
+                    metadata
             );
         }
 
@@ -177,9 +179,9 @@ public class DynamicContext implements Serializable, KryoSerializable {
             return _parent.getRDDVariableValue(varName, metadata);
         }
 
-        throw new SparksoniqRuntimeException(
+        throw new OurBadException(
                 "Runtime error retrieving variable " + varName + " value",
-                metadata.getExpressionMetadata()
+                metadata
         );
     }
 
@@ -192,9 +194,9 @@ public class DynamicContext implements Serializable, KryoSerializable {
             return _parent.getDFVariableValue(varName, metadata);
         }
 
-        throw new SparksoniqRuntimeException(
+        throw new OurBadException(
                 "Runtime error retrieving variable " + varName + " value",
-                metadata.getExpressionMetadata()
+                metadata
         );
     }
 
@@ -214,7 +216,7 @@ public class DynamicContext implements Serializable, KryoSerializable {
         if (_parent != null) {
             return _parent.getVariableCount(varName);
         }
-        throw new SparksoniqRuntimeException("Runtime error retrieving variable " + varName + " value");
+        throw new OurBadException("Runtime error retrieving variable " + varName + " value");
     }
 
     public void removeVariable(String varName) {

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -475,7 +475,10 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
     public RuntimeIterator visitNamedFunctionRef(NamedFunctionRef expression, RuntimeIterator argument) {
         FunctionIdentifier identifier = expression.getIdentifier();
         if (Functions.checkBuiltInFunctionExists(identifier)) {
-            throw new UnsupportedFeatureException("Higher order functions using builtin functions are not supported.", expression.getMetadata());
+            throw new UnsupportedFeatureException(
+                    "Higher order functions using builtin functions are not supported.",
+                    expression.getMetadata()
+            );
         }
         if (Functions.checkUserDefinedFunctionExists(identifier)) {
             FunctionItem function = Functions.getUserDefinedFunction(identifier);

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -475,7 +475,7 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
     public RuntimeIterator visitNamedFunctionRef(NamedFunctionRef expression, RuntimeIterator argument) {
         FunctionIdentifier identifier = expression.getIdentifier();
         if (Functions.checkBuiltInFunctionExists(identifier)) {
-            throw new SparksoniqRuntimeException("Higher order functions using builtin functions are not supported.");
+            throw new UnsupportedFeatureException("Higher order functions using builtin functions are not supported.", expression.getMetadata());
         }
         if (Functions.checkUserDefinedFunctionExists(identifier)) {
             FunctionItem function = Functions.getUserDefinedFunction(identifier);

--- a/src/main/java/sparksoniq/spark/SparkSessionManager.java
+++ b/src/main/java/sparksoniq/spark/SparkSessionManager.java
@@ -28,6 +28,8 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
 import org.rumbledb.api.Item;
 import org.rumbledb.cli.Main;
+
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.item.BooleanItem;
@@ -94,7 +96,7 @@ public class SparkSessionManager {
 
             session = SparkSession.builder().config(this.configuration).getOrCreate();
         } else {
-            throw new SparksoniqRuntimeException("Session already exists: new session initialization prevented.");
+            throw new OurBadException("Session already exists: new session initialization prevented.");
         }
     }
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
@@ -26,6 +26,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.rumbledb.api.Item;
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.ItemFactory;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -75,7 +76,7 @@ public class CountClauseSparkIterator extends RuntimeTupleIterator {
 
             setNextLocalTupleResult();
         } else {
-            throw new SparksoniqRuntimeException("Invalid count clause.");
+            throw new OurBadException("Invalid count clause.");
         }
     }
 
@@ -116,7 +117,7 @@ public class CountClauseSparkIterator extends RuntimeTupleIterator {
             Map<String, DynamicContext.VariableDependency> parentProjection
     ) {
         if (this._child == null) {
-            throw new SparksoniqRuntimeException("Invalid count clause.");
+            throw new OurBadException("Invalid count clause.");
         }
         Dataset<Row> df = _child.getDataFrame(context, getProjection(parentProjection));
         StructType inputSchema = df.schema();

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -162,6 +162,7 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
         if (_child != null) {
             this._child.close();
         }
+        _expression.close();
     }
 
     @Override

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -31,6 +31,7 @@ import sparksoniq.exceptions.InvalidGroupVariableException;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.JobWithinAJobException;
 import sparksoniq.exceptions.NonAtomicKeyException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.primary.VariableReferenceIterator;
@@ -92,7 +93,7 @@ public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
             _child.open(_currentDynamicContext);
             this._hasNext = _child.hasNext();
         } else {
-            throw new SparksoniqRuntimeException("Invalid groupby clause.");
+            throw new OurBadException("Invalid groupby clause.");
         }
     }
 
@@ -222,7 +223,7 @@ public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
             Map<String, DynamicContext.VariableDependency> parentProjection
     ) {
         if (this._child == null) {
-            throw new SparksoniqRuntimeException("Invalid groupby clause.");
+            throw new OurBadException("Invalid groupby clause.");
         }
 
         for (GroupByClauseSparkIteratorExpression expression : _expressions) {

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -30,6 +30,7 @@ import org.rumbledb.api.Item;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.JobWithinAJobException;
 import sparksoniq.exceptions.NonAtomicKeyException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -91,7 +92,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
 
             this._hasNext = _child.hasNext();
         } else {
-            throw new SparksoniqRuntimeException("Invalid where clause.");
+            throw new OurBadException("Invalid where clause.");
         }
     }
 
@@ -199,7 +200,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             Map<String, DynamicContext.VariableDependency> parentProjection
     ) {
         if (this._child == null) {
-            throw new SparksoniqRuntimeException("Invalid orderby clause.");
+            throw new OurBadException("Invalid orderby clause.");
         }
 
         for (OrderByClauseSparkIteratorExpression expression : _expressions) {

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -26,6 +26,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.JobWithinAJobException;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -75,7 +76,7 @@ public class WhereClauseSparkIterator extends RuntimeTupleIterator {
             setNextLocalTupleResult();
 
         } else {
-            throw new SparksoniqRuntimeException("Invalid where clause.");
+            throw new OurBadException("Invalid where clause.");
         }
     }
 
@@ -121,7 +122,7 @@ public class WhereClauseSparkIterator extends RuntimeTupleIterator {
             Map<String, DynamicContext.VariableDependency> parentProjection
     ) {
         if (this._child == null) {
-            throw new SparksoniqRuntimeException("Invalid where clause.");
+            throw new OurBadException("Invalid where clause.");
         }
 
         if (_expression.isRDD()) {

--- a/src/main/java/sparksoniq/spark/iterator/function/ParallelizeFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/function/ParallelizeFunctionIterator.java
@@ -73,7 +73,7 @@ public class ParallelizeFunctionIterator extends RDDRuntimeIterator {
                     .parallelize(contents, partitions.getIntegerValue());
             } catch (Exception e) {
                 if (!partitionsIterator.hasNext())
-                    throw new SparksoniqRuntimeException("The second parameter of parallelize must be an integer.");
+                    throw new UnexpectedTypeException("The second parameter of parallelize must be an integer.", getMetadata());
             }
             partitionsIterator.close();
         }

--- a/src/main/java/sparksoniq/spark/iterator/function/ParallelizeFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/function/ParallelizeFunctionIterator.java
@@ -73,7 +73,10 @@ public class ParallelizeFunctionIterator extends RDDRuntimeIterator {
                     .parallelize(contents, partitions.getIntegerValue());
             } catch (Exception e) {
                 if (!partitionsIterator.hasNext())
-                    throw new UnexpectedTypeException("The second parameter of parallelize must be an integer.", getMetadata());
+                    throw new UnexpectedTypeException(
+                            "The second parameter of parallelize must be an integer.",
+                            getMetadata()
+                    );
             }
             partitionsIterator.close();
         }

--- a/src/main/java/sparksoniq/spark/udf/OrderClauseCreateColumnsUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/OrderClauseCreateColumnsUDF.java
@@ -28,6 +28,7 @@ import org.apache.spark.sql.api.java.UDF2;
 import org.joda.time.Instant;
 import org.rumbledb.api.Item;
 import scala.collection.mutable.WrappedArray;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.compiler.translator.expr.flowr.OrderByClauseExpr;
 import sparksoniq.jsoniq.item.ItemFactory;
@@ -168,12 +169,12 @@ public class OrderClauseCreateColumnsUDF implements UDF2<WrappedArray<byte[]>, W
                                 _results.add(nextItem.getDateTimeValue().getMillis());
                                 break;
                             default:
-                                throw new SparksoniqRuntimeException(
+                                throw new OurBadException(
                                         "Unexpected ordering type found while creating columns."
                                 );
                         }
                     } catch (RuntimeException e) {
-                        throw new SparksoniqRuntimeException(
+                        throw new OurBadException(
                                 "Invalid sort key: cannot compare item of type "
                                     + typeName
                                     + " with item of type "

--- a/src/main/java/sparksoniq/spark/udf/OrderClauseDetermineTypeUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/OrderClauseDetermineTypeUDF.java
@@ -25,6 +25,7 @@ import com.esotericsoftware.kryo.io.Input;
 import org.apache.spark.sql.api.java.UDF2;
 import org.rumbledb.api.Item;
 import scala.collection.mutable.WrappedArray;
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.ItemFactory;
@@ -159,7 +160,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
                         expression.getIteratorMetadata()
                 );
             } else {
-                throw new SparksoniqRuntimeException("Unexpected type found.");
+                throw new OurBadException("Unexpected type found.");
             }
         }
         return result;

--- a/src/main/resources/test_files/runtime-spark/DataFrames/GroupbyClauseDurations.jq
+++ b/src/main/resources/test_files/runtime-spark/DataFrames/GroupbyClauseDurations.jq
@@ -1,4 +1,5 @@
-(:JIQS: ShouldRun; Output="(PT4H6M5.500S, P7DT5H18M13.300S, P2Y6M5DT12H35M30S, -P2Y3M, P12Y, PT0S)" :)
+(:JIQS: ShouldRun; Output="(-P2Y3M, P12Y, P2Y6M5DT12H35M30S, P7DT5H18M13.300S, PT0S, PT4H6M5.500S)" :)
 for $j as duration in parallelize((dayTimeDuration("P3DT99H66M4333.3S"), dayTimeDuration("P0DT0M"), dayTimeDuration("PT4H6M5.5S"), yearMonthDuration("-P2Y3M"), yearMonthDuration("P0Y0M"), yearMonthDuration(()), duration("P12Y"),duration("P144M"), duration("P2Y6M5DT12H35M30S")))
 group by $j
+order by string($j)
 return $j

--- a/src/main/resources/test_files/runtime-spark/LocalClauses/GroupbyClauseDurations.jq
+++ b/src/main/resources/test_files/runtime-spark/LocalClauses/GroupbyClauseDurations.jq
@@ -1,4 +1,5 @@
-(:JIQS: ShouldRun; Output="(PT0S, -P2Y3M, PT4H6M5.500S, P7DT5H18M13.300S, P2Y6M5DT12H35M30S, P12Y)" :)
+(:JIQS: ShouldRun; Output="(-P2Y3M, P12Y, P2Y6M5DT12H35M30S, P7DT5H18M13.300S, PT0S, PT4H6M5.500S)" :)
 for $j as duration in (dayTimeDuration("P3DT99H66M4333.3S"), dayTimeDuration("P0DT0M"), dayTimeDuration("PT4H6M5.5S"), yearMonthDuration("-P2Y3M"), yearMonthDuration("P0Y0M"), yearMonthDuration(()), duration("P12Y"),duration("P144M"), duration("P2Y6M5DT12H35M30S"))
 group by $j
+order by string($j)
 return $j

--- a/src/main/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error2.jq
+++ b/src/main/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error2.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="XPDY0130"; :)
+(:JIQS: ShouldCrash; ErrorCode="RBST0002"; :)
 max#1
 
 (: referencing built-in functions - not supported :)

--- a/src/main/resources/test_files/runtime/NestedFLWORLocal5.jq
+++ b/src/main/resources/test_files/runtime/NestedFLWORLocal5.jq
@@ -1,0 +1,2 @@
+(:JIQS: ShouldRun; Output="2" :)
+let $i := [1, 1] return sum(for $c in $i[] return 1)

--- a/src/test/java/iq/RuntimeTests.java
+++ b/src/test/java/iq/RuntimeTests.java
@@ -29,7 +29,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.rumbledb.api.Item;
-import sparksoniq.exceptions.SparksoniqRuntimeException;
+
+import sparksoniq.exceptions.OurBadException;
 import sparksoniq.jsoniq.compiler.JsoniqExpressionTreeVisitor;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.semantics.DynamicContext;
@@ -173,6 +174,6 @@ public class RuntimeTests extends AnnotationsTestsBase {
             sb.append(")");
             return sb.toString();
         }
-        throw new SparksoniqRuntimeException("Unexpected rdd result count in getRDDResults()");
+        throw new OurBadException("Unexpected rdd result count in getRDDResults()");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/RumbleDB/rumble/issues/418

Also:
- adds undocumented parameter --error-info to display stack trace when other issues like this happen in the future.
- adds OurBadException to clearly distinguish those cases that are our fault and must trigger a clear message asking for a bug report. Many runtime exceptions were incorrectly displaying an error message as if it were the user's fault (with a clean dynamic error code).
