### PR TITLE
Improve annotate() and DataFrameUtils exceptions

### DIFF
--- a/src/main/java/org/rumbledb/exceptions/MLInvalidDataFrameSchemaException.java
+++ b/src/main/java/org/rumbledb/exceptions/MLInvalidDataFrameSchemaException.java
@@ -26,9 +26,16 @@ public class MLInvalidDataFrameSchemaException extends SparksoniqRuntimeExceptio
 
     private static final long serialVersionUID = 1L;
 
+    public MLInvalidDataFrameSchemaException(String message) {
+        super(
+            message,
+            ErrorCodes.MLInvalidDataFrameSchemaErrorCode
+        );
+    }
+
     public MLInvalidDataFrameSchemaException(String message, ExceptionMetadata metadata) {
         super(
-            "Invalid Schema; " + message,
+            message,
             ErrorCodes.MLInvalidDataFrameSchemaErrorCode,
             metadata
         );


### PR DESCRIPTION
This is mostly cosmetic.  I have tried to improve the annotate() exceptions while also separating the exceptions caused in DataFrameUtils class from annotate method(). This will make it easier to re-use these utility methods without them mentioning annotate() in their exceptions.