### PR TITLE
Fix bug.

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -235,7 +235,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
         Map<String, DynamicContext.VariableDependency> result =
             new TreeMap<>();
         for (RuntimeIterator iterator : _children) {
-            result.putAll(iterator.getVariableDependencies());
+            DynamicContext.mergeVariableDependencies(result, iterator.getVariableDependencies());
         }
         return result;
     }

--- a/src/main/java/sparksoniq/semantics/DynamicContext.java
+++ b/src/main/java/sparksoniq/semantics/DynamicContext.java
@@ -304,5 +304,27 @@ public class DynamicContext implements Serializable, KryoSerializable {
         MAX,
         MIN
     }
+
+    private static VariableDependency mergeSingleVariableDependency(VariableDependency left, VariableDependency right) {
+        if (left.equals(right)) {
+            return left;
+        }
+        return VariableDependency.FULL;
+    }
+
+    public static void mergeVariableDependencies(
+            Map<String, DynamicContext.VariableDependency> into,
+            Map<String, DynamicContext.VariableDependency> from
+    ) {
+        for (String v : from.keySet()) {
+            if (into.containsKey(v)) {
+                into.put(v, DynamicContext.mergeSingleVariableDependency(into.get(v), from.get(v)));
+            } else {
+                into.put(v, from.get(v));
+            }
+        }
+    }
+
+
 }
 

--- a/src/main/resources/test_files/runtime-spark/DataFrames/GroupbyClause18.jq
+++ b/src/main/resources/test_files/runtime-spark/DataFrames/GroupbyClause18.jq
@@ -1,0 +1,2 @@
+(:JIQS: ShouldRun; Output="1" :)
+for $game in parallelize(1) group by $c := 0 return count($game[1]) div count($game)


### PR DESCRIPTION
The automatic detection of count optimization did not work quite well on iterators with more than one child: the last child "overrode" the previous ones, leading to an issue.

Now, dependencies are correctly merged: COUNT+FULL = FULL, COUNT+COUNT=COUNT, FULL+FULL=FULL.