### PR TITLE
Tidyup apply estimator, apply transformer, FunctionItemCallIterator

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/FunctionItemCallIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/FunctionItemCallIterator.java
@@ -79,6 +79,9 @@ public class FunctionItemCallIterator extends HybridRuntimeIterator {
 
     @Override
     public void openLocal() {
+        this.validateNumberOfArguments();
+        this.wrapArgumentIteratorsWithTypeCheckingIterators();
+
         if (this.isPartialApplication) {
             this.functionBodyIterator = generatePartiallyAppliedFunction(this.currentDynamicContextForLocalExecution);
         } else {
@@ -134,9 +137,6 @@ public class FunctionItemCallIterator extends HybridRuntimeIterator {
      * @return FunctionRuntimeIterator that contains the newly generated FunctionItem
      */
     private FunctionRuntimeIterator generatePartiallyAppliedFunction(DynamicContext context) {
-        this.validateNumberOfArguments();
-        this.wrapArgumentIteratorsWithTypeCheckingIterators();
-
         String argName;
         RuntimeIterator argIterator;
 
@@ -188,9 +188,6 @@ public class FunctionItemCallIterator extends HybridRuntimeIterator {
     }
 
     private DynamicContext createNewDynamicContextWithArguments(DynamicContext context) {
-        this.validateNumberOfArguments();
-        this.wrapArgumentIteratorsWithTypeCheckingIterators();
-
         String argName;
         RuntimeIterator argIterator;
 
@@ -274,9 +271,11 @@ public class FunctionItemCallIterator extends HybridRuntimeIterator {
                     "Unexpected program state reached. Partially applied function calls must be evaluated locally."
             );
         }
-        DynamicContext contextWithArguments = dynamicContext;
+        this.validateNumberOfArguments();
+        this.wrapArgumentIteratorsWithTypeCheckingIterators();
+
+        DynamicContext contextWithArguments = this.createNewDynamicContextWithArguments(dynamicContext);
         this.functionBodyIterator = this.functionItem.getBodyIterator();
-        contextWithArguments = this.createNewDynamicContextWithArguments(contextWithArguments);
         return this.functionBodyIterator.getRDD(contextWithArguments);
     }
 }

--- a/src/main/java/sparksoniq/spark/ml/ApplyEstimatorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/ApplyEstimatorRuntimeIterator.java
@@ -80,14 +80,14 @@ public class ApplyEstimatorRuntimeIterator extends LocalRuntimeIterator {
 
     private Dataset<Row> getInputDataset(DynamicContext context) {
         return context.getDataFrameVariableValue(
-            GetEstimatorFunctionIterator.estimatorParameterNames.get(0),
+            GetEstimatorFunctionIterator.estimatorFunctionParameterNames.get(0),
             getMetadata()
         );
     }
 
     private Item getParamMapItem(DynamicContext context) {
         List<Item> paramMapItemList = context.getLocalVariableValue(
-            GetEstimatorFunctionIterator.estimatorParameterNames.get(1),
+            GetEstimatorFunctionIterator.estimatorFunctionParameterNames.get(1),
             getMetadata()
         );
         if (paramMapItemList.size() != 1) {

--- a/src/main/java/sparksoniq/spark/ml/ApplyEstimatorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/ApplyEstimatorRuntimeIterator.java
@@ -16,6 +16,7 @@ import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.FunctionIdentifier;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.FunctionSignature;
+import sparksoniq.semantics.DynamicContext;
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 import sparksoniq.semantics.types.SequenceType;
@@ -51,21 +52,9 @@ public class ApplyEstimatorRuntimeIterator extends LocalRuntimeIterator {
         }
         this.hasNext = false;
 
-        Dataset<Row> inputDataset = this.currentDynamicContextForLocalExecution.getDataFrameVariableValue(
-            GetEstimatorFunctionIterator.estimatorParameterNames.get(0),
-            getMetadata()
-        );
-        List<Item> paramMapItemList = this.currentDynamicContextForLocalExecution.getLocalVariableValue(
-            GetEstimatorFunctionIterator.estimatorParameterNames.get(1),
-            getMetadata()
-        );
-        if (paramMapItemList.size() != 1) {
-            throw new OurBadException(
-                    "Applying an estimator takes a single object as the second parameter.",
-                    getMetadata()
-            );
-        }
-        Item paramMapItem = paramMapItemList.get(0);
+        Dataset<Row> inputDataset = getInputDataset(this.currentDynamicContextForLocalExecution);
+        Item paramMapItem = getParamMapItem(this.currentDynamicContextForLocalExecution);
+
         ParamMap paramMap = convertRumbleObjectItemToSparkMLParamMap(
             this.estimatorShortName,
             this.estimator,
@@ -86,6 +75,31 @@ public class ApplyEstimatorRuntimeIterator extends LocalRuntimeIterator {
             );
         }
 
+        return generateTransformerFunctionItem(fittedModel);
+    }
+
+    private Dataset<Row> getInputDataset(DynamicContext context) {
+        return context.getDataFrameVariableValue(
+            GetEstimatorFunctionIterator.estimatorParameterNames.get(0),
+            getMetadata()
+        );
+    }
+
+    private Item getParamMapItem(DynamicContext context) {
+        List<Item> paramMapItemList = context.getLocalVariableValue(
+            GetEstimatorFunctionIterator.estimatorParameterNames.get(1),
+            getMetadata()
+        );
+        if (paramMapItemList.size() != 1) {
+            throw new OurBadException(
+                    "Applying an estimator takes a single object as the second parameter.",
+                    getMetadata()
+            );
+        }
+        return paramMapItemList.get(0);
+    }
+
+    private Item generateTransformerFunctionItem(Transformer fittedModel) {
         RuntimeIterator bodyIterator = new ApplyTransformerRuntimeIterator(
                 RumbleMLCatalog.getRumbleMLShortName(fittedModel.getClass().getName()),
                 fittedModel,

--- a/src/main/java/sparksoniq/spark/ml/ApplyTransformerRuntimeIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/ApplyTransformerRuntimeIterator.java
@@ -36,21 +36,9 @@ public class ApplyTransformerRuntimeIterator extends DataFrameRuntimeIterator {
 
     @Override
     public Dataset<Row> getDataFrame(DynamicContext context) {
-        Dataset<Row> inputDataset = context.getDataFrameVariableValue(
-            GetTransformerFunctionIterator.transformerParameterNames.get(0),
-            getMetadata()
-        );
-        List<Item> paramMapItemList = context.getLocalVariableValue(
-            GetTransformerFunctionIterator.transformerParameterNames.get(1),
-            getMetadata()
-        );
-        if (paramMapItemList.size() != 1) {
-            throw new OurBadException(
-                    "Applying a transformer takes a single object as the second parameter.",
-                    getMetadata()
-            );
-        }
-        Item paramMapItem = paramMapItemList.get(0);
+        Dataset<Row> inputDataset = getInputDataset(context);
+        Item paramMapItem = getParamMapItem(context);
+
         ParamMap paramMap = convertRumbleObjectItemToSparkMLParamMap(
             this.transformerShortName,
             this.transformer,
@@ -69,5 +57,26 @@ public class ApplyTransformerRuntimeIterator extends DataFrameRuntimeIterator {
                     getMetadata()
             );
         }
+    }
+
+    private Dataset<Row> getInputDataset(DynamicContext context) {
+        return context.getDataFrameVariableValue(
+            GetTransformerFunctionIterator.transformerParameterNames.get(0),
+            getMetadata()
+        );
+    }
+
+    private Item getParamMapItem(DynamicContext context) {
+        List<Item> paramMapItemList = context.getLocalVariableValue(
+            GetTransformerFunctionIterator.transformerParameterNames.get(1),
+            getMetadata()
+        );
+        if (paramMapItemList.size() != 1) {
+            throw new OurBadException(
+                    "Applying a transformer takes a single object as the second parameter.",
+                    getMetadata()
+            );
+        }
+        return paramMapItemList.get(0);
     }
 }

--- a/src/main/java/sparksoniq/spark/ml/GetEstimatorFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/GetEstimatorFunctionIterator.java
@@ -45,7 +45,12 @@ import java.util.List;
 public class GetEstimatorFunctionIterator extends LocalFunctionCallIterator {
 
     private static final long serialVersionUID = 1L;
-    public static final List<String> estimatorParameterNames = new ArrayList<>(Arrays.asList("input", "params"));
+    public static final List<String> estimatorFunctionParameterNames = new ArrayList<>(
+            Arrays.asList(
+                "estimator-input-f6c87df3-fcba-47c7-a5ff-a1a7553b1cab",
+                "estimator-paramobject-ded8adb9-df6f-42b2-b493-863a421a2754"
+            )
+    );
     private String estimatorShortName;
     private Class<?> estimatorSparkMLClass;
 
@@ -123,7 +128,7 @@ public class GetEstimatorFunctionIterator extends LocalFunctionCallIterator {
 
                 return new FunctionItem(
                         new FunctionIdentifier(this.estimatorSparkMLClass.getName(), 2),
-                        estimatorParameterNames,
+                        estimatorFunctionParameterNames,
                         new FunctionSignature(
                                 paramTypes,
                                 returnType

--- a/src/main/java/sparksoniq/spark/ml/GetTransformerFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/GetTransformerFunctionIterator.java
@@ -45,7 +45,12 @@ import java.util.List;
 public class GetTransformerFunctionIterator extends LocalFunctionCallIterator {
 
     private static final long serialVersionUID = 1L;
-    public static final List<String> transformerParameterNames = new ArrayList<>(Arrays.asList("input", "params"));
+    public static final List<String> transformerParameterNames = new ArrayList<>(
+            Arrays.asList(
+                "transformer-input-9470aa1b-13cb-405b-b598-910cb2d18224",
+                "transformer-paramobject-e05c895c-be12-4df1-8a86-8b90f10a7129"
+            )
+    );
     private String transformerShortName;
     private Class<?> transformerSparkMLClass;
 


### PR DESCRIPTION
Extracted some operations to functions for increased readability. These are mostly cosmetic changes.

Functional change 1: Error messages referring to partially applied functions. Previously name of a function was not specified when a validation error with arguments of a partially applied function occurred. Now the partially applied function will be referred as "partially applied x" function with x being the original function that was partially applied.

Functional change 2: Introduced UUIDs to internal estimator and transformer variable parameter names. This will prevent collisions with user variables.