### PR TITLE
Simplify typeSwitchExpression by removing redundant variableReferenceIterators

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/TypeSwitchCase.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/TypeSwitchCase.java
@@ -2,33 +2,32 @@ package sparksoniq.jsoniq.runtime.iterator.control;
 
 import sparksoniq.jsoniq.compiler.translator.expr.flowr.FlworVarSequenceType;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
-import sparksoniq.jsoniq.runtime.iterator.primary.VariableReferenceIterator;
 
 import java.util.List;
 
 public class TypeSwitchCase {
-    private final VariableReferenceIterator variable;
+    private final String variableName;
     private final List<FlworVarSequenceType> sequenceTypeUnion;
     private final RuntimeIterator returnIterator;
 
     public TypeSwitchCase(
-            VariableReferenceIterator variable,
+            String variableName,
             List<FlworVarSequenceType> sequenceTypeUnion,
             RuntimeIterator returnIterator
     ) {
-        this.variable = variable;
+        this.variableName = variableName;
         this.sequenceTypeUnion = sequenceTypeUnion;
         this.returnIterator = returnIterator;
     }
 
-    public TypeSwitchCase(VariableReferenceIterator variable, RuntimeIterator returnIterator) {
-        this.variable = variable;
+    public TypeSwitchCase(String variableName, RuntimeIterator returnIterator) {
+        this.variableName = variableName;
         this.sequenceTypeUnion = null;
         this.returnIterator = returnIterator;
     }
 
-    VariableReferenceIterator getVariable() {
-        return variable;
+    String getVariableName() {
+        return variableName;
     }
 
     List<FlworVarSequenceType> getSequenceTypeUnion() {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/TypeSwitchRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/TypeSwitchRuntimeIterator.java
@@ -27,17 +27,13 @@ public class TypeSwitchRuntimeIterator extends LocalRuntimeIterator {
             TypeSwitchCase defaultCase,
             IteratorMetadata iteratorMetadata
     ) {
-
         super(null, iteratorMetadata);
         this._children.add(test);
         for (TypeSwitchCase typeSwitchCase : cases) {
             this._children.add(typeSwitchCase.getReturnIterator());
-            if (typeSwitchCase.getVariable() != null)
-                this._children.add(typeSwitchCase.getVariable());
         }
-        if (defaultCase.getVariable() != null)
-            this._children.add(defaultCase.getVariable());
         this._children.add(defaultCase.getReturnIterator());
+
         this.testField = test;
         this.cases = cases;
         this.defaultCase = defaultCase;
@@ -81,9 +77,9 @@ public class TypeSwitchRuntimeIterator extends LocalRuntimeIterator {
         }
 
         if (matchingIterator == null) {
-            if (defaultCase.getVariable() != null) {
+            if (defaultCase.getVariableName() != null) {
                 _currentDynamicContextForLocalExecution.addVariableValue(
-                    defaultCase.getVariable().getVariableName(),
+                    defaultCase.getVariableName(),
                     Collections.singletonList(testValue)
                 );
             }
@@ -98,9 +94,9 @@ public class TypeSwitchRuntimeIterator extends LocalRuntimeIterator {
     private boolean testTypeMatch(TypeSwitchCase typeSwitchCase) {
         for (FlworVarSequenceType sequenceType : typeSwitchCase.getSequenceTypeUnion()) {
             if (testValue != null && testValue.isTypeOf(sequenceType.getSequence().getItemType())) {
-                if (typeSwitchCase.getVariable() != null) {
+                if (typeSwitchCase.getVariableName() != null) {
                     _currentDynamicContextForLocalExecution.addVariableValue(
-                        typeSwitchCase.getVariable().getVariableName(),
+                        typeSwitchCase.getVariableName(),
                         Collections.singletonList(testValue)
                     );
                 }

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -863,16 +863,13 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
     public RuntimeIterator visitTypeSwitchExpression(TypeSwitchExpression expression, RuntimeIterator argument) {
         List<TypeSwitchCase> cases = new ArrayList<>();
         for (TypeSwitchCaseExpression caseExpression : expression.getCases()) {
-            VariableReferenceIterator variableReferenceIterator = null;
+            String caseVariableName = null;
             if (caseExpression.getVariableReference() != null) {
-                variableReferenceIterator = (VariableReferenceIterator) this.visit(
-                    caseExpression.getVariableReference(),
-                    argument
-                );
+                caseVariableName = caseExpression.getVariableReference().getVariableName();
             }
             cases.add(
                 new TypeSwitchCase(
-                        variableReferenceIterator,
+                        caseVariableName,
                         caseExpression.getUnion(),
                         this.visit(caseExpression.getReturnExpression(), argument)
                 )
@@ -880,12 +877,12 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
         }
 
         TypeSwitchCase defaultCase;
-        VariableReferenceIterator varRefDefaultIterator = null;
+        String defaultCaseVariableName = null;
         if (expression.getVarRefDefault() != null) {
-            varRefDefaultIterator = (VariableReferenceIterator) this.visit(expression.getVarRefDefault(), argument);
+            defaultCaseVariableName = expression.getVarRefDefault().getVariableName();
         }
         defaultCase = new TypeSwitchCase(
-                varRefDefaultIterator,
+                defaultCaseVariableName,
                 this.visit(expression.getDefaultExpression(), argument)
         );
 


### PR DESCRIPTION
Original typeSwitchExpression implementation created variableReferenceIterators only to access their names. I have eliminated the iterator generation and passed the names in directly instead. This not only improves performance by eliminating redundant object creation, but also improves correctness. The use of variableReference in the case of $a in the example below is to simply define the variable, not look it up from current (static or dynamic) context. VariableReferenceIterator should be used **only** for the return clauses of 2nd and 3rd cases where an actual variable referencing should be performed. 

typeswitch(4.234243e3)
case $a as hexBinary+ return "not this"
case $b as boolean | double? | base64Binary? return ($b cast as string) || " correct"
case $c as string | decimal? return $c
default return "DEF"

@ghislainfourny We can also include Andrea as reviewer if you think this would be relevant to his work/report