### PR TITLE
Refactor applyTransformerIterator to take a Transformer as parameter

### DIFF
--- a/src/main/java/sparksoniq/spark/ml/ApplyTransformerRuntimeIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/ApplyTransformerRuntimeIterator.java
@@ -20,53 +20,49 @@ import static sparksoniq.spark.ml.RumbleMLUtils.convertRumbleObjectItemToSparkML
 public class ApplyTransformerRuntimeIterator extends DataFrameRuntimeIterator {
 
     private static final long serialVersionUID = 1L;
-    private String _transformerName;
-    private Class<?> _transformerSparkMLClass;
+    private String _transformerShortName;
+    private Transformer _transformer;
 
     public ApplyTransformerRuntimeIterator(
-            String transformerName,
-            Class<?> transformerSparkMLClass,
+            String transformerShortName,
+            Transformer transformer,
             ExecutionMode executionMode,
             IteratorMetadata iteratorMetadata
     ) {
         super(null, executionMode, iteratorMetadata);
-        this._transformerName = transformerName;
-        this._transformerSparkMLClass = transformerSparkMLClass;
+        this._transformerShortName = transformerShortName;
+        this._transformer = transformer;
     }
 
     @Override
     public Dataset<Row> getDataFrame(DynamicContext context) {
-        try {
-            Transformer transformer = (Transformer) _transformerSparkMLClass.newInstance();
+        Dataset<Row> inputDataset = context.getDataFrameVariableValue(
+            GetTransformerFunctionIterator.transformerParameterNames.get(0),
+            getMetadata()
+        );
+        List<Item> paramMapItemList = context.getLocalVariableValue(
+            GetTransformerFunctionIterator.transformerParameterNames.get(1),
+            getMetadata()
+        );
+        if (paramMapItemList.size() != 1) {
+            throw new OurBadException(
+                    "Applying a transformer takes a single object as the second parameter.",
+                    getMetadata()
+            );
+        }
+        Item paramMapItem = paramMapItemList.get(0);
+        ParamMap paramMap = convertRumbleObjectItemToSparkMLParamMap(
+            _transformerShortName,
+            _transformer,
+            paramMapItem,
+            getMetadata()
+        );
 
-            Dataset<Row> inputDataset = context.getDataFrameVariableValue(
-                GetTransformerFunctionIterator.transformerParameterNames.get(0),
-                getMetadata()
-            );
-            List<Item> paramMapItemList = context.getLocalVariableValue(
-                GetTransformerFunctionIterator.transformerParameterNames.get(1),
-                getMetadata()
-            );
-            if (paramMapItemList.size() != 1) {
-                throw new OurBadException(
-                        "Applying a transformer takes a single object as the second parameter.",
-                        getMetadata()
-                );
-            }
-            Item paramMapItem = paramMapItemList.get(0);
-            ParamMap paramMap = convertRumbleObjectItemToSparkMLParamMap(
-                _transformerSparkMLClass,
-                _transformerName,
-                transformer,
-                paramMapItem,
-                getMetadata()
-            );
-            return transformer.transform(inputDataset, paramMap);
-        } catch (InstantiationException | IllegalAccessException e) {
-            throw new OurBadException("Error while generating an instance from transformer class.", getMetadata());
+        try {
+            return _transformer.transform(inputDataset, paramMap);
         } catch (IllegalArgumentException e) {
             throw new InvalidRumbleMLParamException(
-                    "Parameter provided to " + _transformerName + " causes the following error: " + e.getMessage(),
+                    "Parameter provided to " + _transformerShortName + " causes the following error: " + e.getMessage(),
                     getMetadata()
             );
         }

--- a/src/main/java/sparksoniq/spark/ml/RumbleMLCatalog.java
+++ b/src/main/java/sparksoniq/spark/ml/RumbleMLCatalog.java
@@ -1226,19 +1226,19 @@ public class RumbleMLCatalog {
     }
 
     public static void validateParameterForTransformer(
-            String transformerName,
+            String transformerShortName,
             String paramName,
             IteratorMetadata metadata
     ) {
-        if (!transformerParams.containsKey(transformerName)) {
-            throw new UnrecognizedRumbleMLClassReferenceException(transformerName, metadata);
+        if (!transformerParams.containsKey(transformerShortName)) {
+            throw new UnrecognizedRumbleMLClassReferenceException(transformerShortName, metadata);
         }
-        if (!transformerParams.get(transformerName).contains(paramName)) {
+        if (!transformerParams.get(transformerShortName).contains(paramName)) {
             throw new UnrecognizedRumbleMLParamReferenceException(
                     "Make sure \""
                         + paramName
                         + "\" is a valid parameter of \""
-                        + transformerName
+                        + transformerShortName
                         + "\".",
                     metadata
             );

--- a/src/main/java/sparksoniq/spark/ml/RumbleMLUtils.java
+++ b/src/main/java/sparksoniq/spark/ml/RumbleMLUtils.java
@@ -15,8 +15,7 @@ import java.util.List;
 
 public class RumbleMLUtils {
     public static ParamMap convertRumbleObjectItemToSparkMLParamMap(
-            Class<?> transformerClass,
-            String transformerName,
+            String transformerShortName,
             Transformer transformer,
             Item paramMapItem,
             IteratorMetadata metadata
@@ -27,13 +26,15 @@ public class RumbleMLUtils {
             String paramName = paramMapItem.getKeys().get(paramIndex);
             Item paramValue = paramMapItem.getValues().get(paramIndex);
 
-            RumbleMLCatalog.validateParameterForTransformer(transformerName, paramName, metadata);
+            RumbleMLCatalog.validateParameterForTransformer(transformerShortName, paramName, metadata);
             String paramJavaTypeName = RumbleMLCatalog.getParamJavaTypeName(paramName, metadata);
 
             Object paramValueInJava = convertParamItemToJava(paramValue, paramJavaTypeName);
 
             try {
-                Param<Object> sparkMLParam = (Param<Object>) transformerClass.getMethod(paramName).invoke(transformer);
+                Param<Object> sparkMLParam = (Param<Object>) transformer.getClass()
+                    .getMethod(paramName)
+                    .invoke(transformer);
                 result.put(sparkMLParam.w(paramValueInJava));
             } catch (
                     NoSuchMethodException
@@ -42,7 +43,7 @@ public class RumbleMLUtils {
                     | ClassCastException e
             ) {
                 throw new OurBadException(
-                        "Error while extracting " + paramName + " for " + transformerName + ".",
+                        "Error while extracting " + paramName + " for " + transformerShortName + ".",
                         metadata
                 );
             }


### PR DESCRIPTION
Based on #415. 

Apply transformer now takes the transformer to be applied directly as a parameter rather than generating it. This will allow us to use the same class for applying the transformers that result from fitting an estimator.