### PR TITLE
Improvements with spotless and basedir usage in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <compilerArguments>
-                        <properties>${basedir}/org.eclipse.jdt.core.prefs</properties>
+                        <properties>${project.basedir}/org.eclipse.jdt.core.prefs</properties>
                     </compilerArguments>
                 </configuration>
                 <dependencies>
@@ -179,9 +179,18 @@
                 </executions>
                 <configuration>
                     <java>
+                        <includes>
+                            <!-- include all java files in "java" folders under "src" -->
+                            <include>src/**/java/**/*.java</include>
+                        </includes>
+
+                        <excludes>
+                            <exclude>src/main/java/org/rumbledb/parser/*</exclude>
+                        </excludes>
                         <eclipse>
-                            <file>${basedir}/spotless-formatter-eclipse-jdt-configurations.xml</file>
+                            <file>${project.basedir}/spotless-formatter-eclipse-jdt-configurations.xml</file>
                         </eclipse>
+                        <removeUnusedImports/>
                     </java>
                 </configuration>
             </plugin>


### PR DESCRIPTION
According maven documentation [here](https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#Available_Variables) "project.basedir" should be used as alternatives such as "basedir" or "pom.basedir" are now deprecated.

Spotless configuration for file inclusion and exclusion is added as described [here](https://github.com/diffplug/spotless/tree/master/plugin-maven#file-includes-and-excludes). These relative paths are unfortunately not prefixed with a form of "basedir". This is because no form of maven basedir specification worked with these. They do however function properly in the current state with relative paths.

Added spotless error for unused imports. 