### PR TITLE
Bypass comma expression

### DIFF
--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -200,6 +200,9 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<No
             expressions.add((Expression) this.visitExprSingle(expr));
 
         }
+        if (expressions.size() == 1) {
+            return expressions.get(0);
+        }
         return new CommaExpression(expressions, createMetadataFromContext(ctx));
     }
 


### PR DESCRIPTION
Performance improvement for the translation. This should significantly reduce the size of the expression tree.