### PR TITLE
12-2-Add static type checking for typeswitch default case

### DIFF
--- a/src/main/resources/test_files/runtime/ControlIterators/TypeswitchExpressionError2.jq
+++ b/src/main/resources/test_files/runtime/ControlIterators/TypeswitchExpressionError2.jq
@@ -1,0 +1,8 @@
+(:JIQS: ShouldNotCompile; ErrorCode="XPST0008"; ErrorMetadata="LINE:6:COLUMN:20:" :)
+typeswitch(base64Binary("AaBb"))
+case $a as hexBinary+ return "not this"
+case $b as boolean | double+ return ($b cast as string) || " not even this"
+case $a as string? | decimal return $a
+default $def return $asd
+
+(: Uninitialized variable reference in default expression :)


### PR DESCRIPTION
This is based on #440 
Original implementation did not perform static checks on the condition and default case of the typeswitch expression. I have added these in this PR.