### PR TITLE
Simplify expression tree.

### DIFF
--- a/src/main/java/org/rumbledb/api/Rumble.java
+++ b/src/main/java/org/rumbledb/api/Rumble.java
@@ -5,14 +5,15 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.rumbledb.compiler.TranslationVisitor;
+import org.rumbledb.compiler.VisitorHelpers;
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.ParsingException;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.parser.JsoniqLexer;
 import org.rumbledb.parser.JsoniqParser;
-import sparksoniq.jsoniq.compiler.JsoniqExpressionTreeVisitor;
+
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
-import sparksoniq.semantics.visitor.VisitorHelpers;
 import sparksoniq.spark.SparkSessionManager;
 
 /**
@@ -50,7 +51,7 @@ public class Rumble {
         JsoniqLexer lexer = new JsoniqLexer(charStream);
         JsoniqParser parser = new JsoniqParser(new CommonTokenStream(lexer));
         parser.setErrorHandler(new BailErrorStrategy());
-        JsoniqExpressionTreeVisitor visitor = new JsoniqExpressionTreeVisitor();
+        TranslationVisitor visitor = new TranslationVisitor();
         try {
             // TODO Handle module extras
             JsoniqParser.ModuleContext module = parser.module();

--- a/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
@@ -18,11 +18,12 @@
  *
  */
 
-package sparksoniq.semantics.visitor;
+package org.rumbledb.compiler;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.UnknownFunctionCallException;
 import org.rumbledb.exceptions.UnsupportedFeatureException;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.CommaExpression;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
