### PR TITLE
Bringing up to spec so that boolean() has the expected behaviour

### DIFF
--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -34,6 +34,7 @@ import org.rumbledb.exceptions.IteratorFlowException;
 import org.rumbledb.exceptions.OurBadException;
 import sparksoniq.jsoniq.ExecutionMode;
 import sparksoniq.semantics.DynamicContext;
+import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 
 import java.math.BigDecimal;
@@ -102,7 +103,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
                 }
             } else if (item.isNull()) {
                 result = false;
-            } else if (item.isString()) {
+            } else if (item.canBePromotedTo(new ItemType("string"))) {
                 result = !item.getStringValue().isEmpty();
             } else if (item.isObject()) {
                 return true;


### PR DESCRIPTION
For boolean(), the rules [here](https://www.w3.org/TR/xpath-functions-30/#func-boolean) indicate that types derived from string and anyURI should also be handled. I have implemented this here in preparation for my anyURI implementation by calling `canBePromotedTo`, for which anyURI should return string, if I have interpreted this correctly.