### PR TITLE
Improve naming of orderbyClauseSparkIteratorExpression and its usage

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKeyComparator.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKeyComparator.java
@@ -21,7 +21,7 @@
 package sparksoniq.jsoniq.tuple;
 
 import sparksoniq.jsoniq.compiler.translator.expr.flowr.OrderByClauseExpr;
-import sparksoniq.spark.iterator.flowr.expression.OrderByClauseSparkIteratorExpression;
+import sparksoniq.spark.iterator.flowr.expression.OrderByClauseExprWithIterator;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -31,9 +31,9 @@ public class FlworKeyComparator implements Comparator<FlworKey>, Serializable {
 
     private static final long serialVersionUID = 1L;
     // private final boolean _isStable;
-    private final List<OrderByClauseSparkIteratorExpression> _expressions;
+    private final List<OrderByClauseExprWithIterator> _expressions;
 
-    public FlworKeyComparator(List<OrderByClauseSparkIteratorExpression> expressions, boolean isStable) {
+    public FlworKeyComparator(List<OrderByClauseExprWithIterator> expressions, boolean isStable) {
         // this._isStable = isStable;
         this._expressions = expressions;
     }

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKeyComparator.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKeyComparator.java
@@ -21,7 +21,7 @@
 package sparksoniq.jsoniq.tuple;
 
 import sparksoniq.jsoniq.compiler.translator.expr.flowr.OrderByClauseExpr;
-import sparksoniq.spark.iterator.flowr.expression.OrderByClauseExprWithIterator;
+import sparksoniq.spark.iterator.flowr.expression.OrderByClauseAnnotatedChildIterator;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -31,9 +31,9 @@ public class FlworKeyComparator implements Comparator<FlworKey>, Serializable {
 
     private static final long serialVersionUID = 1L;
     // private final boolean _isStable;
-    private final List<OrderByClauseExprWithIterator> _expressions;
+    private final List<OrderByClauseAnnotatedChildIterator> _expressions;
 
-    public FlworKeyComparator(List<OrderByClauseExprWithIterator> expressions, boolean isStable) {
+    public FlworKeyComparator(List<OrderByClauseAnnotatedChildIterator> expressions, boolean isStable) {
         // this._isStable = isStable;
         this._expressions = expressions;
     }

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -285,8 +285,7 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
                             this.visit(orderExpr.getExpression(), argument),
                             orderExpr.isAscending(),
                             orderExpr.getUri(),
-                            orderExpr.getEmptyOrder(),
-                            createIteratorMetadata(orderExpr)
+                            orderExpr.getEmptyOrder()
                     )
                 );
             }

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -136,7 +136,7 @@ import sparksoniq.spark.iterator.flowr.OrderByClauseSparkIterator;
 import sparksoniq.spark.iterator.flowr.ReturnClauseSparkIterator;
 import sparksoniq.spark.iterator.flowr.WhereClauseSparkIterator;
 import sparksoniq.spark.iterator.flowr.expression.GroupByClauseSparkIteratorExpression;
-import sparksoniq.spark.iterator.flowr.expression.OrderByClauseSparkIteratorExpression;
+import sparksoniq.spark.iterator.flowr.expression.OrderByClauseExprWithIterator;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -278,10 +278,10 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
                     createIteratorMetadata(clause)
             );
         } else if (clause instanceof OrderByClause) {
-            List<OrderByClauseSparkIteratorExpression> expressions = new ArrayList<>();
+            List<OrderByClauseExprWithIterator> expressionsWithIterator = new ArrayList<>();
             for (OrderByClauseExpr orderExpr : ((OrderByClause) clause).getExpressions()) {
-                expressions.add(
-                    new OrderByClauseSparkIteratorExpression(
+                expressionsWithIterator.add(
+                    new OrderByClauseExprWithIterator(
                             this.visit(orderExpr.getExpression(), argument),
                             orderExpr.isAscending(),
                             orderExpr.getUri(),
@@ -292,7 +292,7 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
             }
             previousIterator = new OrderByClauseSparkIterator(
                     previousIterator,
-                    expressions,
+                    expressionsWithIterator,
                     ((OrderByClause) clause).isStable(),
                     createIteratorMetadata(clause)
             );

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -136,7 +136,7 @@ import sparksoniq.spark.iterator.flowr.OrderByClauseSparkIterator;
 import sparksoniq.spark.iterator.flowr.ReturnClauseSparkIterator;
 import sparksoniq.spark.iterator.flowr.WhereClauseSparkIterator;
 import sparksoniq.spark.iterator.flowr.expression.GroupByClauseSparkIteratorExpression;
-import sparksoniq.spark.iterator.flowr.expression.OrderByClauseExprWithIterator;
+import sparksoniq.spark.iterator.flowr.expression.OrderByClauseAnnotatedChildIterator;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -278,10 +278,10 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
                     createIteratorMetadata(clause)
             );
         } else if (clause instanceof OrderByClause) {
-            List<OrderByClauseExprWithIterator> expressionsWithIterator = new ArrayList<>();
+            List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator = new ArrayList<>();
             for (OrderByClauseExpr orderExpr : ((OrderByClause) clause).getExpressions()) {
                 expressionsWithIterator.add(
-                    new OrderByClauseExprWithIterator(
+                    new OrderByClauseAnnotatedChildIterator(
                             this.visit(orderExpr.getExpression(), argument),
                             orderExpr.isAscending(),
                             orderExpr.getUri(),

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -159,7 +159,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
                         if (!resultItem.isAtomic()) {
                             throw new NonAtomicKeyException(
                                     "Order by keys must be atomics",
-                                    expressionWithIterator.getIteratorMetadata().getExpressionMetadata()
+                                    expressionWithIterator.getIterator().getMetadata().getExpressionMetadata()
                             );
                         }
                         if (resultItem.isBinary()) {

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -42,7 +42,7 @@ import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.semantics.types.ItemTypes;
 import sparksoniq.spark.DataFrameUtils;
-import sparksoniq.spark.iterator.flowr.expression.OrderByClauseSparkIteratorExpression;
+import sparksoniq.spark.iterator.flowr.expression.OrderByClauseExprWithIterator;
 import sparksoniq.spark.udf.OrderClauseCreateColumnsUDF;
 import sparksoniq.spark.udf.OrderClauseDetermineTypeUDF;
 
@@ -58,7 +58,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
 
     private static final long serialVersionUID = 1L;
     private final boolean _isStable;
-    private final List<OrderByClauseSparkIteratorExpression> _expressions;
+    private final List<OrderByClauseExprWithIterator> _expressionsWithIterator;
     private Map<String, DynamicContext.VariableDependency> _dependencies;
 
     private List<FlworTuple> _localTupleResults;
@@ -66,16 +66,16 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
 
     public OrderByClauseSparkIterator(
             RuntimeTupleIterator child,
-            List<OrderByClauseSparkIteratorExpression> expressions,
+            List<OrderByClauseExprWithIterator> expressionsWithIterator,
             boolean stable,
             IteratorMetadata iteratorMetadata
     ) {
         super(child, iteratorMetadata);
-        this._expressions = expressions;
+        this._expressionsWithIterator = expressionsWithIterator;
         this._isStable = stable;
         _dependencies = new TreeMap<>();
-        for (OrderByClauseSparkIteratorExpression e : _expressions) {
-            _dependencies.putAll(e.getExpression().getVariableDependencies());
+        for (OrderByClauseExprWithIterator e : _expressionsWithIterator) {
+            _dependencies.putAll(e.getIterator().getVariableDependencies());
         }
     }
 
@@ -137,7 +137,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
         // OrderByClauseSortClosure implements a comparator and provides the exact desired behavior for local execution
         // as well
         TreeMap<FlworKey, List<FlworTuple>> keyValuePairs = new TreeMap<>(
-                new FlworKeyComparator(_expressions, true)
+                new FlworKeyComparator(_expressionsWithIterator, true)
         );
 
         // assign current context as parent. re-use the same context object for efficiency
@@ -146,20 +146,20 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             FlworTuple inputTuple = _child.next();
 
             List<Item> results = new ArrayList<>(); // results from the expressions will become a key
-            for (OrderByClauseSparkIteratorExpression orderByExpression : _expressions) {
+            for (OrderByClauseExprWithIterator expressionWithIterator : _expressionsWithIterator) {
                 tupleContext.removeAllVariables(); // clear the previous variables
                 tupleContext.setBindingsFromTuple(inputTuple, getMetadata()); // assign new variables from new tuple
 
                 boolean isFieldEmpty = true;
-                RuntimeIterator expression = orderByExpression.getExpression();
-                expression.open(tupleContext);
-                while (expression.hasNext()) {
-                    Item resultItem = expression.next();
+                RuntimeIterator iterator = expressionWithIterator.getIterator();
+                iterator.open(tupleContext);
+                while (iterator.hasNext()) {
+                    Item resultItem = iterator.next();
                     if (resultItem != null) {
                         if (!resultItem.isAtomic()) {
                             throw new NonAtomicKeyException(
                                     "Order by keys must be atomics",
-                                    orderByExpression.getIteratorMetadata().getExpressionMetadata()
+                                    expressionWithIterator.getIteratorMetadata().getExpressionMetadata()
                             );
                         }
                         if (resultItem.isBinary()) {
@@ -181,7 +181,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
                 if (isFieldEmpty) {
                     results.add(null);
                 }
-                expression.close();
+                iterator.close();
             }
             FlworKey key = new FlworKey(results);
             List<FlworTuple> values = keyValuePairs.get(key); // all values for a single matching key are held in a list
@@ -203,8 +203,8 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             throw new OurBadException("Invalid orderby clause.");
         }
 
-        for (OrderByClauseSparkIteratorExpression expression : _expressions) {
-            if (expression.getExpression().isRDD()) {
+        for (OrderByClauseExprWithIterator expressionWithIterator : _expressionsWithIterator) {
+            if (expressionWithIterator.getIterator().isRDD()) {
                 throw new JobWithinAJobException(
                         "An order by clause expression cannot produce a big sequence of items for a big number of tuples, as this would lead to a data flow explosion.",
                         getMetadata().getExpressionMetadata()
@@ -229,7 +229,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             .udf()
             .register(
                 "determineOrderingDataType",
-                new OrderClauseDetermineTypeUDF(_expressions, context, UDFcolumnsByType),
+                new OrderClauseDetermineTypeUDF(_expressionsWithIterator, context, UDFcolumnsByType),
                 DataTypes.createArrayType(DataTypes.StringType)
             );
 
@@ -342,7 +342,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             }
             typedFields.add(DataTypes.createStructField(columnName, columnType, true));
 
-            OrderByClauseSparkIteratorExpression expression = _expressions.get(columnIndex);
+            OrderByClauseExprWithIterator expressionWithIterator = _expressionsWithIterator.get(columnIndex);
             // accessing the created ordering row as "`ordering_columns`.`0-nullEmptyCheckField` (desc)"
             // prepare sql for expression's 1st column
             orderingSQL.append("`");
@@ -350,7 +350,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             orderingSQL.append("`.`");
             orderingSQL.append(columnIndex);
             orderingSQL.append("-nullEmptyCheckField`");
-            if (expression.isAscending()) {
+            if (expressionWithIterator.isAscending()) {
                 orderingSQL.append(", ");
             } else {
                 orderingSQL.append(" desc, ");
@@ -363,13 +363,13 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             orderingSQL.append(columnIndex);
             orderingSQL.append("-valueField`");
             if (columnIndex != typesForAllColumns.size() - 1) {
-                if (expression.isAscending()) {
+                if (expressionWithIterator.isAscending()) {
                     orderingSQL.append(", ");
                 } else {
                     orderingSQL.append(" desc, ");
                 }
             } else {
-                if (!expression.isAscending()) {
+                if (!expressionWithIterator.isAscending()) {
                     orderingSQL.append(" desc");
                 }
             }
@@ -380,7 +380,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             .register(
                 "createOrderingColumns",
                 new OrderClauseCreateColumnsUDF(
-                        _expressions,
+                        _expressionsWithIterator,
                         context,
                         typesForAllColumns,
                         UDFcolumnsByType
@@ -406,8 +406,8 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
 
     public Map<String, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<String, DynamicContext.VariableDependency> result = new TreeMap<>();
-        for (OrderByClauseSparkIteratorExpression iterator : _expressions) {
-            result.putAll(iterator.getExpression().getVariableDependencies());
+        for (OrderByClauseExprWithIterator expressionWithIterator : _expressionsWithIterator) {
+            result.putAll(expressionWithIterator.getIterator().getVariableDependencies());
         }
         for (String var : _child.getVariablesBoundInCurrentFLWORExpression()) {
             result.remove(var);
@@ -422,8 +422,8 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
 
     public void print(StringBuffer buffer, int indent) {
         super.print(buffer, indent);
-        for (OrderByClauseSparkIteratorExpression iterator : _expressions) {
-            iterator.getExpression().print(buffer, indent + 1);
+        for (OrderByClauseExprWithIterator iterator : _expressionsWithIterator) {
+            iterator.getIterator().print(buffer, indent + 1);
         }
     }
 
@@ -435,8 +435,8 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             new TreeMap<>(parentProjection);
 
         // add the variable dependencies needed by this for clause's expression.
-        for (OrderByClauseSparkIteratorExpression iterator : _expressions) {
-            Map<String, DynamicContext.VariableDependency> exprDependency = iterator.getExpression()
+        for (OrderByClauseExprWithIterator iterator : _expressionsWithIterator) {
+            Map<String, DynamicContext.VariableDependency> exprDependency = iterator.getIterator()
                 .getVariableDependencies();
             for (String variable : exprDependency.keySet()) {
                 if (projection.containsKey(variable)) {

--- a/src/main/java/sparksoniq/spark/iterator/flowr/expression/OrderByClauseAnnotatedChildIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/expression/OrderByClauseAnnotatedChildIterator.java
@@ -25,7 +25,7 @@ import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 
 import java.io.Serializable;
 
-public class OrderByClauseExprWithIterator implements Serializable {
+public class OrderByClauseAnnotatedChildIterator implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private final RuntimeIterator _iterator;
@@ -34,7 +34,7 @@ public class OrderByClauseExprWithIterator implements Serializable {
     private final OrderByClauseExpr.EMPTY_ORDER _emptyOrder;
 
 
-    public OrderByClauseExprWithIterator(
+    public OrderByClauseAnnotatedChildIterator(
             RuntimeIterator iterator,
             boolean ascending,
             String uri,

--- a/src/main/java/sparksoniq/spark/iterator/flowr/expression/OrderByClauseExprWithIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/expression/OrderByClauseExprWithIterator.java
@@ -22,7 +22,6 @@ package sparksoniq.spark.iterator.flowr.expression;
 
 import sparksoniq.jsoniq.compiler.translator.expr.flowr.OrderByClauseExpr;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
-import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 
 import java.io.Serializable;
 
@@ -33,21 +32,18 @@ public class OrderByClauseExprWithIterator implements Serializable {
     private final boolean _ascending;
     private final String _uri;
     private final OrderByClauseExpr.EMPTY_ORDER _emptyOrder;
-    private final IteratorMetadata iteratorMetadata;
 
 
     public OrderByClauseExprWithIterator(
             RuntimeIterator iterator,
             boolean ascending,
             String uri,
-            OrderByClauseExpr.EMPTY_ORDER empty_order,
-            IteratorMetadata iteratorMetadata
+            OrderByClauseExpr.EMPTY_ORDER empty_order
     ) {
         this._iterator = iterator;
         this._ascending = ascending;
         this._uri = uri;
         this._emptyOrder = empty_order;
-        this.iteratorMetadata = iteratorMetadata;
     }
 
     public RuntimeIterator getIterator() {
@@ -64,10 +60,6 @@ public class OrderByClauseExprWithIterator implements Serializable {
 
     public OrderByClauseExpr.EMPTY_ORDER getEmptyOrder() {
         return _emptyOrder;
-    }
-
-    public IteratorMetadata getIteratorMetadata() {
-        return iteratorMetadata;
     }
 
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/expression/OrderByClauseExprWithIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/expression/OrderByClauseExprWithIterator.java
@@ -26,32 +26,32 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 
 import java.io.Serializable;
 
-public class OrderByClauseSparkIteratorExpression implements Serializable {
+public class OrderByClauseExprWithIterator implements Serializable {
 
     private static final long serialVersionUID = 1L;
-    private final RuntimeIterator _expression;
+    private final RuntimeIterator _iterator;
     private final boolean _ascending;
     private final String _uri;
     private final OrderByClauseExpr.EMPTY_ORDER _emptyOrder;
     private final IteratorMetadata iteratorMetadata;
 
 
-    public OrderByClauseSparkIteratorExpression(
-            RuntimeIterator expression,
+    public OrderByClauseExprWithIterator(
+            RuntimeIterator iterator,
             boolean ascending,
             String uri,
             OrderByClauseExpr.EMPTY_ORDER empty_order,
             IteratorMetadata iteratorMetadata
     ) {
-        this._expression = expression;
+        this._iterator = iterator;
         this._ascending = ascending;
         this._uri = uri;
         this._emptyOrder = empty_order;
         this.iteratorMetadata = iteratorMetadata;
     }
 
-    public RuntimeIterator getExpression() {
-        return _expression;
+    public RuntimeIterator getIterator() {
+        return _iterator;
     }
 
     public boolean isAscending() {

--- a/src/main/java/sparksoniq/spark/udf/OrderClauseCreateColumnsUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/OrderClauseCreateColumnsUDF.java
@@ -36,7 +36,7 @@ import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.semantics.types.ItemTypes;
 import sparksoniq.spark.DataFrameUtils;
-import sparksoniq.spark.iterator.flowr.expression.OrderByClauseExprWithIterator;
+import sparksoniq.spark.iterator.flowr.expression.OrderByClauseAnnotatedChildIterator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,7 +47,7 @@ import java.util.TreeMap;
 public class OrderClauseCreateColumnsUDF implements UDF2<WrappedArray<byte[]>, WrappedArray<Long>, Row> {
 
     private static final long serialVersionUID = 1L;
-    private List<OrderByClauseExprWithIterator> _expressionsWithIterator;
+    private List<OrderByClauseAnnotatedChildIterator> _expressionsWithIterator;
     private Map<String, DynamicContext.VariableDependency> _dependencies;
 
     private Map<String, List<String>> _columnNamesByType;
@@ -63,7 +63,7 @@ public class OrderClauseCreateColumnsUDF implements UDF2<WrappedArray<byte[]>, W
     private transient Input _input;
 
     public OrderClauseCreateColumnsUDF(
-            List<OrderByClauseExprWithIterator> expressionsWithIterator,
+            List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator,
             DynamicContext context,
             Map<Integer, String> allColumnTypes,
             Map<String, List<String>> columnNamesByType
@@ -78,7 +78,7 @@ public class OrderClauseCreateColumnsUDF implements UDF2<WrappedArray<byte[]>, W
         _results = new ArrayList<>();
 
         _dependencies = new TreeMap<>();
-        for (OrderByClauseExprWithIterator expressionWithIterator : _expressionsWithIterator) {
+        for (OrderByClauseAnnotatedChildIterator expressionWithIterator : _expressionsWithIterator) {
             _dependencies.putAll(expressionWithIterator.getIterator().getVariableDependencies());
         }
         _columnNamesByType = columnNamesByType;
@@ -114,7 +114,7 @@ public class OrderClauseCreateColumnsUDF implements UDF2<WrappedArray<byte[]>, W
         );
 
         for (int expressionIndex = 0; expressionIndex < _expressionsWithIterator.size(); expressionIndex++) {
-            OrderByClauseExprWithIterator expressionWithIterator = _expressionsWithIterator.get(expressionIndex);
+            OrderByClauseAnnotatedChildIterator expressionWithIterator = _expressionsWithIterator.get(expressionIndex);
 
             // nulls and empty sequences have special ordering captured in the first sorting column
             // if non-null, non-empty-sequence value is given, the second column is used to sort the input

--- a/src/main/java/sparksoniq/spark/udf/OrderClauseDetermineTypeUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/OrderClauseDetermineTypeUDF.java
@@ -113,7 +113,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
                 if (iterator.hasNext()) {
                     throw new UnexpectedTypeException(
                             "Can not order by variables with sequences of multiple items.",
-                            expressionWithIterator.getIteratorMetadata()
+                            expressionWithIterator.getIterator().getMetadata()
                     );
                 }
             }
@@ -148,7 +148,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
             } else if (_nextItem.isArray() || _nextItem.isObject()) {
                 throw new UnexpectedTypeException(
                         "Order by variable can not contain arrays or objects.",
-                        expressionWithIterator.getIteratorMetadata()
+                        expressionWithIterator.getIterator().getMetadata()
                 );
             } else if (_nextItem.isBinary()) {
                 String itemType = ItemTypes.getItemTypeName(_nextItem.getClass().getSimpleName());
@@ -158,7 +158,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
                             + "\": invalid type: can not compare for equality to type \""
                             + itemType
                             + "\"",
-                        expressionWithIterator.getIteratorMetadata()
+                        expressionWithIterator.getIterator().getMetadata()
                 );
             } else {
                 throw new OurBadException("Unexpected type found.");

--- a/src/main/java/sparksoniq/spark/udf/OrderClauseDetermineTypeUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/OrderClauseDetermineTypeUDF.java
@@ -32,7 +32,7 @@ import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.semantics.types.ItemTypes;
 import sparksoniq.spark.DataFrameUtils;
-import sparksoniq.spark.iterator.flowr.expression.OrderByClauseExprWithIterator;
+import sparksoniq.spark.iterator.flowr.expression.OrderByClauseAnnotatedChildIterator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -44,7 +44,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
     private static final long serialVersionUID = 1L;
     private Map<String, DynamicContext.VariableDependency> _dependencies;
     private Map<String, List<String>> _columnNamesByType;
-    private List<OrderByClauseExprWithIterator> _expressionsWithIterator;
+    private List<OrderByClauseAnnotatedChildIterator> _expressionsWithIterator;
     private List<List<Item>> _deserializedParams;
     private List<Item> _longParams;
     private DynamicContext _parentContext;
@@ -56,7 +56,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
     private transient Input _input;
 
     public OrderClauseDetermineTypeUDF(
-            List<OrderByClauseExprWithIterator> expressionsWithIterator,
+            List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator,
             DynamicContext context,
             Map<String, List<String>> columnNamesByType
     ) {
@@ -69,7 +69,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
         result = new ArrayList<>();
 
         _dependencies = new TreeMap<String, DynamicContext.VariableDependency>();
-        for (OrderByClauseExprWithIterator expressionWithIterator : _expressionsWithIterator) {
+        for (OrderByClauseAnnotatedChildIterator expressionWithIterator : _expressionsWithIterator) {
             _dependencies.putAll(expressionWithIterator.getIterator().getVariableDependencies());
         }
         _columnNamesByType = columnNamesByType;
@@ -104,7 +104,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
             _longParams
         );
 
-        for (OrderByClauseExprWithIterator expressionWithIterator : _expressionsWithIterator) {
+        for (OrderByClauseAnnotatedChildIterator expressionWithIterator : _expressionsWithIterator) {
             // apply expression in the dynamic context
             RuntimeIterator iterator = expressionWithIterator.getIterator();
             iterator.open(_context);

--- a/src/main/java/sparksoniq/spark/udf/OrderClauseDetermineTypeUDF.java
+++ b/src/main/java/sparksoniq/spark/udf/OrderClauseDetermineTypeUDF.java
@@ -28,10 +28,11 @@ import scala.collection.mutable.WrappedArray;
 import sparksoniq.exceptions.OurBadException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.ItemFactory;
+import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.semantics.types.ItemTypes;
 import sparksoniq.spark.DataFrameUtils;
-import sparksoniq.spark.iterator.flowr.expression.OrderByClauseSparkIteratorExpression;
+import sparksoniq.spark.iterator.flowr.expression.OrderByClauseExprWithIterator;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,7 +44,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
     private static final long serialVersionUID = 1L;
     private Map<String, DynamicContext.VariableDependency> _dependencies;
     private Map<String, List<String>> _columnNamesByType;
-    private List<OrderByClauseSparkIteratorExpression> _expressions;
+    private List<OrderByClauseExprWithIterator> _expressionsWithIterator;
     private List<List<Item>> _deserializedParams;
     private List<Item> _longParams;
     private DynamicContext _parentContext;
@@ -55,11 +56,11 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
     private transient Input _input;
 
     public OrderClauseDetermineTypeUDF(
-            List<OrderByClauseSparkIteratorExpression> expressions,
+            List<OrderByClauseExprWithIterator> expressionsWithIterator,
             DynamicContext context,
             Map<String, List<String>> columnNamesByType
     ) {
-        _expressions = expressions;
+        _expressionsWithIterator = expressionsWithIterator;
 
         _deserializedParams = new ArrayList<>();
         _longParams = new ArrayList<>();
@@ -68,8 +69,8 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
         result = new ArrayList<>();
 
         _dependencies = new TreeMap<String, DynamicContext.VariableDependency>();
-        for (OrderByClauseSparkIteratorExpression expression : _expressions) {
-            _dependencies.putAll(expression.getExpression().getVariableDependencies());
+        for (OrderByClauseExprWithIterator expressionWithIterator : _expressionsWithIterator) {
+            _dependencies.putAll(expressionWithIterator.getIterator().getVariableDependencies());
         }
         _columnNamesByType = columnNamesByType;
 
@@ -103,19 +104,20 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
             _longParams
         );
 
-        for (OrderByClauseSparkIteratorExpression expression : _expressions) {
+        for (OrderByClauseExprWithIterator expressionWithIterator : _expressionsWithIterator) {
             // apply expression in the dynamic context
-            expression.getExpression().open(_context);
-            if (expression.getExpression().hasNext()) {
-                _nextItem = expression.getExpression().next();
-                if (expression.getExpression().hasNext()) {
+            RuntimeIterator iterator = expressionWithIterator.getIterator();
+            iterator.open(_context);
+            if (iterator.hasNext()) {
+                _nextItem = iterator.next();
+                if (iterator.hasNext()) {
                     throw new UnexpectedTypeException(
                             "Can not order by variables with sequences of multiple items.",
-                            expression.getIteratorMetadata()
+                            expressionWithIterator.getIteratorMetadata()
                     );
                 }
             }
-            expression.getExpression().close();
+            iterator.close();
 
             if (_nextItem == null) {
                 result.add("empty-sequence");
@@ -146,7 +148,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
             } else if (_nextItem.isArray() || _nextItem.isObject()) {
                 throw new UnexpectedTypeException(
                         "Order by variable can not contain arrays or objects.",
-                        expression.getIteratorMetadata()
+                        expressionWithIterator.getIteratorMetadata()
                 );
             } else if (_nextItem.isBinary()) {
                 String itemType = ItemTypes.getItemTypeName(_nextItem.getClass().getSimpleName());
@@ -156,7 +158,7 @@ public class OrderClauseDetermineTypeUDF implements UDF2<WrappedArray<byte[]>, W
                             + "\": invalid type: can not compare for equality to type \""
                             + itemType
                             + "\"",
-                        expression.getIteratorMetadata()
+                        expressionWithIterator.getIteratorMetadata()
                 );
             } else {
                 throw new OurBadException("Unexpected type found.");

--- a/src/test/java/iq/FrontendTests.java
+++ b/src/test/java/iq/FrontendTests.java
@@ -126,10 +126,10 @@ public class FrontendTests extends AnnotationsTestsBase {
      * ForClause startClause = (ForClause) node.getStartClause();
      * Assert.assertTrue(startClause.getForVariables().get(0)
      * .getVariableReference().getVariableName().equals("var"));
-     * Assert.assertTrue(startClause.getForVariables().get(0).getExpression()
+     * Assert.assertTrue(startClause.getForVariables().get(0).getIterator()
      * .getDescendantsOfType(d -> d instanceof RangeExpression, true).size() == 1);
      * 
-     * RangeExpression range = (RangeExpression) startClause.getForVariables().get(0).getExpression()
+     * RangeExpression range = (RangeExpression) startClause.getForVariables().get(0).getIterator()
      * .getDescendantsOfType(d -> d instanceof RangeExpression, true).get(0);
      * UnaryExpression unary = (UnaryExpression) range.
      * getDescendantsOfType(d -> d instanceof UnaryExpression, true).get(0);


### PR DESCRIPTION
This one may be a matter of taste but I tried to improve the naming of orderbyClauseSparkIteratorExpression as it did not mean much to me in its original state. This PR does not aim to change the functionality. It merely renames and extracts a runtimeIterator to a variable in 2 UDFs

Basically this class consists of an orderByClause's subExpression (called orderByClauseExpr), and the iterator generated from the said expression. 

As a general remark, especially in the past few months, I have found that the 'expression' keyword to be used ambiguous ways in multiple contexts. While the meaning becomes clear once you are familiar with the context, for future maintainability of the project and onboarding of new developers, it may be very helpful to disentangle such meanings with hopefully better keyword selections. A low priority refactoring effort may be beneficial for minimizing the potential technical debt of the project in the future.

There are two sources that I identify and while the first one is easy and quick to address, the second one will most likely be a challenging effort with design & naming:
- Using expression keyword as a variable name for RuntimeIterators even though they are separate classes living in the same project
- Ambiguity between what you would describe as an expression from a language's lexical perspective, and what is defined as an expression in the semantic perspective of XQuery specification. More specifically, every language construct we have in Rumble inherits from ExpressionOrClause type, however, in the context of XQuery specs which we adhere to, they are not necessarily expressions. 'MainModule' would be the simplest example of the lying at the top of our grammar. Furthermore, adding FLWOR clauses (not expressions semantically) to the picture with their lexical expressions and sub-expressions (such as components of order by clause or multiple variable definitions in for or let clauses) this ambiguity quickly grows. 

@ghislainfourny What are you thoughts on this issue? If you find it valuable as well, we can extract this to an issue.