### PR TITLE
Prevent silent failing of unhandled log paths

### DIFF
--- a/src/main/java/org/rumbledb/cli/JsoniqQueryExecutor.java
+++ b/src/main/java/org/rumbledb/cli/JsoniqQueryExecutor.java
@@ -159,19 +159,19 @@ public class JsoniqQueryExecutor {
             timeLogPath += Path.SEPARATOR + "time_log_";
             java.nio.file.Path finalPath = FileUtils.getUniqueFileName(timeLogPath);
             java.nio.file.Files.write(finalPath, result.getBytes());
-        }
-        if (this.configuration.getLogPath().startsWith("hdfs://")) {
+        } else if (this.configuration.getLogPath().startsWith("hdfs://")) {
             org.apache.hadoop.fs.FileSystem fileSystem = org.apache.hadoop.fs.FileSystem
                 .get(SparkSessionManager.getInstance().getJavaSparkContext().hadoopConfiguration());
             FSDataOutputStream fsDataOutputStream = fileSystem.create(new Path(this.configuration.getLogPath()));
             BufferedOutputStream stream = new BufferedOutputStream(fsDataOutputStream);
             stream.write(result.getBytes());
             stream.close();
-        }
-        if (this.configuration.getLogPath().startsWith("./")) {
+        } else if (this.configuration.getLogPath().startsWith("./")) {
             List<String> lines = Arrays.asList(result);
             java.nio.file.Path file = Paths.get(this.configuration.getLogPath());
             Files.write(file, lines, Charset.forName("UTF-8"));
+        } else {
+            throw new OurBadException("An unhandled log path is found: " + this.configuration.getLogPath());
         }
     }
 


### PR DESCRIPTION
The query given in the example below would never create an execution time log. The reason is the given log paths fits none of the expected patterns which are: 
- "file://"
- "hdfs://"
- "./"
```
noglob spark-submit --master local[*] --conf "spark.driver.host"="127.0.0.1" 
spark-rumble-1.4-jar-with-dependencies.jar --query-path my-query.jq 
--output-path my-output.json --log-path my-log.txt
```

This PR adds an OurBadException so that this does not fail silently for the future. The path given in the example above still needs to be handled. Should I create an issue for this or would you like to take this PR over @ghislainfourny ?