@@ -615,309 +616,264 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
     // region operational
     @Override
     public RuntimeIterator visitAdditiveExpr(AdditiveExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator left, right;
-            // convert nary to tree of iterators
-            if (expression.getOperators().size() > 1) {
-                right = this.visit(
-                    expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
-                    argument
-                );
-                AdditiveExpression remainingExpressions = new AdditiveExpression(
-                        expression.getMainExpression(),
-                        expression.getRightExpressions().subList(0, expression.getRightExpressions().size() - 1),
-                        expression.getOperators().subList(0, expression.getOperators().size() - 1),
-                        expression.getMetadata()
-                );
-                remainingExpressions.initHighestExecutionMode();
-                left = this.visit(
-                    remainingExpressions,
-                    argument
-                );
-            } else {
-                left = this.visit(expression.getMainExpression(), argument);
-                right = this.visit(expression.getRightExpressions().get(0), argument);
-            }
-
-            return new AdditiveOperationIterator(
-                    left,
-                    right,
-                    expression.getOperators().get(expression.getOperators().size() - 1),
-                    expression.getHighestExecutionMode(),
+        RuntimeIterator left, right;
+        // convert nary to tree of iterators
+        if (expression.getOperators().size() > 1) {
+            right = this.visit(
+                expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
+                argument
+            );
+            AdditiveExpression remainingExpressions = new AdditiveExpression(
+                    expression.getMainExpression(),
+                    expression.getRightExpressions().subList(0, expression.getRightExpressions().size() - 1),
+                    expression.getOperators().subList(0, expression.getOperators().size() - 1),
                     expression.getMetadata()
             );
+            remainingExpressions.initHighestExecutionMode();
+            left = this.visit(
+                remainingExpressions,
+                argument
+            );
+        } else {
+            left = this.visit(expression.getMainExpression(), argument);
+            right = this.visit(expression.getRightExpressions().get(0), argument);
         }
-        return defaultAction(expression, argument);
+
+        return new AdditiveOperationIterator(
+                left,
+                right,
+                expression.getOperators().get(expression.getOperators().size() - 1),
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitMultiplicativeExpr(MultiplicativeExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator left, right;
-            // convert nary to tree of iterators
-            if (expression.getOperators().size() > 1) {
-                right = this.visit(
-                    expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
-                    argument
-                );
-                MultiplicativeExpression remainingExpressions = new MultiplicativeExpression(
-                        expression.getMainExpression(),
-                        expression.getRightExpressions().subList(0, expression.getRightExpressions().size() - 1),
-                        expression.getOperators().subList(0, expression.getOperators().size() - 1),
-                        expression.getMetadata()
-                );
-                remainingExpressions.initHighestExecutionMode();
-                left = this.visit(
-                    remainingExpressions,
-                    argument
-                );
-            } else {
-                left = this.visit(expression.getMainExpression(), argument);
-                right = this.visit(expression.getRightExpressions().get(0), argument);
-            }
-
-            return new MultiplicativeOperationIterator(
-                    left,
-                    right,
-                    expression.getOperators().get(expression.getOperators().size() - 1),
-                    expression.getHighestExecutionMode(),
+        RuntimeIterator left, right;
+        // convert nary to tree of iterators
+        if (expression.getOperators().size() > 1) {
+            right = this.visit(
+                expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
+                argument
+            );
+            MultiplicativeExpression remainingExpressions = new MultiplicativeExpression(
+                    expression.getMainExpression(),
+                    expression.getRightExpressions().subList(0, expression.getRightExpressions().size() - 1),
+                    expression.getOperators().subList(0, expression.getOperators().size() - 1),
                     expression.getMetadata()
             );
+            remainingExpressions.initHighestExecutionMode();
+            left = this.visit(
+                remainingExpressions,
+                argument
+            );
+        } else {
+            left = this.visit(expression.getMainExpression(), argument);
+            right = this.visit(expression.getRightExpressions().get(0), argument);
         }
-        return defaultAction(expression, argument);
+
+        return new MultiplicativeOperationIterator(
+                left,
+                right,
+                expression.getOperators().get(expression.getOperators().size() - 1),
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitAndExpr(AndExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator left, right;
-            // convert nary to tree of iterators
-            if (expression.getRightExpressions().size() > 1) {
-                right = this.visit(
-                    expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
-                    argument
-                );
-                AndExpression remainingExpressiongs = new AndExpression(
-                        expression.getMainExpression(),
-                        expression.getRightExpressions().subList(0, expression.getRightExpressions().size() - 1),
-                        expression.getMetadata()
-                );
-                remainingExpressiongs.initHighestExecutionMode();
-                left = this.visit(
-                    remainingExpressiongs,
-                    argument
-                );
-            } else {
-                left = this.visit(expression.getMainExpression(), argument);
-                right = this.visit(expression.getRightExpressions().get(0), argument);
-            }
-
-            return new AndOperationIterator(
-                    left,
-                    right,
-                    expression.getHighestExecutionMode(),
+        RuntimeIterator left, right;
+        // convert nary to tree of iterators
+        if (expression.getRightExpressions().size() > 1) {
+            right = this.visit(
+                expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
+                argument
+            );
+            AndExpression remainingExpressiongs = new AndExpression(
+                    expression.getMainExpression(),
+                    expression.getRightExpressions().subList(0, expression.getRightExpressions().size() - 1),
                     expression.getMetadata()
             );
+            remainingExpressiongs.initHighestExecutionMode();
+            left = this.visit(
+                remainingExpressiongs,
+                argument
+            );
+        } else {
+            left = this.visit(expression.getMainExpression(), argument);
+            right = this.visit(expression.getRightExpressions().get(0), argument);
         }
-        return defaultAction(expression, argument);
+
+        return new AndOperationIterator(
+                left,
+                right,
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitOrExpr(OrExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator left, right;
-            // convert nary to tree of iterators
-            if (expression.getRightExpressions().size() > 1) {
-                right = this.visit(
-                    expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
-                    argument
-                );
-                OrExpression remainingExpressions = new OrExpression(
-                        expression.getMainExpression(),
-                        expression.getRightExpressions()
-                            .subList(0, expression.getRightExpressions().size() - 1),
-                        expression.getMetadata()
-                );
-                remainingExpressions.initHighestExecutionMode();
-                left = this.visit(
-                    remainingExpressions,
-                    argument
-                );
-            } else {
-                left = this.visit(expression.getMainExpression(), argument);
-                right = this.visit(expression.getRightExpressions().get(0), argument);
-            }
-
-            return new OrOperationIterator(
-                    left,
-                    right,
-                    expression.getHighestExecutionMode(),
+        RuntimeIterator left, right;
+        // convert nary to tree of iterators
+        if (expression.getRightExpressions().size() > 1) {
+            right = this.visit(
+                expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
+                argument
+            );
+            OrExpression remainingExpressions = new OrExpression(
+                    expression.getMainExpression(),
+                    expression.getRightExpressions()
+                        .subList(0, expression.getRightExpressions().size() - 1),
                     expression.getMetadata()
             );
+            remainingExpressions.initHighestExecutionMode();
+            left = this.visit(
+                remainingExpressions,
+                argument
+            );
+        } else {
+            left = this.visit(expression.getMainExpression(), argument);
+            right = this.visit(expression.getRightExpressions().get(0), argument);
         }
-        return defaultAction(expression, argument);
+
+        return new OrOperationIterator(
+                left,
+                right,
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitNotExpr(NotExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            return new NotOperationIterator(
-                    this.visit(expression.getMainExpression(), argument),
-                    expression.getHighestExecutionMode(),
-                    expression.getMetadata()
-            );
-        }
-        return defaultAction(expression, argument);
+        return new NotOperationIterator(
+                this.visit(expression.getMainExpression(), argument),
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitUnaryExpr(UnaryExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            // compute +- final result
-            int result = 1;
-            for (OperationalExpressionBase.Operator op : expression.getOperators()) {
-                if (op == OperationalExpressionBase.Operator.MINUS) {
-                    result *= -1;
-                }
+        // compute +- final result
+        int result = 1;
+        for (OperationalExpressionBase.Operator op : expression.getOperators()) {
+            if (op == OperationalExpressionBase.Operator.MINUS) {
+                result *= -1;
             }
-            return new UnaryOperationIterator(
-                    this.visit(expression.getMainExpression(), argument),
-                    result == -1 ? OperationalExpressionBase.Operator.MINUS : OperationalExpressionBase.Operator.PLUS,
-                    expression.getHighestExecutionMode(),
-                    expression.getMetadata()
-            );
         }
-        return defaultAction(expression, argument);
+        return new UnaryOperationIterator(
+                this.visit(expression.getMainExpression(), argument),
+                result == -1 ? OperationalExpressionBase.Operator.MINUS : OperationalExpressionBase.Operator.PLUS,
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitRangeExpr(RangeExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator left = this.visit(expression.getMainExpression(), argument);
-            RuntimeIterator right = this.visit(expression.getRightExpression(), argument);
-            return new RangeOperationIterator(
-                    left,
-                    right,
-                    expression.getHighestExecutionMode(),
-                    expression.getMetadata()
-            );
-        } else {
-            return defaultAction(expression, argument);
-        }
+        RuntimeIterator left = this.visit(expression.getMainExpression(), argument);
+        RuntimeIterator right = this.visit(expression.getRightExpression(), argument);
+        return new RangeOperationIterator(
+                left,
+                right,
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitComparisonExpr(ComparisonExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator left = this.visit(expression.getMainExpression(), argument);
-            RuntimeIterator right = this.visit(expression.getRightExpression(), argument);
-            return new ComparisonOperationIterator(
-                    left,
-                    right,
-                    expression.getOperator(),
-                    expression.getHighestExecutionMode(),
-                    expression.getMetadata()
-            );
-        } else {
-            return defaultAction(expression, argument);
-        }
+        RuntimeIterator left = this.visit(expression.getMainExpression(), argument);
+        RuntimeIterator right = this.visit(expression.getRightExpression(), argument);
+        return new ComparisonOperationIterator(
+                left,
+                right,
+                expression.getOperator(),
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitStringConcatExpr(StringConcatExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator left, right;
-            // convert nary to tree of iterators
-            if (expression.getRightExpressions().size() > 1) {
-                right = this.visit(
-                    expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
-                    argument
-                );
-                StringConcatExpression remainingExpressions = new StringConcatExpression(
-                        expression.getMainExpression(),
-                        expression.getRightExpressions()
-                            .subList(0, expression.getRightExpressions().size() - 1),
-                        expression.getMetadata()
-                );
-                remainingExpressions.initHighestExecutionMode();
-                left = this.visit(
-                    remainingExpressions,
-                    argument
-                );
-            } else {
-                left = this.visit(expression.getMainExpression(), argument);
-                right = this.visit(expression.getRightExpressions().get(0), argument);
-            }
-
-            return new StringConcatIterator(
-                    left,
-                    right,
-                    expression.getHighestExecutionMode(),
+        RuntimeIterator left, right;
+        // convert nary to tree of iterators
+        if (expression.getRightExpressions().size() > 1) {
+            right = this.visit(
+                expression.getRightExpressions().get(expression.getRightExpressions().size() - 1),
+                argument
+            );
+            StringConcatExpression remainingExpressions = new StringConcatExpression(
+                    expression.getMainExpression(),
+                    expression.getRightExpressions()
+                        .subList(0, expression.getRightExpressions().size() - 1),
                     expression.getMetadata()
             );
+            remainingExpressions.initHighestExecutionMode();
+            left = this.visit(
+                remainingExpressions,
+                argument
+            );
+        } else {
+            left = this.visit(expression.getMainExpression(), argument);
+            right = this.visit(expression.getRightExpressions().get(0), argument);
         }
-        return defaultAction(expression, argument);
+
+        return new StringConcatIterator(
+                left,
+                right,
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitInstanceOfExpression(InstanceOfExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
-            return new InstanceOfIterator(
-                    childExpression,
-                    expression.getsequenceType().getSequence(),
-                    expression.getHighestExecutionMode(),
-                    expression.getMetadata()
-            );
-        } else {
-            return defaultAction(expression, argument);
-        }
+        RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
+        return new InstanceOfIterator(
+                childExpression,
+                expression.getsequenceType().getSequence(),
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitTreatExpression(TreatExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
-            return new TreatIterator(
-                    childExpression,
-                    expression.getsequenceType().getSequence(),
-                    true,
-                    expression.getHighestExecutionMode(),
-                    expression.getMetadata()
-            );
-        } else {
-            return defaultAction(expression, argument);
-        }
+        RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
+        return new TreatIterator(
+                childExpression,
+                expression.getsequenceType().getSequence(),
+                true,
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitCastableExpression(CastableExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
-            return new CastableIterator(
-                    childExpression,
-                    expression.getAtomicType().getSingleType(),
-                    expression.getHighestExecutionMode(),
-                    expression.getMetadata()
-            );
-        } else {
-            return defaultAction(expression, argument);
-        }
+        RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
+        return new CastableIterator(
+                childExpression,
+                expression.getAtomicType().getSingleType(),
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
 
     @Override
     public RuntimeIterator visitCastExpression(CastExpression expression, RuntimeIterator argument) {
-        if (expression.isActive()) {
-            RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
-            return new CastIterator(
-                    childExpression,
-                    expression.getFlworVarSingleType().getSingleType(),
-                    expression.getHighestExecutionMode(),
-                    expression.getMetadata()
-            );
-        } else {
-            return defaultAction(expression, argument);
-        }
+        RuntimeIterator childExpression = this.visit(expression.getMainExpression(), argument);
+        return new CastIterator(
+                childExpression,
+                expression.getFlworVarSingleType().getSingleType(),
+                expression.getHighestExecutionMode(),
+                expression.getMetadata()
+        );
     }
     // endregion
 

--- a/src/main/java/org/rumbledb/compiler/StaticContextVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/StaticContextVisitor.java
@@ -18,9 +18,10 @@
  *
  */
 
-package sparksoniq.semantics.visitor;
+package org.rumbledb.compiler;
 
 import org.rumbledb.exceptions.UndeclaredVariableException;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.control.TypeSwitchCaseExpression;

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -506,7 +506,7 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
         List<Expression> rhs = new ArrayList<>();
         this.visitNotExpr(ctx.main_expr);
         if (!(ctx.rhs == null) && !ctx.rhs.isEmpty()) {
-            mainExpression = (NotExpression) this.currentExpression;
+            mainExpression = this.currentExpression;
             for (JsoniqParser.NotExprContext child : ctx.rhs) {
                 this.visitNotExpr(child);
                 rhs.add(this.currentExpression);
@@ -885,7 +885,6 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
 
     @Override
     public Void visitArrayConstructor(JsoniqParser.ArrayConstructorContext ctx) {
-        ArrayConstructorExpression node;
         Expression content;
         if (ctx.expr() == null)
             this.currentExpression = new ArrayConstructorExpression(createMetadataFromContext(ctx));
@@ -956,7 +955,6 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
 
     @Override
     public Void visitSingleType(JsoniqParser.SingleTypeContext ctx) {
-        FlworVarSingleType node;
         if (ctx.item == null)
             this.currentExpression = new FlworVarSingleType(createMetadataFromContext(ctx));
         else {
@@ -1052,7 +1050,6 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
                 mostGeneralSequenceType,
                 createMetadataFromContext(ctx)
         );
-        CommaExpression fnBody;
         String paramName;
         FlworVarSequenceType paramType;
         if (ctx.paramList() != null) {

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -506,7 +506,7 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
         List<Expression> rhs = new ArrayList<>();
         this.visitNotExpr(ctx.main_expr);
         if (!(ctx.rhs == null) && !ctx.rhs.isEmpty()) {
-        	mainExpression = (NotExpression) this.currentExpression;
+            mainExpression = (NotExpression) this.currentExpression;
             for (JsoniqParser.NotExprContext child : ctx.rhs) {
                 this.visitNotExpr(child);
                 rhs.add(this.currentExpression);
@@ -520,14 +520,13 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
     public Void visitNotExpr(JsoniqParser.NotExprContext ctx) {
         Expression mainExpression;
         this.visitComparisonExpr(ctx.main_expr);
-        if(!(ctx.op == null || ctx.op.isEmpty()))
-		{
+        if (!(ctx.op == null || ctx.op.isEmpty())) {
             mainExpression = this.currentExpression;
-	        this.currentExpression = new NotExpression(
-	                mainExpression,
-	                createMetadataFromContext(ctx)
-	        );
-		}
+            this.currentExpression = new NotExpression(
+                    mainExpression,
+                    createMetadataFromContext(ctx)
+            );
+        }
         return null;
     }
 
@@ -615,7 +614,7 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
         List<Expression> rhs = new ArrayList<>();
         this.visitInstanceOfExpr(ctx.main_expr);
         if (ctx.rhs != null && !ctx.rhs.isEmpty()) {
-        	mainExpression = this.currentExpression;
+            mainExpression = this.currentExpression;
             for (JsoniqParser.InstanceOfExprContext child : ctx.rhs) {
                 this.visitInstanceOfExpr(child);
                 rhs.add(this.currentExpression);
@@ -636,7 +635,7 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
         FlworVarSequenceType sequenceType;
         this.visitTreatExpr(ctx.main_expr);
         if (ctx.seq != null && !ctx.seq.isEmpty()) {
-        	mainExpression = this.currentExpression;
+            mainExpression = this.currentExpression;
             JsoniqParser.SequenceTypeContext child = ctx.seq;
             this.visitSequenceType(child);
             sequenceType = (FlworVarSequenceType) this.currentExpression;
@@ -655,7 +654,7 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
         FlworVarSequenceType sequenceType;
         this.visitCastableExpr(ctx.main_expr);
         if (ctx.seq != null && !ctx.seq.isEmpty()) {
-        	mainExpression = this.currentExpression;
+            mainExpression = this.currentExpression;
             JsoniqParser.SequenceTypeContext child = ctx.seq;
             this.visitSequenceType(child);
             sequenceType = (FlworVarSequenceType) this.currentExpression;
@@ -698,15 +697,14 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<Vo
     public Void visitUnaryExpr(JsoniqParser.UnaryExprContext ctx) {
         Expression mainExpression;
         this.visitSimpleMapExpr(ctx.main_expr);
-        if (!(ctx.op == null || ctx.op.isEmpty()))
-		{
-			mainExpression = this.currentExpression;
+        if (!(ctx.op == null || ctx.op.isEmpty())) {
+            mainExpression = this.currentExpression;
             this.currentExpression = new UnaryExpression(
                     mainExpression,
                     OperationalExpressionBase.getOperatorFromOpList(ctx.op),
                     createMetadataFromContext(ctx)
             );
-		}
+        }
         return null;
     }
     // endregion

--- a/src/main/java/org/rumbledb/compiler/VisitorHelpers.java
+++ b/src/main/java/org/rumbledb/compiler/VisitorHelpers.java
@@ -1,4 +1,4 @@
-package sparksoniq.semantics.visitor;
+package org.rumbledb.compiler;
 
 import org.rumbledb.exceptions.DuplicateFunctionIdentifierException;
 import org.rumbledb.exceptions.OurBadException;

--- a/src/main/java/org/rumbledb/expressions/AbstractNodeVisitor.java
+++ b/src/main/java/org/rumbledb/expressions/AbstractNodeVisitor.java
@@ -18,10 +18,8 @@
  *
  */
 
-package sparksoniq.semantics.visitor;
+package org.rumbledb.expressions;
 
-import org.rumbledb.expressions.CommaExpression;
-import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.control.IfExpression;
 import org.rumbledb.expressions.control.SwitchCaseExpression;
 import org.rumbledb.expressions.control.SwitchExpression;

--- a/src/main/java/org/rumbledb/expressions/AbstractNodeVisitor.java
+++ b/src/main/java/org/rumbledb/expressions/AbstractNodeVisitor.java
@@ -56,7 +56,6 @@ import org.rumbledb.expressions.postfix.ArrayLookupExpression;
 import org.rumbledb.expressions.postfix.ArrayUnboxingExpression;
 import org.rumbledb.expressions.postfix.DynamicFunctionCallExpression;
 import org.rumbledb.expressions.postfix.ObjectLookupExpression;
-import org.rumbledb.expressions.postfix.PostfixExpression;
 import org.rumbledb.expressions.postfix.PredicateExpression;
 import org.rumbledb.expressions.primary.ArrayConstructorExpression;
 import org.rumbledb.expressions.primary.BooleanLiteralExpression;

--- a/src/main/java/org/rumbledb/expressions/CommaExpression.java
+++ b/src/main/java/org/rumbledb/expressions/CommaExpression.java
@@ -23,7 +23,6 @@ package org.rumbledb.expressions;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
 import sparksoniq.jsoniq.ExecutionMode;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/Node.java
+++ b/src/main/java/org/rumbledb/expressions/Node.java
@@ -23,7 +23,6 @@ package org.rumbledb.expressions;
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.OurBadException;
 import sparksoniq.jsoniq.ExecutionMode;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/control/IfExpression.java
+++ b/src/main/java/org/rumbledb/expressions/control/IfExpression.java
@@ -22,9 +22,9 @@ package org.rumbledb.expressions.control;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/control/SwitchCaseExpression.java
+++ b/src/main/java/org/rumbledb/expressions/control/SwitchCaseExpression.java
@@ -22,9 +22,9 @@ package org.rumbledb.expressions.control;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/control/SwitchExpression.java
+++ b/src/main/java/org/rumbledb/expressions/control/SwitchExpression.java
@@ -22,9 +22,9 @@ package org.rumbledb.expressions.control;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/control/TypeSwitchCaseExpression.java
+++ b/src/main/java/org/rumbledb/expressions/control/TypeSwitchCaseExpression.java
@@ -2,11 +2,11 @@ package org.rumbledb.expressions.control;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.flowr.FlworVarSequenceType;
 import org.rumbledb.expressions.primary.VariableReferenceExpression;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/control/TypeSwitchExpression.java
+++ b/src/main/java/org/rumbledb/expressions/control/TypeSwitchExpression.java
@@ -2,10 +2,10 @@ package org.rumbledb.expressions.control;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.primary.VariableReferenceExpression;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/CountClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/CountClause.java
@@ -21,9 +21,9 @@
 package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.primary.VariableReferenceExpression;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/FlworExpression.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/FlworExpression.java
@@ -22,10 +22,10 @@ package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.SemanticException;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import sparksoniq.jsoniq.ExecutionMode;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/FlworVarSequenceType.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/FlworVarSequenceType.java
@@ -22,12 +22,13 @@ package org.rumbledb.expressions.flowr;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
+
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 import sparksoniq.semantics.types.SequenceType;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/FlworVarSingleType.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/FlworVarSingleType.java
@@ -1,11 +1,12 @@
 package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
+
 import sparksoniq.semantics.types.AtomicTypes;
 import sparksoniq.semantics.types.SingleType;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/ForClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/ForClause.java
@@ -22,8 +22,8 @@ package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.SemanticException;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/ForClauseVar.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/ForClauseVar.java
@@ -21,12 +21,12 @@
 package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.primary.VariableReferenceExpression;
 import sparksoniq.jsoniq.ExecutionMode;
 import sparksoniq.semantics.types.SequenceType;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/GroupByClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/GroupByClause.java
@@ -22,8 +22,8 @@ package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.SemanticException;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/GroupByClauseVar.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/GroupByClauseVar.java
@@ -21,10 +21,10 @@
 package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.primary.VariableReferenceExpression;
 import sparksoniq.jsoniq.ExecutionMode;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 public class GroupByClauseVar extends FlworVarDecl {
 

--- a/src/main/java/org/rumbledb/expressions/flowr/LetClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/LetClause.java
@@ -22,8 +22,8 @@ package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.SemanticException;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/LetClauseVar.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/LetClauseVar.java
@@ -22,10 +22,10 @@ package org.rumbledb.expressions.flowr;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.primary.VariableReferenceExpression;
 import sparksoniq.jsoniq.ExecutionMode;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 
 

--- a/src/main/java/org/rumbledb/expressions/flowr/OrderByClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/OrderByClause.java
@@ -23,8 +23,8 @@ package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.SemanticException;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/OrderByClauseExpr.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/OrderByClauseExpr.java
@@ -21,10 +21,10 @@
 package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import sparksoniq.jsoniq.ExecutionMode;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/ReturnClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/ReturnClause.java
@@ -21,10 +21,10 @@
 package org.rumbledb.expressions.flowr;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import sparksoniq.jsoniq.ExecutionMode;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/flowr/WhereClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/WhereClause.java
@@ -22,9 +22,9 @@ package org.rumbledb.expressions.flowr;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/module/MainModule.java
+++ b/src/main/java/org/rumbledb/expressions/module/MainModule.java
@@ -23,7 +23,6 @@ package org.rumbledb.expressions.module;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.expressions.AbstractNodeVisitor;
-import org.rumbledb.expressions.CommaExpression;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 

--- a/src/main/java/org/rumbledb/expressions/module/MainModule.java
+++ b/src/main/java/org/rumbledb/expressions/module/MainModule.java
@@ -22,10 +22,10 @@ package org.rumbledb.expressions.module;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.CommaExpression;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/module/Prolog.java
+++ b/src/main/java/org/rumbledb/expressions/module/Prolog.java
@@ -22,10 +22,10 @@ package org.rumbledb.expressions.module;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.primary.InlineFunctionExpression;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/operational/AdditiveExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/AdditiveExpression.java
@@ -22,9 +22,9 @@ package org.rumbledb.expressions.operational;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.operational.base.NaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,11 +32,6 @@ import java.util.List;
 public class AdditiveExpression extends NaryExpressionBase {
 
     public static final Operator[] operators = new Operator[] { Operator.PLUS, Operator.MINUS };
-
-    public AdditiveExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-
-    }
 
     public AdditiveExpression(
             Expression mainExpression,

--- a/src/main/java/org/rumbledb/expressions/operational/AndExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/AndExpression.java
@@ -21,18 +21,13 @@
 package org.rumbledb.expressions.operational;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.operational.base.NaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.List;
 
 public class AndExpression extends NaryExpressionBase {
-
-    public AndExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-
-    }
 
     public AndExpression(
             Expression mainExpression,

--- a/src/main/java/org/rumbledb/expressions/operational/CastExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/CastExpression.java
@@ -1,29 +1,18 @@
 package org.rumbledb.expressions.operational;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.flowr.FlworVarSingleType;
 import org.rumbledb.expressions.operational.base.UnaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 public class CastExpression extends UnaryExpressionBase {
 
     private FlworVarSingleType singleType;
 
-    public CastExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-        this.isActive = false;
-    }
-
     public CastExpression(Expression mainExpression, FlworVarSingleType singleType, ExceptionMetadata metadata) {
-        super(mainExpression, Operator.CAST, true, metadata);
+        super(mainExpression, Operator.CAST, metadata);
         this.singleType = singleType;
-    }
-
-
-    @Override
-    public boolean isActive() {
-        return this.isActive;
     }
 
     @Override

--- a/src/main/java/org/rumbledb/expressions/operational/CastableExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/CastableExpression.java
@@ -1,29 +1,18 @@
 package org.rumbledb.expressions.operational;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.flowr.FlworVarSingleType;
 import org.rumbledb.expressions.operational.base.UnaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 public class CastableExpression extends UnaryExpressionBase {
 
     private FlworVarSingleType atomicType;
 
-    public CastableExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-        this.isActive = false;
-    }
-
     public CastableExpression(Expression mainExpression, FlworVarSingleType atomicType, ExceptionMetadata metadata) {
-        super(mainExpression, Operator.CASTABLE, true, metadata);
+        super(mainExpression, Operator.CASTABLE, metadata);
         this.atomicType = atomicType;
-    }
-
-
-    @Override
-    public boolean isActive() {
-        return this.isActive;
     }
 
     @Override

--- a/src/main/java/org/rumbledb/expressions/operational/ComparisonExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/ComparisonExpression.java
@@ -21,9 +21,9 @@
 package org.rumbledb.expressions.operational;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.operational.base.BinaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.Arrays;
 
@@ -43,10 +43,6 @@ public class ComparisonExpression extends BinaryExpressionBase {
         Operator.GC_LE,
         Operator.GC_LT };
 
-
-    public ComparisonExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-    }
 
     public ComparisonExpression(
             Expression mainExpression,

--- a/src/main/java/org/rumbledb/expressions/operational/InstanceOfExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/InstanceOfExpression.java
@@ -21,37 +21,27 @@
 package org.rumbledb.expressions.operational;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.flowr.FlworVarSequenceType;
 import org.rumbledb.expressions.operational.base.UnaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 
 public class InstanceOfExpression extends UnaryExpressionBase {
 
     private FlworVarSequenceType sequenceType;
 
-    public InstanceOfExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-        this.isActive = false;
-    }
-
     public InstanceOfExpression(
             Expression mainExpression,
             FlworVarSequenceType sequenceType,
             ExceptionMetadata metadata
     ) {
-        super(mainExpression, Operator.INSTANCE_OF, true, metadata);
+        super(mainExpression, Operator.INSTANCE_OF, metadata);
         this.sequenceType = sequenceType;
     }
 
     public FlworVarSequenceType getsequenceType() {
         return this.sequenceType;
-    }
-
-    @Override
-    public boolean isActive() {
-        return this.isActive;
     }
 
     @Override

--- a/src/main/java/org/rumbledb/expressions/operational/MultiplicativeExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/MultiplicativeExpression.java
@@ -22,9 +22,9 @@ package org.rumbledb.expressions.operational;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.operational.base.NaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,10 +38,6 @@ public class MultiplicativeExpression extends NaryExpressionBase {
         Operator.MOD,
         Operator.IDIV };
 
-
-    public MultiplicativeExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-    }
 
     public MultiplicativeExpression(
             Expression mainExpression,

--- a/src/main/java/org/rumbledb/expressions/operational/NotExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/NotExpression.java
@@ -21,16 +21,16 @@
 package org.rumbledb.expressions.operational;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.operational.base.UnaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 
 
 public class NotExpression extends UnaryExpressionBase {
 
-    public NotExpression(Expression mainExpression, boolean isActive, ExceptionMetadata metadata) {
-        super(mainExpression, Operator.NOT, isActive, metadata);
+    public NotExpression(Expression mainExpression, ExceptionMetadata metadata) {
+        super(mainExpression, Operator.NOT, metadata);
     }
 
     @Override
@@ -41,8 +41,7 @@ public class NotExpression extends UnaryExpressionBase {
     @Override
     public String serializationString(boolean prefix) {
         String result = "(notExpr ";
-        if (this.isActive())
-            result += "not ";
+        result += "not ";
         result += this.mainExpression.serializationString(true);
         result += ")";
         return result;

--- a/src/main/java/org/rumbledb/expressions/operational/OrExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/OrExpression.java
@@ -22,19 +22,14 @@ package org.rumbledb.expressions.operational;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.operational.base.NaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.List;
 
 
 public class OrExpression extends NaryExpressionBase {
-
-    public OrExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-
-    }
 
     public OrExpression(
             Expression mainExpression,

--- a/src/main/java/org/rumbledb/expressions/operational/RangeExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/RangeExpression.java
@@ -21,18 +21,13 @@
 package org.rumbledb.expressions.operational;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.operational.base.BinaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 
 
 public class RangeExpression extends BinaryExpressionBase {
-
-    public RangeExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-
-    }
 
     public RangeExpression(Expression mainExpression, Expression rhs, ExceptionMetadata metadata) {
         super(mainExpression, rhs, Operator.TO, metadata);

--- a/src/main/java/org/rumbledb/expressions/operational/StringConcatExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/StringConcatExpression.java
@@ -22,19 +22,15 @@ package org.rumbledb.expressions.operational;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.operational.base.NaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.List;
 
 public class StringConcatExpression extends NaryExpressionBase {
     public StringConcatExpression(Expression mainExpression, List<Expression> rhs, ExceptionMetadata metadata) {
         super(mainExpression, rhs, Operator.CONCAT, metadata);
-    }
-
-    public StringConcatExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/expressions/operational/TreatExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/TreatExpression.java
@@ -1,29 +1,24 @@
 package org.rumbledb.expressions.operational;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.flowr.FlworVarSequenceType;
 import org.rumbledb.expressions.operational.base.UnaryExpressionBase;
 import sparksoniq.jsoniq.ExecutionMode;
 import sparksoniq.semantics.types.SequenceType;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 
 public class TreatExpression extends UnaryExpressionBase {
 
     private FlworVarSequenceType sequenceType;
 
-    public TreatExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-        this.isActive = false;
-    }
-
     public TreatExpression(
             Expression mainExpression,
             FlworVarSequenceType sequenceType,
             ExceptionMetadata metadata
     ) {
-        super(mainExpression, Operator.TREAT, true, metadata);
+        super(mainExpression, Operator.TREAT, metadata);
         this.sequenceType = sequenceType;
     }
 
@@ -33,9 +28,6 @@ public class TreatExpression extends UnaryExpressionBase {
 
     @Override
     public void initHighestExecutionMode() {
-        if (bypassCurrentExpressionForExecutionModeOperations()) {
-            return;
-        }
         SequenceType sequenceType = this.sequenceType.getSequence();
         this.highestExecutionMode = calculateIsRDDFromSequenceTypeAndExpression(sequenceType, this.mainExpression);
     }

--- a/src/main/java/org/rumbledb/expressions/operational/UnaryExpression.java
+++ b/src/main/java/org/rumbledb/expressions/operational/UnaryExpression.java
@@ -22,9 +22,9 @@ package org.rumbledb.expressions.operational;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.operational.base.UnaryExpressionBase;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,25 +35,14 @@ public class UnaryExpression extends UnaryExpressionBase {
     public static final Operator[] operators = new Operator[] { Operator.PLUS, Operator.MINUS };
     private Expression mainExpression;
 
-    public UnaryExpression(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, metadata);
-        this.mainExpression = mainExpression;
-        this.isActive = false;
-    }
-
     public UnaryExpression(Expression mainExpression, List<Operator> ops, ExceptionMetadata metadata) {
-        super(mainExpression, ops, ops != null && !ops.isEmpty(), metadata);
+        super(mainExpression, ops, metadata);
         this.validateOperators(Arrays.asList(operators), ops);
         this.mainExpression = mainExpression;
     }
 
     public Expression getMainExpression() {
         return this.mainExpression;
-    }
-
-    @Override
-    public boolean isActive() {
-        return this.isActive;
     }
 
     @Override

--- a/src/main/java/org/rumbledb/expressions/operational/base/BinaryExpressionBase.java
+++ b/src/main/java/org/rumbledb/expressions/operational/base/BinaryExpressionBase.java
@@ -32,12 +32,6 @@ public abstract class BinaryExpressionBase extends OperationalExpressionBase {
 
     private Expression rightExpression;
 
-    public BinaryExpressionBase(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, Operator.NONE, metadata);
-        this.isActive = false;
-
-    }
-
     public BinaryExpressionBase(
             Expression mainExpression,
             Expression rhs,
@@ -46,17 +40,10 @@ public abstract class BinaryExpressionBase extends OperationalExpressionBase {
     ) {
         super(mainExpression, op, metadata);
         this.rightExpression = rhs;
-        if (Operator.NONE != op && rhs != null)
-            this.isActive = true;
     }
 
     public Expression getRightExpression() {
         return this.rightExpression;
-    }
-
-    @Override
-    public boolean isActive() {
-        return this.isActive;
     }
 
     public Operator getOperator() {

--- a/src/main/java/org/rumbledb/expressions/operational/base/NaryExpressionBase.java
+++ b/src/main/java/org/rumbledb/expressions/operational/base/NaryExpressionBase.java
@@ -30,14 +30,7 @@ import java.util.List;
 
 public abstract class NaryExpressionBase extends OperationalExpressionBase {
 
-
     private List<Expression> rightExpressions;
-
-    public NaryExpressionBase(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, Operator.NONE, metadata);
-        this.isActive = false;
-
-    }
 
     public NaryExpressionBase(
             Expression mainExpression,
@@ -47,8 +40,6 @@ public abstract class NaryExpressionBase extends OperationalExpressionBase {
     ) {
         super(mainExpression, op, metadata);
         this.rightExpressions = rhs;
-        if (Operator.NONE != op)
-            this.isActive = true;
     }
 
     public NaryExpressionBase(
@@ -59,7 +50,6 @@ public abstract class NaryExpressionBase extends OperationalExpressionBase {
     ) {
         super(mainExpression, ops, metadata);
         this.rightExpressions = rhs;
-        this.isActive = true;
     }
 
     public List<Expression> getRightExpressions() {
@@ -72,11 +62,6 @@ public abstract class NaryExpressionBase extends OperationalExpressionBase {
 
     public Operator getSingleOperator() {
         return this.singleOperator;
-    }
-
-    @Override
-    public boolean isActive() {
-        return this.isActive;
     }
 
     @Override

--- a/src/main/java/org/rumbledb/expressions/operational/base/OperationalExpressionBase.java
+++ b/src/main/java/org/rumbledb/expressions/operational/base/OperationalExpressionBase.java
@@ -23,6 +23,7 @@ package org.rumbledb.expressions.operational.base;
 import org.antlr.v4.runtime.Token;
 import org.rumbledb.api.Item;
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.exceptions.OurBadException;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import sparksoniq.jsoniq.ExecutionMode;
@@ -61,23 +62,13 @@ public abstract class OperationalExpressionBase extends Expression {
         this.multipleOperators = ops;
     }
 
-    protected boolean bypassCurrentExpressionForExecutionModeOperations() {
-        return !isActive();
-    }
-
     @Override
     public void initHighestExecutionMode() {
-        if (bypassCurrentExpressionForExecutionModeOperations()) {
-            return;
-        }
         super.initHighestExecutionMode();
     }
 
     @Override
     public ExecutionMode getHighestExecutionMode(boolean ignoreUnsetError) {
-        if (bypassCurrentExpressionForExecutionModeOperations()) {
-            return this.mainExpression.getHighestExecutionMode(ignoreUnsetError);
-        }
         return super.getHighestExecutionMode(ignoreUnsetError);
     }
 
@@ -144,7 +135,7 @@ public abstract class OperationalExpressionBase extends Expression {
                 return Operator.CAST;
         }
 
-        return Operator.NONE;
+        throw new OurBadException("Operator not recognized.");
     }
 
     public static String getStringFromOperator(Operator operator) {
@@ -170,8 +161,6 @@ public abstract class OperationalExpressionBase extends Expression {
                 return operator.toString().toLowerCase();
         }
     }
-
-    public abstract boolean isActive();
 
     public void validateOperators(List<Operator> validOps, List<Operator> ops) {
         for (Operator op : ops)
@@ -302,9 +291,7 @@ public abstract class OperationalExpressionBase extends Expression {
         COMMA,
         TREAT,
         CASTABLE,
-        CAST,
-
-        NONE;
+        CAST;
 
         public Item apply(Item left, Item right) {
             return null;

--- a/src/main/java/org/rumbledb/expressions/operational/base/UnaryExpressionBase.java
+++ b/src/main/java/org/rumbledb/expressions/operational/base/UnaryExpressionBase.java
@@ -28,34 +28,20 @@ import java.util.List;
 
 public abstract class UnaryExpressionBase extends OperationalExpressionBase {
 
-    protected UnaryExpressionBase(Expression mainExpression, ExceptionMetadata metadata) {
-        super(mainExpression, Operator.NONE, metadata);
-    }
-
     protected UnaryExpressionBase(
             Expression mainExpression,
             List<Operator> ops,
-            boolean isActive,
             ExceptionMetadata metadata
     ) {
         super(mainExpression, ops, metadata);
-        this.isActive = isActive;
-
     }
 
     protected UnaryExpressionBase(
             Expression mainExpression,
             Operator singleOperator,
-            boolean isActive,
             ExceptionMetadata metadata
     ) {
         super(mainExpression, singleOperator, metadata);
-        this.isActive = isActive;
-    }
-
-    @Override
-    public boolean isActive() {
-        return this.isActive;
     }
 
     public List<Operator> getOperators() {

--- a/src/main/java/org/rumbledb/expressions/postfix/ArrayLookupExpression.java
+++ b/src/main/java/org/rumbledb/expressions/postfix/ArrayLookupExpression.java
@@ -21,10 +21,9 @@
 package org.rumbledb.expressions.postfix;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/postfix/ArrayUnboxingExpression.java
+++ b/src/main/java/org/rumbledb/expressions/postfix/ArrayUnboxingExpression.java
@@ -25,10 +25,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 public class ArrayUnboxingExpression extends PostfixExpression {
 

--- a/src/main/java/org/rumbledb/expressions/postfix/DynamicFunctionCallExpression.java
+++ b/src/main/java/org/rumbledb/expressions/postfix/DynamicFunctionCallExpression.java
@@ -21,11 +21,11 @@
 package org.rumbledb.expressions.postfix;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 
 import sparksoniq.jsoniq.ExecutionMode;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/postfix/ObjectLookupExpression.java
+++ b/src/main/java/org/rumbledb/expressions/postfix/ObjectLookupExpression.java
@@ -22,10 +22,9 @@ package org.rumbledb.expressions.postfix;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/postfix/PredicateExpression.java
+++ b/src/main/java/org/rumbledb/expressions/postfix/PredicateExpression.java
@@ -22,10 +22,9 @@ package org.rumbledb.expressions.postfix;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/primary/ArrayConstructorExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/ArrayConstructorExpression.java
@@ -21,10 +21,10 @@
 package org.rumbledb.expressions.primary;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.CommaExpression;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/primary/BooleanLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/BooleanLiteralExpression.java
@@ -22,7 +22,7 @@ package org.rumbledb.expressions.primary;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 
 public class BooleanLiteralExpression extends PrimaryExpression {
 

--- a/src/main/java/org/rumbledb/expressions/primary/ContextItemExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/ContextItemExpression.java
@@ -21,7 +21,7 @@
 package org.rumbledb.expressions.primary;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 
 public class ContextItemExpression extends PrimaryExpression {
 

--- a/src/main/java/org/rumbledb/expressions/primary/DecimalLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/DecimalLiteralExpression.java
@@ -21,7 +21,7 @@
 package org.rumbledb.expressions.primary;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 
 import java.math.BigDecimal;
 

--- a/src/main/java/org/rumbledb/expressions/primary/DoubleLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/DoubleLiteralExpression.java
@@ -22,7 +22,7 @@ package org.rumbledb.expressions.primary;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 
 public class DoubleLiteralExpression extends PrimaryExpression {
 

--- a/src/main/java/org/rumbledb/expressions/primary/FunctionCallExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/FunctionCallExpression.java
@@ -24,6 +24,7 @@ import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.OurBadException;
 import org.rumbledb.exceptions.UnknownFunctionCallException;
 import org.rumbledb.exceptions.UnsupportedFeatureException;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import sparksoniq.jsoniq.ExecutionMode;
@@ -31,7 +32,6 @@ import sparksoniq.jsoniq.runtime.iterator.functions.base.BuiltinFunction;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.BuiltinFunction.BuiltinFunctionExecutionMode;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.FunctionIdentifier;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.Functions;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/main/java/org/rumbledb/expressions/primary/InlineFunctionExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/InlineFunctionExpression.java
@@ -22,12 +22,13 @@ package org.rumbledb.expressions.primary;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.flowr.FlworVarSequenceType;
+
 import sparksoniq.jsoniq.runtime.iterator.functions.base.FunctionIdentifier;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.Functions;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/primary/IntegerLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/IntegerLiteralExpression.java
@@ -22,7 +22,7 @@ package org.rumbledb.expressions.primary;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 
 public class IntegerLiteralExpression extends PrimaryExpression {
 

--- a/src/main/java/org/rumbledb/expressions/primary/NamedFunctionReferenceExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/NamedFunctionReferenceExpression.java
@@ -21,9 +21,10 @@
 package org.rumbledb.expressions.primary;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Node;
+
 import sparksoniq.jsoniq.runtime.iterator.functions.base.FunctionIdentifier;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/primary/NullLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/NullLiteralExpression.java
@@ -22,7 +22,7 @@ package org.rumbledb.expressions.primary;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 
 
 

--- a/src/main/java/org/rumbledb/expressions/primary/ObjectConstructorExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/ObjectConstructorExpression.java
@@ -22,9 +22,9 @@ package org.rumbledb.expressions.primary;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/primary/StringLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/StringLiteralExpression.java
@@ -22,7 +22,7 @@ package org.rumbledb.expressions.primary;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 
 
 

--- a/src/main/java/org/rumbledb/expressions/primary/VariableReferenceExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/VariableReferenceExpression.java
@@ -23,9 +23,10 @@ package org.rumbledb.expressions.primary;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.OurBadException;
+import org.rumbledb.expressions.AbstractNodeVisitor;
+
 import sparksoniq.jsoniq.ExecutionMode;
 import sparksoniq.semantics.types.SequenceType;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.io.Serializable;
 

--- a/src/main/java/org/rumbledb/expressions/quantifiers/QuantifiedExpression.java
+++ b/src/main/java/org/rumbledb/expressions/quantifiers/QuantifiedExpression.java
@@ -22,9 +22,9 @@ package org.rumbledb.expressions.quantifiers;
 
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/rumbledb/expressions/quantifiers/QuantifiedExpressionVar.java
+++ b/src/main/java/org/rumbledb/expressions/quantifiers/QuantifiedExpressionVar.java
@@ -21,11 +21,12 @@
 package org.rumbledb.expressions.quantifiers;
 
 import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.expressions.AbstractNodeVisitor;
 import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.primary.VariableReferenceExpression;
+
 import sparksoniq.semantics.types.SequenceType;
-import sparksoniq.semantics.visitor.AbstractNodeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/iq/FrontendTests.java
+++ b/src/test/java/iq/FrontendTests.java
@@ -24,10 +24,11 @@ package iq;
 import iq.base.AnnotationsTestsBase;
 import org.junit.Assert;
 import org.junit.Test;
+import org.rumbledb.compiler.TranslationVisitor;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.expressions.primary.VariableReferenceExpression;
 import org.rumbledb.parser.JsoniqBaseVisitor;
-import sparksoniq.jsoniq.compiler.JsoniqExpressionTreeVisitor;
+
 import sparksoniq.semantics.types.ItemTypes;
 
 import java.io.File;
@@ -100,7 +101,7 @@ public class FrontendTests extends AnnotationsTestsBase {
         initializeTests(semanticTestsDirectory);
         for (File testFile : this.testFiles) {
             System.err.println(counter++ + " : " + testFile);
-            JsoniqExpressionTreeVisitor visitor = new JsoniqExpressionTreeVisitor();
+            TranslationVisitor visitor = new TranslationVisitor();
             testAnnotations(testFile.getAbsolutePath(), visitor);
             if (Arrays.asList(manualSemanticChecksFiles).contains(testFile.getName()))
                 testVariableTypes(testFile, visitor);
@@ -183,7 +184,7 @@ public class FrontendTests extends AnnotationsTestsBase {
      * }
      */
 
-    private void testVariableTypes(File testFile, JsoniqExpressionTreeVisitor visitor) {
+    private void testVariableTypes(File testFile, TranslationVisitor visitor) {
 
         List<Node> vars = visitor.getMainModule()
             .getDescendantsMatching(

--- a/src/test/java/iq/RuntimeTests.java
+++ b/src/test/java/iq/RuntimeTests.java
@@ -29,8 +29,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.rumbledb.api.Item;
+import org.rumbledb.compiler.TranslationVisitor;
 import org.rumbledb.exceptions.OurBadException;
-import sparksoniq.jsoniq.compiler.JsoniqExpressionTreeVisitor;
+
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.SparkSessionManager;
@@ -92,7 +93,7 @@ public class RuntimeTests extends AnnotationsTestsBase {
     @Test(timeout = 1000000)
     public void testRuntimeIterators() throws Throwable {
         System.err.println(AnnotationsTestsBase.counter++ + " : " + this._testFile);
-        JsoniqExpressionTreeVisitor visitor = new JsoniqExpressionTreeVisitor();
+        TranslationVisitor visitor = new TranslationVisitor();
         testAnnotations(this._testFile.getAbsolutePath(), visitor);
     }
 

--- a/src/test/java/iq/base/AnnotationsTestsBase.java
+++ b/src/test/java/iq/base/AnnotationsTestsBase.java
@@ -25,6 +25,8 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.junit.Assert;
+import org.rumbledb.compiler.TranslationVisitor;
+import org.rumbledb.compiler.VisitorHelpers;
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.ParsingException;
 import org.rumbledb.exceptions.SemanticException;
@@ -33,10 +35,9 @@ import org.rumbledb.expressions.module.MainModule;
 import org.rumbledb.parser.JsoniqBaseVisitor;
 import org.rumbledb.parser.JsoniqLexer;
 import org.rumbledb.parser.JsoniqParser;
-import sparksoniq.jsoniq.compiler.JsoniqExpressionTreeVisitor;
+
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.Functions;
-import sparksoniq.semantics.visitor.VisitorHelpers;
 import utils.FileManager;
 import utils.annotations.AnnotationParseException;
 import utils.annotations.AnnotationProcessor;
@@ -78,8 +79,8 @@ public class AnnotationsTestsBase {
             Functions.clearUserDefinedFunctions(); // clear UDFs between each test run
 
             // generate static context and runtime iterators
-            if (visitor instanceof JsoniqExpressionTreeVisitor) {
-                JsoniqExpressionTreeVisitor completeVisitor = ((JsoniqExpressionTreeVisitor) visitor);
+            if (visitor instanceof TranslationVisitor) {
+                TranslationVisitor completeVisitor = ((TranslationVisitor) visitor);
                 MainModule mainModule = completeVisitor.getMainModule();
                 VisitorHelpers.populateStaticContext(mainModule);
                 runtimeIterator = VisitorHelpers.generateRuntimeIterator(mainModule);

--- a/src/test/java/utils/AstSerialization.java
+++ b/src/test/java/utils/AstSerialization.java
@@ -20,8 +20,8 @@
 
 package utils;
 
+import org.rumbledb.compiler.TranslationVisitor;
 import org.rumbledb.parser.JsoniqParser;
-import sparksoniq.jsoniq.compiler.JsoniqExpressionTreeVisitor;
 
 import java.util.Arrays;
 
@@ -177,7 +177,7 @@ public class AstSerialization {
         "stringLiteral" };
 
     public static boolean checkSerialization(
-            JsoniqExpressionTreeVisitor visitor,
+            TranslationVisitor visitor,
             JsoniqParser.MainModuleContext context
     ) {
 


### PR DESCRIPTION
This removes inactive expressions -- this was also a syntactic artifact. If an expression was inactive, then it is now replaced with its only child expression, which makes expression trees much smaller.

I also moved over some classes to the new package scheme.