### PR TITLE
Implement (annotate(object*, object) as object*) function: Local/RDD -> DataFrame conversion with schema

### DIFF
--- a/docs/Error codes.md
+++ b/docs/Error codes.md
@@ -25,6 +25,12 @@ An unrecognized parameter is used in query while operating with a Rumble ML clas
 - [RBML0003] - Invalid Rumble ML Param
 Provided parameter does not match the expected type or value for the referenced Rumble ML class.
 
+- [RBML0004] - Input is not a DataFrame
+Provided input of items does not form a DataFrame as expected by RumbleML.
+
+- [RBML0005] - Invalid schema for DataFrame in annotate()
+The provided schema can not be applied to the item data while converting the data to a DataFrame
+
 - [RBST0001] - CLI error. Raised when invalid parameters are supplied at launch.
 
 - [RBST0002] - Unimplemented feature error.

--- a/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
@@ -212,7 +212,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
         if (clause instanceof ForClause) {
             for (ForClauseVar var : ((ForClause) clause).getForVariables()) {
                 RuntimeIterator assignmentIterator = this.visit(var.getExpression(), argument);
-                if (var.getSequenceType() != null) {
+                if (var.getSequenceType() != SequenceType.mostGeneralSequenceType) {
                     ExecutionMode executionMode = TreatExpression.calculateIsRDDFromSequenceTypeAndExpression(
                         var.getSequenceType(),
                         var.getExpression()
@@ -237,7 +237,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
         } else if (clause instanceof LetClause) {
             for (LetClauseVar var : ((LetClause) clause).getLetVariables()) {
                 RuntimeIterator assignmentIterator = this.visit(var.getExpression(), argument);
-                if (var.getSequenceType() != null) {
+                if (var.getSequenceType() != SequenceType.mostGeneralSequenceType) {
                     ExecutionMode executionMode = TreatExpression.calculateIsRDDFromSequenceTypeAndExpression(
                         var.getSequenceType(),
                         var.getExpression()
@@ -266,7 +266,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 RuntimeIterator groupByExpressionIterator = null;
                 if (groupByExpression != null) {
                     groupByExpressionIterator = this.visit(groupByExpression, argument);
-                    if (var.getSequenceType() != null) {
+                    if (var.getSequenceType() != SequenceType.mostGeneralSequenceType) {
                         ExecutionMode executionMode = TreatExpression.calculateIsRDDFromSequenceTypeAndExpression(
                             var.getSequenceType(),
                             groupByExpression

--- a/src/main/java/org/rumbledb/errorcodes/ErrorCodes.java
+++ b/src/main/java/org/rumbledb/errorcodes/ErrorCodes.java
@@ -46,6 +46,8 @@ public class ErrorCodes {
     public static final String UnrecognizedRumbleMLClassReferenceErrorCode = "RBML0001";
     public static final String UnrecognizedRumbleMLParamReferenceErrorCode = "RBML0002";
     public static final String InvalidRumbleMLParamErrorCode = "RBML0003";
+    public static final String MLNotADataFrameErrorCode = "RBML0004";
+    public static final String MLInvalidDataFrameSchemaErrorCode = "RBML0005";
 
 
     public static final String CliErrorCode = "RBST0001";

--- a/src/main/java/org/rumbledb/exceptions/MLInvalidDataFrameSchemaException.java
+++ b/src/main/java/org/rumbledb/exceptions/MLInvalidDataFrameSchemaException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors: Stefan Irimescu, Can Berker Cikis
+ *
+ */
+
+package org.rumbledb.exceptions;
+
+import org.rumbledb.errorcodes.ErrorCodes;
+
+public class MLInvalidDataFrameSchemaException extends SparksoniqRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MLInvalidDataFrameSchemaException(String message, ExceptionMetadata metadata) {
+        super(
+            "Invalid Schema; " + message,
+            ErrorCodes.MLInvalidDataFrameSchemaErrorCode,
+            metadata
+        );
+    }
+}

--- a/src/main/java/org/rumbledb/exceptions/MLNotADataFrameException.java
+++ b/src/main/java/org/rumbledb/exceptions/MLNotADataFrameException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors: Stefan Irimescu, Can Berker Cikis
+ *
+ */
+
+package org.rumbledb.exceptions;
+
+import org.rumbledb.errorcodes.ErrorCodes;
+
+public class MLNotADataFrameException extends SparksoniqRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public MLNotADataFrameException(String message, ExceptionMetadata metadata) {
+        super(
+            "Invalid Param; " + message,
+            ErrorCodes.MLNotADataFrameErrorCode,
+            metadata
+        );
+    }
+}

--- a/src/main/java/org/rumbledb/expressions/operational/TreatExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/TreatExpression.java
@@ -27,7 +27,7 @@ public class TreatExpression extends UnaryExpressionBase {
 
     @Override
     public void initHighestExecutionMode() {
-        this.highestExecutionMode = calculateIsRDDFromSequenceTypeAndExpression(sequenceType, this.mainExpression);
+        this.highestExecutionMode = calculateIsRDDFromSequenceTypeAndExpression(this.sequenceType, this.mainExpression);
     }
 
     public static ExecutionMode calculateIsRDDFromSequenceTypeAndExpression(

--- a/src/main/java/org/rumbledb/runtime/functions/base/Functions.java
+++ b/src/main/java/org/rumbledb/runtime/functions/base/Functions.java
@@ -2115,7 +2115,7 @@ public class Functions {
             "annotate",
             "object*",
             "object",
-            "item*", // TODO: revert back to ObjectItem when TypePromotoionIter. has DF implementation
+            "item*", // TODO: revert back to ObjectItem when TypePromotionIter. has DF implementation
             AnnotateFunctionIterator.class,
             BuiltinFunction.BuiltinFunctionExecutionMode.DATAFRAME
         );

--- a/src/main/java/org/rumbledb/runtime/functions/base/Functions.java
+++ b/src/main/java/org/rumbledb/runtime/functions/base/Functions.java
@@ -141,6 +141,7 @@ import sparksoniq.jsoniq.ExecutionMode;
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 import sparksoniq.semantics.types.SequenceType;
+import sparksoniq.spark.ml.AnnotateFunctionIterator;
 import sparksoniq.spark.ml.GetEstimatorFunctionIterator;
 import sparksoniq.spark.ml.GetTransformerFunctionIterator;
 
@@ -166,6 +167,7 @@ import static org.rumbledb.runtime.functions.base.Functions.FunctionNames.adjust
 import static org.rumbledb.runtime.functions.base.Functions.FunctionNames.adjust_date_to_timezone2;
 import static org.rumbledb.runtime.functions.base.Functions.FunctionNames.adjust_time_to_timezone1;
 import static org.rumbledb.runtime.functions.base.Functions.FunctionNames.adjust_time_to_timezone2;
+import static org.rumbledb.runtime.functions.base.Functions.FunctionNames.annotate;
 import static org.rumbledb.runtime.functions.base.Functions.FunctionNames.asin;
 import static org.rumbledb.runtime.functions.base.Functions.FunctionNames.atan;
 import static org.rumbledb.runtime.functions.base.Functions.FunctionNames.atan2;
@@ -335,6 +337,7 @@ public class Functions {
 
         sequenceTypes.put("object", new SequenceType(itemTypes.get("object"), SequenceType.Arity.One));
         sequenceTypes.put("object+", new SequenceType(itemTypes.get("object"), SequenceType.Arity.OneOrMore));
+        sequenceTypes.put("object*", new SequenceType(itemTypes.get("object"), SequenceType.Arity.ZeroOrMore));
 
         sequenceTypes.put("array?", new SequenceType(itemTypes.get("array"), SequenceType.Arity.OneOrZero));
 
@@ -532,6 +535,7 @@ public class Functions {
 
         builtInFunctions.put(get_transformer.getIdentifier(), get_transformer);
         builtInFunctions.put(get_estimator.getIdentifier(), get_estimator);
+        builtInFunctions.put(annotate.getIdentifier(), annotate);
     }
 
     static {
@@ -2102,6 +2106,18 @@ public class Functions {
             "item",
             GetEstimatorFunctionIterator.class,
             BuiltinFunction.BuiltinFunctionExecutionMode.LOCAL
+        );
+
+        /**
+         * function converts given RDD or local data to a DataFrame using a schema
+         */
+        static final BuiltinFunction annotate = createBuiltinFunction(
+            "annotate",
+            "object*",
+            "object",
+            "item*", // TODO: revert back to ObjectItem when TypePromotoionIter. has DF implementation
+            AnnotateFunctionIterator.class,
+            BuiltinFunction.BuiltinFunctionExecutionMode.DATAFRAME
         );
     }
 }

--- a/src/main/java/sparksoniq/semantics/types/ItemType.java
+++ b/src/main/java/sparksoniq/semantics/types/ItemType.java
@@ -153,7 +153,7 @@ public class ItemType implements Serializable {
 
     @Override
     public String toString() {
-        switch (type) {
+        switch (this.type) {
             case Item:
                 return "item";
             case IntegerItem:

--- a/src/main/java/sparksoniq/spark/DataFrameUtils.java
+++ b/src/main/java/sparksoniq/spark/DataFrameUtils.java
@@ -1,0 +1,116 @@
+package sparksoniq.spark;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.rumbledb.api.Item;
+import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.exceptions.MLInvalidDataFrameSchemaException;
+import org.rumbledb.items.ObjectItem;
+import org.rumbledb.items.parsing.ItemParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DataFrameUtils {
+    public static Dataset<Row> convertItemRDDToDataFrame(
+            JavaRDD<Item> itemRDD,
+            ObjectItem schemaItem,
+            ExceptionMetadata metadata
+    ) {
+        validateSchemaAgainstData(schemaItem, (ObjectItem) itemRDD.take(1).get(0), metadata);
+        StructType schema = generateSchemaFromSchemaItem(schemaItem, metadata);
+        JavaRDD<Row> rowRDD = itemRDD.map((Function<Item, Row>) item -> ItemParser.getRowFromItem(item));
+        try {
+            return SparkSessionManager.getInstance().getOrCreateSession().createDataFrame(rowRDD, schema);
+        } catch (IllegalArgumentException ex) {
+            throw new MLInvalidDataFrameSchemaException(ex.getMessage(), metadata);
+        }
+    }
+
+    public static Dataset<Row> convertLocalItemsToDataFrame(
+            List<Item> items,
+            ObjectItem schemaItem,
+            ExceptionMetadata metadata
+    ) {
+        validateSchemaAgainstData(schemaItem, (ObjectItem) items.get(0), metadata);
+        StructType schema = generateSchemaFromSchemaItem(schemaItem, metadata);
+        List<Row> rows = ItemParser.getRowsFromItems(items);
+        try {
+            return SparkSessionManager.getInstance().getOrCreateSession().createDataFrame(rows, schema);
+        } catch (IllegalArgumentException ex) {
+            throw new MLInvalidDataFrameSchemaException(ex.getMessage(), metadata);
+        }
+    }
+
+    private static void validateSchemaAgainstData(
+            ObjectItem schemaItem,
+            ObjectItem dataItem,
+            ExceptionMetadata metadata
+    ) {
+        for (String schemaColumn : schemaItem.getKeys()) {
+            if (!dataItem.getKeys().contains(schemaColumn)) {
+                throw new MLInvalidDataFrameSchemaException(
+                        "annotate() schema must fully match the columns of input data",
+                        metadata
+                );
+            }
+        }
+        for (String dataColumn : dataItem.getKeys()) {
+            if (!schemaItem.getKeys().contains(dataColumn)) {
+                throw new MLInvalidDataFrameSchemaException(
+                        "annotate() schema must fully match the columns of input data",
+                        metadata
+                );
+            }
+        }
+    }
+
+    private static StructType generateSchemaFromSchemaItem(ObjectItem schemaItem, ExceptionMetadata metadata) {
+        List<StructField> fields = new ArrayList<>();
+        try {
+            for (String columnName : schemaItem.getKeys()) {
+                String itemTypeName = schemaItem.getItemByKey(columnName).getStringValue();
+                StructField field = DataTypes.createStructField(
+                    columnName,
+                    getDataTypeFromItemTypeName(itemTypeName),
+                    true
+                );
+                fields.add(field);
+            }
+        } catch (RuntimeException ex) {
+            throw new MLInvalidDataFrameSchemaException(
+                    "Unexpected item type found in the annotate() schema",
+                    metadata
+            );
+        }
+        return DataTypes.createStructType(fields);
+    }
+
+    private static DataType getDataTypeFromItemTypeName(String itemTypeName) {
+        if (itemTypeName.equals("boolean")) {
+            return DataTypes.BooleanType;
+        } else if (itemTypeName.equals("integer")) {
+            return DataTypes.IntegerType;
+        } else if (itemTypeName.equals("double")) {
+            return DataTypes.DoubleType;
+        } else if (itemTypeName.equals("decimal")) {
+            return DataTypes.DoubleType;
+        } else if (itemTypeName.equals("string")) {
+            return DataTypes.StringType;
+        } else if (itemTypeName.equals("null")) {
+            return DataTypes.NullType;
+        } else if (itemTypeName.equals("date")) {
+            return DataTypes.DateType;
+        } else if (itemTypeName.equals("datetime")) {
+            return DataTypes.TimestampType;
+        } else {
+            throw new RuntimeException("Unexpected item type found.");
+        }
+    }
+}

--- a/src/main/java/sparksoniq/spark/ml/AnnotateFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/AnnotateFunctionIterator.java
@@ -1,0 +1,67 @@
+package sparksoniq.spark.ml;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.rumbledb.api.Item;
+import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.exceptions.UnexpectedTypeException;
+import org.rumbledb.items.ObjectItem;
+import org.rumbledb.runtime.DataFrameRuntimeIterator;
+import org.rumbledb.runtime.RuntimeIterator;
+import sparksoniq.jsoniq.ExecutionMode;
+import sparksoniq.semantics.DynamicContext;
+import sparksoniq.spark.DataFrameUtils;
+
+import java.util.List;
+
+public class AnnotateFunctionIterator extends DataFrameRuntimeIterator {
+
+    private static final long serialVersionUID = 1L;
+
+    public AnnotateFunctionIterator(
+            List<RuntimeIterator> arguments,
+            ExecutionMode executionMode,
+            ExceptionMetadata iteratorMetadata
+    ) {
+        super(arguments, executionMode, iteratorMetadata);
+    }
+
+    @Override
+    public Dataset<Row> getDataFrame(DynamicContext context) {
+        RuntimeIterator inputDataIterator = this.children.get(0);
+        RuntimeIterator schemaIterator = this.children.get(1);
+        ObjectItem schemaItem;
+
+        // materialize singleton pattern
+        schemaIterator.open(context);
+        if (!schemaIterator.hasNext()) {
+            throw new UnexpectedTypeException(
+                    "Schema provided to annotate function can not be an empty sequence.",
+                    getMetadata()
+            );
+        }
+        schemaItem = (ObjectItem) schemaIterator.next();
+        if (schemaIterator.hasNext()) {
+            throw new UnexpectedTypeException(
+                    "Schema provided to annotate function must be a singleton object.",
+                    getMetadata()
+            );
+        }
+        schemaIterator.close();
+
+        if (inputDataIterator.isDataFrame()) {
+            // TODO: perform type checking and throw exception if it does not match the given dataframe
+            return inputDataIterator.getDataFrame(context);
+        }
+
+        if (inputDataIterator.isRDD()) {
+            JavaRDD<Item> rdd = inputDataIterator.getRDD(context);
+            return DataFrameUtils.convertItemRDDToDataFrame(rdd, schemaItem, getMetadata());
+        }
+
+        List<Item> items = inputDataIterator.materialize(context);;
+        return DataFrameUtils.convertLocalItemsToDataFrame(items, schemaItem, getMetadata());
+    }
+
+}

--- a/src/main/java/sparksoniq/spark/ml/ApplyEstimatorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/ApplyEstimatorRuntimeIterator.java
@@ -9,6 +9,7 @@ import org.rumbledb.api.Item;
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.InvalidRumbleMLParamException;
 import org.rumbledb.exceptions.IteratorFlowException;
+import org.rumbledb.exceptions.MLNotADataFrameException;
 import org.rumbledb.exceptions.OurBadException;
 import org.rumbledb.items.FunctionItem;
 import org.rumbledb.runtime.LocalRuntimeIterator;
@@ -79,9 +80,24 @@ public class ApplyEstimatorRuntimeIterator extends LocalRuntimeIterator {
     }
 
     private Dataset<Row> getInputDataset(DynamicContext context) {
-        return context.getDataFrameVariableValue(
-            GetEstimatorFunctionIterator.estimatorFunctionParameterNames.get(0),
-            getMetadata()
+        String estimatorInputVariableName = GetEstimatorFunctionIterator.estimatorFunctionParameterNames.get(0);
+
+        if (!context.contains(estimatorInputVariableName)) {
+            throw new OurBadException("Estimator's input data is not available in the dynamic context");
+        }
+
+        if (context.isDataFrame(estimatorInputVariableName, getMetadata())) {
+            return context.getDataFrameVariableValue(
+                estimatorInputVariableName,
+                getMetadata()
+            );
+        }
+
+        throw new MLNotADataFrameException(
+                "Estimators operate on DataFrames. "
+                    +
+                    "Please consider using 'annotate' built-in function to generate a DataFrame.",
+                getMetadata()
         );
     }
 

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-AtomicTypes1.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-AtomicTypes1.jq
@@ -1,0 +1,16 @@
+(:JIQS: ShouldRun; Output="({ "id" : 1, "age" : 20, "weight" : 68.8, "name" : "a", "isAlien" : null, "isAlive" : true }, { "id" : 2, "age" : 35, "weight" : 72.4, "name" : "a", "isAlien" : null, "isAlive" : true }, { "id" : 3, "age" : 50, "weight" : 76.3, "name" : "a", "isAlien" : null, "isAlive" : true })" :)
+annotate(
+    (
+        {"id": 1, "age":  20, "weight": 68.8, "name": "a", "isAlien": null, "isAlive": true},
+        {"id": 2, "age":  35, "weight": 72.4, "name": "a", "isAlien": null, "isAlive": true},
+        {"id": 3, "age":  50, "weight": 76.3, "name": "a", "isAlien": null, "isAlive": true}
+    ),
+    {
+        "id": "integer",
+        "age": "integer",
+        "weight": "double",
+        "name": "string",
+        "isAlien": "null",
+        "isAlive": "boolean"
+    }
+)

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-AtomicTypes2.jq.disabled
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-AtomicTypes2.jq.disabled
@@ -1,0 +1,20 @@
+(:JIQS: ShouldRun; Output="" :)
+annotate(
+    (
+        {"id": 1, "age":  20, "weight": 68.8, "name": "a", "isAlien": null, "isAlive": true, "birthDate": date("2004-04-12"), "birthDateTime": dateTime("2004-04-12T13:20:00")},
+        {"id": 2, "age":  35, "weight": 72.4, "name": "a", "isAlien": null, "isAlive": true, "birthDate": date("2004-04-12"), "birthDateTime": dateTime("2004-04-12T13:20:00")},
+        {"id": 3, "age":  50, "weight": 76.3, "name": "a", "isAlien": null, "isAlive": true, "birthDate": date("2004-04-12"), "birthDateTime": dateTime("2004-04-12T13:20:00")}
+    ),
+    {
+        "id": "integer",
+        "age": "integer",
+        "weight": "double",
+        "name": "string",
+        "isAlien": "null",
+        "isAlive": "boolean",
+        "birthDate": "date",
+        "birthDateTime": "datetime"
+    }
+)
+
+(: disabled due to lack of support for date-related atomic types :)

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-SchemaError1.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-SchemaError1.jq
@@ -1,0 +1,11 @@
+(:JIQS: ShouldCrash; ErrorCode="RBML0005"; :)
+annotate(
+    (
+        {"id": 1, "age":  20, "weight": 68.8},
+        {"id": 2, "age":  35, "weight": 72.4},
+        {"id": 3, "age":  50, "weight": 76.3}
+    ),
+    {"id": "integer", "age": "integer", "weight": "double", "name": "string"}
+)
+
+(: schema has extra fields :)

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-SchemaError2.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-SchemaError2.jq
@@ -1,0 +1,11 @@
+(:JIQS: ShouldCrash; ErrorCode="RBML0005"; :)
+annotate(
+    (
+        {"id": 1, "age":  20, "weight": 68.8},
+        {"id": 2, "age":  35, "weight": 72.4},
+        {"id": 3, "age":  50, "weight": 76.3}
+    ),
+    {"id": "integer", "age": "integer" }
+)
+
+(: schema missing a field :)

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-SchemaError3.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-SchemaError3.jq
@@ -1,0 +1,11 @@
+(:JIQS: ShouldCrash; ErrorCode="RBML0005"; :)
+annotate(
+    (
+        {"id": 1, "age":  20, "weight": 68.8},
+        {"id": 2, "age":  35, "weight": 72.4},
+        {"id": 3, "age":  50, "weight": 76.3}
+    ),
+    {"id": "int", "age": "str", "weight": "dou"}
+)
+
+(: schema has unexpected types :)

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-SchemaError4.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-SchemaError4.jq
@@ -1,0 +1,11 @@
+(:JIQS: ShouldCrash; ErrorCode="RBML0005"; :)
+annotate(
+    (
+        {"id": 1, "age":  20, "weight": 68.8},
+        {"id": 2, "age":  35, "weight": 72.4},
+        {"id": 3, "age":  50, "weight": 76.3}
+    ),
+    {"id": "integer", "age": "string", "weight": "double"}
+)
+
+(: schema has incorrect type :)

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-Transformer1.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal-Transformer1.jq
@@ -1,0 +1,13 @@
+(:JIQS: ShouldRun; Output="({ "id" : 1, "age" : 20, "weight" : 68.8, "features" : [ 20, 68.8 ] }, { "id" : 2, "age" : 35, "weight" : 72.4, "features" : [ 35, 72.4 ] }, { "id" : 3, "age" : 50, "weight" : 76.3, "features" : [ 50, 76.3 ] })" :)
+let $transformer := get-transformer("VectorAssembler")
+let $local-data := (
+   {"id": 1, "age":  20, "weight": 68.8},
+   {"id": 2, "age":  35, "weight": 72.4},
+   {"id": 3, "age":  50, "weight": 76.3}
+)
+let $df-data := annotate($local-data, {"id": "integer", "age": "integer", "weight": "double"})
+for $i in $transformer(
+  $df-data,
+  {"inputCols": ["age", "weight"], "outputCol": "features"}
+)
+return $i

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal1.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateLocal1.jq
@@ -1,0 +1,9 @@
+(:JIQS: ShouldRun; Output="({ "id" : 1, "age" : 20, "weight" : 68.8 }, { "id" : 2, "age" : 35, "weight" : 72.4 }, { "id" : 3, "age" : 50, "weight" : 76.3 })" :)
+annotate(
+    (
+        {"id": 1, "age":  20, "weight": 68.8},
+        {"id": 2, "age":  35, "weight": 72.4},
+        {"id": 3, "age":  50, "weight": 76.3}
+    ),
+    {"id": "integer", "age": "integer", "weight": "double"}
+)

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateRDD-Estimator-Error1.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateRDD-Estimator-Error1.jq
@@ -1,0 +1,10 @@
+(:JIQS: ShouldCrash; ErrorCode="RBML0004"; :)
+let $estimator := get-estimator("KMeans")
+let $rdd-data := json-file("./src/main/resources/queries/rumbleML/sample-ml-age-weight-data.json")
+return ($estimator(
+    $rdd-data,
+    {
+        "k": 2,
+        "seed": 1
+    }
+))

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateRDD-Transformer-Error1.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateRDD-Transformer-Error1.jq
@@ -1,0 +1,8 @@
+(:JIQS: ShouldCrash; ErrorCode="RBML0004"; :)
+let $transformer := get-transformer("VectorAssembler")
+let $rdd-data := json-file("./src/main/resources/queries/rumbleML/sample-ml-age-weight-data.json")
+for $i in $transformer(
+  $rdd-data,
+  {"inputCols": ["age", "weight"], "outputCol": "features"}
+)
+return $i

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateRDD-Transformer1.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateRDD-Transformer1.jq
@@ -1,0 +1,9 @@
+(:JIQS: ShouldRun; Output="({ "id" : 1, "age" : 20, "weight" : 68.8, "features" : [ 20, 68.8 ] }, { "id" : 2, "age" : 35, "weight" : 72.4, "features" : [ 35, 72.4 ] }, { "id" : 3, "age" : 50, "weight" : 76.3, "features" : [ 50, 76.3 ] })" :)
+let $transformer := get-transformer("VectorAssembler")
+let $rdd-data := json-file("./src/main/resources/queries/rumbleML/sample-ml-age-weight-data.json")
+let $df-data := annotate($rdd-data, {"id": "integer", "age": "integer", "weight": "double"})
+for $i in $transformer(
+  $df-data,
+  {"inputCols": ["age", "weight"], "outputCol": "features"}
+)
+return $i

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateRDD1.jq
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLAnnotateRDD1.jq
@@ -1,0 +1,5 @@
+(:JIQS: ShouldRun; Output="({ "id" : 1, "age" : 20, "weight" : 68.8 }, { "id" : 2, "age" : 35, "weight" : 72.4 }, { "id" : 3, "age" : 50, "weight" : 76.3 })" :)
+annotate(
+    json-file("./src/main/resources/queries/rumbleML/sample-ml-age-weight-data.json"),
+    {"id": "integer", "age": "integer", "weight": "double"}
+)

--- a/src/main/resources/test_files/runtime-spark/RumbleML/MLTransformer-Multiple1.jq.disabled
+++ b/src/main/resources/test_files/runtime-spark/RumbleML/MLTransformer-Multiple1.jq.disabled
@@ -1,8 +1,8 @@
 (:JIQS: ShouldRun; Output="" :)
 let $tokenizer := get-transformer("Tokenizer")
 let $hashingTF := get-transformer("HashingTF")
-let $data := (structured-json-file("./src/main/resources/queries/rumbleML/sample-ml-numeric-data.json"))
-let $intermediate := $tokenizer($data, {"inputCol": "values", "outputCol": "output"})
+let $data := structured-json-file("./src/main/resources/queries/rumbleML/sample-ml-string-data.json")
+let $intermediate := $tokenizer($data, {"inputCol": "sentence", "outputCol": "output"})
 return $hashingTF($intermediate, {"inputCol": "output", "numFeatures": 2})
 
 (: transformer chaining is not supported atm - RDD needs to be converted into DF prior to transformer.transform() call:)


### PR DESCRIPTION
~@ghislainfourny I have recently been working on item to native java type conversions. We need this to outsource the computation to the SparkML framework, as it would not be able to operate on rumble items. The conversion of common atomic items is already in place. I was hoping I could get your feedback in this week's meeting before moving on to the complex types.~

Edit: annotate(object*, object) as object* is designed to facilitate passing items to SparkML components.
Given sequence of items are converted to a DataFrame of items using the given schema. This underlying implementation detail needs to be exposed for the time being until full schema support is added to Rumble