### PR TITLE
Improve vectorUDT to rumbleItem mapping

### DIFF
--- a/src/main/java/org/rumbledb/items/parsing/ItemParser.java
+++ b/src/main/java/org/rumbledb/items/parsing/ItemParser.java
@@ -23,7 +23,9 @@ package org.rumbledb.items.parsing;
 import com.jsoniter.JsonIterator;
 import com.jsoniter.ValueType;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.spark.ml.linalg.DenseVector;
 import org.apache.spark.ml.linalg.SparseVector;
+import org.apache.spark.ml.linalg.Vector;
 import org.apache.spark.ml.linalg.VectorUDT;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.ArrayType;
@@ -34,6 +36,7 @@ import org.apache.spark.sql.types.StructType;
 import org.joda.time.DateTime;
 import org.rumbledb.api.Item;
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.exceptions.OurBadException;
 import org.rumbledb.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.ItemFactory;
 import sparksoniq.spark.SparkSessionManager;
@@ -227,16 +230,28 @@ public class ItemParser implements Serializable {
             }
             values.add(ItemFactory.getInstance().createArrayItem(members));
         } else if (fieldType instanceof VectorUDT) {
-            // a vector is mapped to a Rumble object where keys are indices of the non-0 values in the vector
-            SparseVector vector = (SparseVector) row.get(i);
-
-            List<String> keyList = new ArrayList<>();
-            List<Item> valueList = new ArrayList<>();
-            for (int index : vector.indices()) {
-                keyList.add(String.valueOf(index));
-                valueList.add(ItemFactory.getInstance().createDoubleItem(vector.values()[index]));
+            Vector vector = (Vector) row.get(i);
+            if (vector instanceof DenseVector) {
+                // a dense vector is mapped to a rumble array
+                DenseVector denseVector = (DenseVector) vector;
+                List<Item> members = new ArrayList<>(vector.size());
+                for (double value : denseVector.values()) {
+                    members.add(ItemFactory.getInstance().createDoubleItem(value));
+                }
+                values.add(ItemFactory.getInstance().createArrayItem(members));
+            } else if (vector instanceof SparseVector) {
+                // a sparse vector is mapped to a Rumble object where keys are indices of the non-0 values in the vector
+                SparseVector sparseVector = (SparseVector) vector;
+                List<String> keyList = new ArrayList<>();
+                List<Item> valueList = new ArrayList<>();
+                for (int index : sparseVector.indices()) {
+                    keyList.add(String.valueOf(index));
+                    valueList.add(ItemFactory.getInstance().createDoubleItem(sparseVector.values()[index]));
+                }
+                values.add(ItemFactory.getInstance().createObjectItem(keyList, valueList, metadata));
+            } else {
+                throw new OurBadException("Unexpected program state reached while converting vectorUDT to rumble item");
             }
-            values.add(ItemFactory.getInstance().createObjectItem(keyList, valueList, metadata));
         } else {
             throw new RuntimeException("DataFrame type unsupported: " + fieldType.json());
         }

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLEstimatorKMeans1.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLEstimatorKMeans1.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldRun; Output="({ "label" : 0, "features" : [ 0, 0, 0 ], "prediction" : 0 }, { "label" : 1, "features" : [ 0.1, 0.1, 0.1 ], "prediction" : 0 }, { "label" : 2, "features" : [ 0.2, 0.2, 0.2 ], "prediction" : 0 }, { "label" : 3, "features" : [ 9, 9, 9 ], "prediction" : 1 }, { "label" : 4, "features" : [ 9.1, 9.1, 9.1 ], "prediction" : 1 }, { "label" : 5, "features" : [ 9.2, 9.2, 9.2 ], "prediction" : 1 })" :)
+(:JIQS: ShouldRun; Output="({ "label" : 0, "features" : { }, "prediction" : 0 }, { "label" : 1, "features" : { "0" : 0.1, "1" : 0.1, "2" : 0.1 }, "prediction" : 0 }, { "label" : 2, "features" : { "0" : 0.2, "1" : 0.2, "2" : 0.2 }, "prediction" : 0 }, { "label" : 3, "features" : { "0" : 9, "1" : 9, "2" : 9 }, "prediction" : 1 }, { "label" : 4, "features" : { "0" : 9.1, "1" : 9.1, "2" : 9.1 }, "prediction" : 1 }, { "label" : 5, "features" : { "0" : 9.2, "1" : 9.2, "2" : 9.2 }, "prediction" : 1 })" :)
 let $est := get-estimator("KMeans")
 let $tra := $est(
     libsvm-file("./src/main/resources/queries/rumbleML/sample-libsvm-kmeans-data.txt"),


### PR DESCRIPTION
As we have discussed in the meeting I have initially implemented SparseVector to ObjectItem mapping.

As per our discussion, I have investigated whether dense and sparse vectors can co-exist within the same dataframe. And this is permitted not only across different columns, but within the same column as well (this can be observed [here](https://spark.apache.org/docs/latest/ml-features.html#pca). 

For this reason, I have extended the implementation to map sparseVectors to objectItems and denseVectors to arrayItems. Do you see any problems with this approach?