### PR TITLE
Format generated parser files

### DIFF
--- a/src/main/java/org/rumbledb/parser/JsoniqBaseVisitor.java
+++ b/src/main/java/org/rumbledb/parser/JsoniqBaseVisitor.java
@@ -11,658 +11,1029 @@ import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
  * of the available methods.
  *
  * @param <T> The return type of the visit operation. Use {@link Void} for
- * operations with no return type.
+ *            operations with no return type.
  */
 public class JsoniqBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements JsoniqVisitor<T> {
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitModule(JsoniqParser.ModuleContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitMainModule(JsoniqParser.MainModuleContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitLibraryModule(JsoniqParser.LibraryModuleContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitProlog(JsoniqParser.PrologContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitDefaultCollationDecl(JsoniqParser.DefaultCollationDeclContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitOrderingModeDecl(JsoniqParser.OrderingModeDeclContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitEmptyOrderDecl(JsoniqParser.EmptyOrderDeclContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitDecimalFormatDecl(JsoniqParser.DecimalFormatDeclContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitDfPropertyName(JsoniqParser.DfPropertyNameContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitModuleImport(JsoniqParser.ModuleImportContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitVarDecl(JsoniqParser.VarDeclContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitFunctionDecl(JsoniqParser.FunctionDeclContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitParamList(JsoniqParser.ParamListContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitParam(JsoniqParser.ParamContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitExpr(JsoniqParser.ExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitExprSingle(JsoniqParser.ExprSingleContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitFlowrExpr(JsoniqParser.FlowrExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitForClause(JsoniqParser.ForClauseContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitForVar(JsoniqParser.ForVarContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitLetClause(JsoniqParser.LetClauseContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitLetVar(JsoniqParser.LetVarContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitWhereClause(JsoniqParser.WhereClauseContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitGroupByClause(JsoniqParser.GroupByClauseContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitGroupByVar(JsoniqParser.GroupByVarContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitOrderByClause(JsoniqParser.OrderByClauseContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitOrderByExpr(JsoniqParser.OrderByExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitCountClause(JsoniqParser.CountClauseContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitQuantifiedExpr(JsoniqParser.QuantifiedExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitQuantifiedExprVar(JsoniqParser.QuantifiedExprVarContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitSwitchExpr(JsoniqParser.SwitchExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitSwitchCaseClause(JsoniqParser.SwitchCaseClauseContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitTypeSwitchExpr(JsoniqParser.TypeSwitchExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitCaseClause(JsoniqParser.CaseClauseContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitIfExpr(JsoniqParser.IfExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitTryCatchExpr(JsoniqParser.TryCatchExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitOrExpr(JsoniqParser.OrExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitAndExpr(JsoniqParser.AndExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitNotExpr(JsoniqParser.NotExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitComparisonExpr(JsoniqParser.ComparisonExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitStringConcatExpr(JsoniqParser.StringConcatExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitRangeExpr(JsoniqParser.RangeExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitAdditiveExpr(JsoniqParser.AdditiveExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitMultiplicativeExpr(JsoniqParser.MultiplicativeExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitInstanceOfExpr(JsoniqParser.InstanceOfExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitTreatExpr(JsoniqParser.TreatExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitCastableExpr(JsoniqParser.CastableExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitCastExpr(JsoniqParser.CastExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitUnaryExpr(JsoniqParser.UnaryExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitSimpleMapExpr(JsoniqParser.SimpleMapExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitPostFixExpr(JsoniqParser.PostFixExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitArrayLookup(JsoniqParser.ArrayLookupContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitArrayUnboxing(JsoniqParser.ArrayUnboxingContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitPredicate(JsoniqParser.PredicateContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitObjectLookup(JsoniqParser.ObjectLookupContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitPrimaryExpr(JsoniqParser.PrimaryExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitVarRef(JsoniqParser.VarRefContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitParenthesizedExpr(JsoniqParser.ParenthesizedExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitContextItemExpr(JsoniqParser.ContextItemExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitOrderedExpr(JsoniqParser.OrderedExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitUnorderedExpr(JsoniqParser.UnorderedExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitFunctionCall(JsoniqParser.FunctionCallContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitArgumentList(JsoniqParser.ArgumentListContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitArgument(JsoniqParser.ArgumentContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitFunctionItemExpr(JsoniqParser.FunctionItemExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitNamedFunctionRef(JsoniqParser.NamedFunctionRefContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitInlineFunctionExpr(JsoniqParser.InlineFunctionExprContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitSequenceType(JsoniqParser.SequenceTypeContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitObjectConstructor(JsoniqParser.ObjectConstructorContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitItemType(JsoniqParser.ItemTypeContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitJSONItemTest(JsoniqParser.JSONItemTestContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordString(JsoniqParser.KeyWordStringContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordInteger(JsoniqParser.KeyWordIntegerContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordDecimal(JsoniqParser.KeyWordDecimalContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordDouble(JsoniqParser.KeyWordDoubleContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordBoolean(JsoniqParser.KeyWordBooleanContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordDuration(JsoniqParser.KeyWordDurationContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordYearMonthDuration(JsoniqParser.KeyWordYearMonthDurationContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordDayTimeDuration(JsoniqParser.KeyWordDayTimeDurationContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordHexBinary(JsoniqParser.KeyWordHexBinaryContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordBase64Binary(JsoniqParser.KeyWordBase64BinaryContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordDateTime(JsoniqParser.KeyWordDateTimeContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordDate(JsoniqParser.KeyWordDateContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordTime(JsoniqParser.KeyWordTimeContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWordAnyURI(JsoniqParser.KeyWordAnyURIContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitTypesKeywords(JsoniqParser.TypesKeywordsContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitSingleType(JsoniqParser.SingleTypeContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitAtomicType(JsoniqParser.AtomicTypeContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitNCNameOrKeyWord(JsoniqParser.NCNameOrKeyWordContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitPairConstructor(JsoniqParser.PairConstructorContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitArrayConstructor(JsoniqParser.ArrayConstructorContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitUriLiteral(JsoniqParser.UriLiteralContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitStringLiteral(JsoniqParser.StringLiteralContext ctx) { return visitChildren(ctx); }
-	/**
-	 * {@inheritDoc}
-	 *
-	 * <p>The default implementation returns the result of calling
-	 * {@link #visitChildren} on {@code ctx}.</p>
-	 */
-	@Override public T visitKeyWords(JsoniqParser.KeyWordsContext ctx) { return visitChildren(ctx); }
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitModule(JsoniqParser.ModuleContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitMainModule(JsoniqParser.MainModuleContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitLibraryModule(JsoniqParser.LibraryModuleContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitProlog(JsoniqParser.PrologContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitDefaultCollationDecl(JsoniqParser.DefaultCollationDeclContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitOrderingModeDecl(JsoniqParser.OrderingModeDeclContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitEmptyOrderDecl(JsoniqParser.EmptyOrderDeclContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitDecimalFormatDecl(JsoniqParser.DecimalFormatDeclContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitDfPropertyName(JsoniqParser.DfPropertyNameContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitModuleImport(JsoniqParser.ModuleImportContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitVarDecl(JsoniqParser.VarDeclContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitFunctionDecl(JsoniqParser.FunctionDeclContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitParamList(JsoniqParser.ParamListContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitParam(JsoniqParser.ParamContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitExpr(JsoniqParser.ExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitExprSingle(JsoniqParser.ExprSingleContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitFlowrExpr(JsoniqParser.FlowrExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitForClause(JsoniqParser.ForClauseContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitForVar(JsoniqParser.ForVarContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitLetClause(JsoniqParser.LetClauseContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitLetVar(JsoniqParser.LetVarContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitWhereClause(JsoniqParser.WhereClauseContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitGroupByClause(JsoniqParser.GroupByClauseContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitGroupByVar(JsoniqParser.GroupByVarContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitOrderByClause(JsoniqParser.OrderByClauseContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitOrderByExpr(JsoniqParser.OrderByExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitCountClause(JsoniqParser.CountClauseContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitQuantifiedExpr(JsoniqParser.QuantifiedExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitQuantifiedExprVar(JsoniqParser.QuantifiedExprVarContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitSwitchExpr(JsoniqParser.SwitchExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitSwitchCaseClause(JsoniqParser.SwitchCaseClauseContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitTypeSwitchExpr(JsoniqParser.TypeSwitchExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitCaseClause(JsoniqParser.CaseClauseContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitIfExpr(JsoniqParser.IfExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitTryCatchExpr(JsoniqParser.TryCatchExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitOrExpr(JsoniqParser.OrExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitAndExpr(JsoniqParser.AndExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitNotExpr(JsoniqParser.NotExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitComparisonExpr(JsoniqParser.ComparisonExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitStringConcatExpr(JsoniqParser.StringConcatExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitRangeExpr(JsoniqParser.RangeExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitAdditiveExpr(JsoniqParser.AdditiveExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitMultiplicativeExpr(JsoniqParser.MultiplicativeExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitInstanceOfExpr(JsoniqParser.InstanceOfExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitTreatExpr(JsoniqParser.TreatExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitCastableExpr(JsoniqParser.CastableExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitCastExpr(JsoniqParser.CastExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitUnaryExpr(JsoniqParser.UnaryExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitSimpleMapExpr(JsoniqParser.SimpleMapExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitPostFixExpr(JsoniqParser.PostFixExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitArrayLookup(JsoniqParser.ArrayLookupContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitArrayUnboxing(JsoniqParser.ArrayUnboxingContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitPredicate(JsoniqParser.PredicateContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitObjectLookup(JsoniqParser.ObjectLookupContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitPrimaryExpr(JsoniqParser.PrimaryExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitVarRef(JsoniqParser.VarRefContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitParenthesizedExpr(JsoniqParser.ParenthesizedExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitContextItemExpr(JsoniqParser.ContextItemExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitOrderedExpr(JsoniqParser.OrderedExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitUnorderedExpr(JsoniqParser.UnorderedExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitFunctionCall(JsoniqParser.FunctionCallContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitArgumentList(JsoniqParser.ArgumentListContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitArgument(JsoniqParser.ArgumentContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitFunctionItemExpr(JsoniqParser.FunctionItemExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitNamedFunctionRef(JsoniqParser.NamedFunctionRefContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitInlineFunctionExpr(JsoniqParser.InlineFunctionExprContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitSequenceType(JsoniqParser.SequenceTypeContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitObjectConstructor(JsoniqParser.ObjectConstructorContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitItemType(JsoniqParser.ItemTypeContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitJSONItemTest(JsoniqParser.JSONItemTestContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordString(JsoniqParser.KeyWordStringContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordInteger(JsoniqParser.KeyWordIntegerContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordDecimal(JsoniqParser.KeyWordDecimalContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordDouble(JsoniqParser.KeyWordDoubleContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordBoolean(JsoniqParser.KeyWordBooleanContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordDuration(JsoniqParser.KeyWordDurationContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordYearMonthDuration(JsoniqParser.KeyWordYearMonthDurationContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordDayTimeDuration(JsoniqParser.KeyWordDayTimeDurationContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordHexBinary(JsoniqParser.KeyWordHexBinaryContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordBase64Binary(JsoniqParser.KeyWordBase64BinaryContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordDateTime(JsoniqParser.KeyWordDateTimeContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordDate(JsoniqParser.KeyWordDateContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordTime(JsoniqParser.KeyWordTimeContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWordAnyURI(JsoniqParser.KeyWordAnyURIContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitTypesKeywords(JsoniqParser.TypesKeywordsContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitSingleType(JsoniqParser.SingleTypeContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitAtomicType(JsoniqParser.AtomicTypeContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitNCNameOrKeyWord(JsoniqParser.NCNameOrKeyWordContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitPairConstructor(JsoniqParser.PairConstructorContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitArrayConstructor(JsoniqParser.ArrayConstructorContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitUriLiteral(JsoniqParser.UriLiteralContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitStringLiteral(JsoniqParser.StringLiteralContext ctx) {
+        return visitChildren(ctx);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation returns the result of calling
+     * {@link #visitChildren} on {@code ctx}.</p>
+     */
+    @Override
+    public T visitKeyWords(JsoniqParser.KeyWordsContext ctx) {
+        return visitChildren(ctx);
+    }
 }

--- a/src/main/java/org/rumbledb/parser/JsoniqLexer.java
+++ b/src/main/java/org/rumbledb/parser/JsoniqLexer.java
@@ -3,562 +3,580 @@
 // Java header
 package org.rumbledb.parser;
 
-import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenStream;
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.atn.*;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.RuntimeMetaData;
+import org.antlr.v4.runtime.Vocabulary;
+import org.antlr.v4.runtime.VocabularyImpl;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.ATNDeserializer;
+import org.antlr.v4.runtime.atn.LexerATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
 import org.antlr.v4.runtime.dfa.DFA;
-import org.antlr.v4.runtime.misc.*;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class JsoniqLexer extends Lexer {
-	static { RuntimeMetaData.checkVersion("4.7", RuntimeMetaData.VERSION); }
+    static {
+        RuntimeMetaData.checkVersion("4.7", RuntimeMetaData.VERSION);
+    }
 
-	protected static final DFA[] _decisionToDFA;
-	protected static final PredictionContextCache _sharedContextCache =
-		new PredictionContextCache();
-	public static final int
-		T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, T__5=6, T__6=7, T__7=8, T__8=9, 
-		T__9=10, T__10=11, T__11=12, T__12=13, T__13=14, T__14=15, T__15=16, T__16=17, 
-		T__17=18, T__18=19, T__19=20, T__20=21, T__21=22, T__22=23, T__23=24, 
-		T__24=25, T__25=26, T__26=27, T__27=28, T__28=29, T__29=30, T__30=31, 
-		T__31=32, T__32=33, T__33=34, T__34=35, T__35=36, T__36=37, T__37=38, 
-		T__38=39, T__39=40, T__40=41, T__41=42, T__42=43, T__43=44, T__44=45, 
-		T__45=46, T__46=47, T__47=48, T__48=49, T__49=50, T__50=51, T__51=52, 
-		T__52=53, T__53=54, T__54=55, T__55=56, T__56=57, T__57=58, T__58=59, 
-		T__59=60, T__60=61, T__61=62, T__62=63, T__63=64, T__64=65, T__65=66, 
-		T__66=67, T__67=68, T__68=69, T__69=70, T__70=71, T__71=72, T__72=73, 
-		T__73=74, T__74=75, T__75=76, Kfor=77, Klet=78, Kwhere=79, Kgroup=80, 
-		Kby=81, Korder=82, Kreturn=83, Kif=84, Kin=85, Kas=86, Kat=87, Kallowing=88, 
-		Kempty=89, Kcount=90, Kstable=91, Kascending=92, Kdescending=93, Ksome=94, 
-		Kevery=95, Ksatisfies=96, Kcollation=97, Kgreatest=98, Kleast=99, Kswitch=100, 
-		Kcase=101, Ktry=102, Kcatch=103, Kdefault=104, Kthen=105, Kelse=106, Ktypeswitch=107, 
-		Kor=108, Kand=109, Knot=110, Kto=111, Kinstance=112, Kof=113, Ktreat=114, 
-		Kcast=115, Kcastable=116, Kversion=117, Kjsoniq=118, Kjson=119, STRING=120, 
-		ArgumentPlaceholder=121, NullLiteral=122, Literal=123, NumericLiteral=124, 
-		BooleanLiteral=125, IntegerLiteral=126, DecimalLiteral=127, DoubleLiteral=128, 
-		WS=129, NCName=130, XQComment=131, ContentChar=132;
-	public static String[] channelNames = {
-		"DEFAULT_TOKEN_CHANNEL", "HIDDEN"
-	};
+    protected static final DFA[] _decisionToDFA;
+    protected static final PredictionContextCache _sharedContextCache =
+            new PredictionContextCache();
+    public static final int
+            T__0 = 1, T__1 = 2, T__2 = 3, T__3 = 4, T__4 = 5, T__5 = 6, T__6 = 7, T__7 = 8, T__8 = 9,
+            T__9 = 10, T__10 = 11, T__11 = 12, T__12 = 13, T__13 = 14, T__14 = 15, T__15 = 16, T__16 = 17,
+            T__17 = 18, T__18 = 19, T__19 = 20, T__20 = 21, T__21 = 22, T__22 = 23, T__23 = 24,
+            T__24 = 25, T__25 = 26, T__26 = 27, T__27 = 28, T__28 = 29, T__29 = 30, T__30 = 31,
+            T__31 = 32, T__32 = 33, T__33 = 34, T__34 = 35, T__35 = 36, T__36 = 37, T__37 = 38,
+            T__38 = 39, T__39 = 40, T__40 = 41, T__41 = 42, T__42 = 43, T__43 = 44, T__44 = 45,
+            T__45 = 46, T__46 = 47, T__47 = 48, T__48 = 49, T__49 = 50, T__50 = 51, T__51 = 52,
+            T__52 = 53, T__53 = 54, T__54 = 55, T__55 = 56, T__56 = 57, T__57 = 58, T__58 = 59,
+            T__59 = 60, T__60 = 61, T__61 = 62, T__62 = 63, T__63 = 64, T__64 = 65, T__65 = 66,
+            T__66 = 67, T__67 = 68, T__68 = 69, T__69 = 70, T__70 = 71, T__71 = 72, T__72 = 73,
+            T__73 = 74, T__74 = 75, T__75 = 76, Kfor = 77, Klet = 78, Kwhere = 79, Kgroup = 80,
+            Kby = 81, Korder = 82, Kreturn = 83, Kif = 84, Kin = 85, Kas = 86, Kat = 87, Kallowing = 88,
+            Kempty = 89, Kcount = 90, Kstable = 91, Kascending = 92, Kdescending = 93, Ksome = 94,
+            Kevery = 95, Ksatisfies = 96, Kcollation = 97, Kgreatest = 98, Kleast = 99, Kswitch = 100,
+            Kcase = 101, Ktry = 102, Kcatch = 103, Kdefault = 104, Kthen = 105, Kelse = 106, Ktypeswitch = 107,
+            Kor = 108, Kand = 109, Knot = 110, Kto = 111, Kinstance = 112, Kof = 113, Ktreat = 114,
+            Kcast = 115, Kcastable = 116, Kversion = 117, Kjsoniq = 118, Kjson = 119, STRING = 120,
+            ArgumentPlaceholder = 121, NullLiteral = 122, Literal = 123, NumericLiteral = 124,
+            BooleanLiteral = 125, IntegerLiteral = 126, DecimalLiteral = 127, DoubleLiteral = 128,
+            WS = 129, NCName = 130, XQComment = 131, ContentChar = 132;
+    public static String[] channelNames = {
+            "DEFAULT_TOKEN_CHANNEL", "HIDDEN"
+    };
 
-	public static String[] modeNames = {
-		"DEFAULT_MODE"
-	};
+    public static String[] modeNames = {
+            "DEFAULT_MODE"
+    };
 
-	public static final String[] ruleNames = {
-		"T__0", "T__1", "T__2", "T__3", "T__4", "T__5", "T__6", "T__7", "T__8", 
-		"T__9", "T__10", "T__11", "T__12", "T__13", "T__14", "T__15", "T__16", 
-		"T__17", "T__18", "T__19", "T__20", "T__21", "T__22", "T__23", "T__24", 
-		"T__25", "T__26", "T__27", "T__28", "T__29", "T__30", "T__31", "T__32", 
-		"T__33", "T__34", "T__35", "T__36", "T__37", "T__38", "T__39", "T__40", 
-		"T__41", "T__42", "T__43", "T__44", "T__45", "T__46", "T__47", "T__48", 
-		"T__49", "T__50", "T__51", "T__52", "T__53", "T__54", "T__55", "T__56", 
-		"T__57", "T__58", "T__59", "T__60", "T__61", "T__62", "T__63", "T__64", 
-		"T__65", "T__66", "T__67", "T__68", "T__69", "T__70", "T__71", "T__72", 
-		"T__73", "T__74", "T__75", "Kfor", "Klet", "Kwhere", "Kgroup", "Kby", 
-		"Korder", "Kreturn", "Kif", "Kin", "Kas", "Kat", "Kallowing", "Kempty", 
-		"Kcount", "Kstable", "Kascending", "Kdescending", "Ksome", "Kevery", "Ksatisfies", 
-		"Kcollation", "Kgreatest", "Kleast", "Kswitch", "Kcase", "Ktry", "Kcatch", 
-		"Kdefault", "Kthen", "Kelse", "Ktypeswitch", "Kor", "Kand", "Knot", "Kto", 
-		"Kinstance", "Kof", "Ktreat", "Kcast", "Kcastable", "Kversion", "Kjsoniq", 
-		"Kjson", "STRING", "ESC", "UNICODE", "HEX", "ArgumentPlaceholder", "NullLiteral", 
-		"Literal", "NumericLiteral", "BooleanLiteral", "IntegerLiteral", "DecimalLiteral", 
-		"DoubleLiteral", "Digits", "WS", "NCName", "NameStartChar", "NameChar", 
-		"XQComment", "ContentChar"
-	};
+    public static final String[] ruleNames = {
+            "T__0", "T__1", "T__2", "T__3", "T__4", "T__5", "T__6", "T__7", "T__8",
+            "T__9", "T__10", "T__11", "T__12", "T__13", "T__14", "T__15", "T__16",
+            "T__17", "T__18", "T__19", "T__20", "T__21", "T__22", "T__23", "T__24",
+            "T__25", "T__26", "T__27", "T__28", "T__29", "T__30", "T__31", "T__32",
+            "T__33", "T__34", "T__35", "T__36", "T__37", "T__38", "T__39", "T__40",
+            "T__41", "T__42", "T__43", "T__44", "T__45", "T__46", "T__47", "T__48",
+            "T__49", "T__50", "T__51", "T__52", "T__53", "T__54", "T__55", "T__56",
+            "T__57", "T__58", "T__59", "T__60", "T__61", "T__62", "T__63", "T__64",
+            "T__65", "T__66", "T__67", "T__68", "T__69", "T__70", "T__71", "T__72",
+            "T__73", "T__74", "T__75", "Kfor", "Klet", "Kwhere", "Kgroup", "Kby",
+            "Korder", "Kreturn", "Kif", "Kin", "Kas", "Kat", "Kallowing", "Kempty",
+            "Kcount", "Kstable", "Kascending", "Kdescending", "Ksome", "Kevery", "Ksatisfies",
+            "Kcollation", "Kgreatest", "Kleast", "Kswitch", "Kcase", "Ktry", "Kcatch",
+            "Kdefault", "Kthen", "Kelse", "Ktypeswitch", "Kor", "Kand", "Knot", "Kto",
+            "Kinstance", "Kof", "Ktreat", "Kcast", "Kcastable", "Kversion", "Kjsoniq",
+            "Kjson", "STRING", "ESC", "UNICODE", "HEX", "ArgumentPlaceholder", "NullLiteral",
+            "Literal", "NumericLiteral", "BooleanLiteral", "IntegerLiteral", "DecimalLiteral",
+            "DoubleLiteral", "Digits", "WS", "NCName", "NameStartChar", "NameChar",
+            "XQComment", "ContentChar"
+    };
 
-	private static final String[] _LITERAL_NAMES = {
-		null, "';'", "'module'", "'namespace'", "'='", "'declare'", "'ordering'", 
-		"'ordered'", "'unordered'", "'decimal-format'", "':'", "'decimal-separator'", 
-		"'grouping-separator'", "'infinity'", "'minus-sign'", "'NaN'", "'percent'", 
-		"'per-mille'", "'zero-digit'", "'digit'", "'pattern-separator'", "'import'", 
-		"','", "'variable'", "':='", "'external'", "'function'", "'('", "')'", 
-		"'{'", "'}'", "'$'", "'|'", "'*'", "'eq'", "'ne'", "'lt'", "'le'", "'gt'", 
-		"'ge'", "'!='", "'<'", "'<='", "'>'", "'>='", "'||'", "'+'", "'-'", "'div'", 
-		"'idiv'", "'mod'", "'!'", "'['", "']'", "'.'", "'$$'", "'#'", "'{|'", 
-		"'|}'", "'item'", "'object'", "'array'", "'string'", "'integer'", "'decimal'", 
-		"'double'", "'boolean'", "'duration'", "'yearMonthDuration'", "'dayTimeDuration'", 
-		"'hexBinary'", "'base64Binary'", "'dateTime'", "'date'", "'time'", "'anyURI'", 
-		"'atomic'", "'for'", "'let'", "'where'", "'group'", "'by'", "'order'", 
-		"'return'", "'if'", "'in'", "'as'", "'at'", "'allowing'", "'empty'", "'count'", 
-		"'stable'", "'ascending'", "'descending'", "'some'", "'every'", "'satisfies'", 
-		"'collation'", "'greatest'", "'least'", "'switch'", "'case'", "'try'", 
-		"'catch'", "'default'", "'then'", "'else'", "'typeswitch'", "'or'", "'and'", 
-		"'not'", "'to'", "'instance'", "'of'", "'treat'", "'cast'", "'castable'", 
-		"'version'", "'jsoniq'", "'json-item'", null, "'?'", "'null'"
-	};
-	private static final String[] _SYMBOLIC_NAMES = {
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, "Kfor", "Klet", "Kwhere", "Kgroup", "Kby", 
-		"Korder", "Kreturn", "Kif", "Kin", "Kas", "Kat", "Kallowing", "Kempty", 
-		"Kcount", "Kstable", "Kascending", "Kdescending", "Ksome", "Kevery", "Ksatisfies", 
-		"Kcollation", "Kgreatest", "Kleast", "Kswitch", "Kcase", "Ktry", "Kcatch", 
-		"Kdefault", "Kthen", "Kelse", "Ktypeswitch", "Kor", "Kand", "Knot", "Kto", 
-		"Kinstance", "Kof", "Ktreat", "Kcast", "Kcastable", "Kversion", "Kjsoniq", 
-		"Kjson", "STRING", "ArgumentPlaceholder", "NullLiteral", "Literal", "NumericLiteral", 
-		"BooleanLiteral", "IntegerLiteral", "DecimalLiteral", "DoubleLiteral", 
-		"WS", "NCName", "XQComment", "ContentChar"
-	};
-	public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
+    private static final String[] _LITERAL_NAMES = {
+            null, "';'", "'module'", "'namespace'", "'='", "'declare'", "'ordering'",
+            "'ordered'", "'unordered'", "'decimal-format'", "':'", "'decimal-separator'",
+            "'grouping-separator'", "'infinity'", "'minus-sign'", "'NaN'", "'percent'",
+            "'per-mille'", "'zero-digit'", "'digit'", "'pattern-separator'", "'import'",
+            "','", "'variable'", "':='", "'external'", "'function'", "'('", "')'",
+            "'{'", "'}'", "'$'", "'|'", "'*'", "'eq'", "'ne'", "'lt'", "'le'", "'gt'",
+            "'ge'", "'!='", "'<'", "'<='", "'>'", "'>='", "'||'", "'+'", "'-'", "'div'",
+            "'idiv'", "'mod'", "'!'", "'['", "']'", "'.'", "'$$'", "'#'", "'{|'",
+            "'|}'", "'item'", "'object'", "'array'", "'string'", "'integer'", "'decimal'",
+            "'double'", "'boolean'", "'duration'", "'yearMonthDuration'", "'dayTimeDuration'",
+            "'hexBinary'", "'base64Binary'", "'dateTime'", "'date'", "'time'", "'anyURI'",
+            "'atomic'", "'for'", "'let'", "'where'", "'group'", "'by'", "'order'",
+            "'return'", "'if'", "'in'", "'as'", "'at'", "'allowing'", "'empty'", "'count'",
+            "'stable'", "'ascending'", "'descending'", "'some'", "'every'", "'satisfies'",
+            "'collation'", "'greatest'", "'least'", "'switch'", "'case'", "'try'",
+            "'catch'", "'default'", "'then'", "'else'", "'typeswitch'", "'or'", "'and'",
+            "'not'", "'to'", "'instance'", "'of'", "'treat'", "'cast'", "'castable'",
+            "'version'", "'jsoniq'", "'json-item'", null, "'?'", "'null'"
+    };
+    private static final String[] _SYMBOLIC_NAMES = {
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, "Kfor", "Klet", "Kwhere", "Kgroup", "Kby",
+            "Korder", "Kreturn", "Kif", "Kin", "Kas", "Kat", "Kallowing", "Kempty",
+            "Kcount", "Kstable", "Kascending", "Kdescending", "Ksome", "Kevery", "Ksatisfies",
+            "Kcollation", "Kgreatest", "Kleast", "Kswitch", "Kcase", "Ktry", "Kcatch",
+            "Kdefault", "Kthen", "Kelse", "Ktypeswitch", "Kor", "Kand", "Knot", "Kto",
+            "Kinstance", "Kof", "Ktreat", "Kcast", "Kcastable", "Kversion", "Kjsoniq",
+            "Kjson", "STRING", "ArgumentPlaceholder", "NullLiteral", "Literal", "NumericLiteral",
+            "BooleanLiteral", "IntegerLiteral", "DecimalLiteral", "DoubleLiteral",
+            "WS", "NCName", "XQComment", "ContentChar"
+    };
+    public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
 
-	/**
-	 * @deprecated Use {@link #VOCABULARY} instead.
-	 */
-	@Deprecated
-	public static final String[] tokenNames;
-	static {
-		tokenNames = new String[_SYMBOLIC_NAMES.length];
-		for (int i = 0; i < tokenNames.length; i++) {
-			tokenNames[i] = VOCABULARY.getLiteralName(i);
-			if (tokenNames[i] == null) {
-				tokenNames[i] = VOCABULARY.getSymbolicName(i);
-			}
+    /**
+     * @deprecated Use {@link #VOCABULARY} instead.
+     */
+    @Deprecated
+    public static final String[] tokenNames;
 
-			if (tokenNames[i] == null) {
-				tokenNames[i] = "<INVALID>";
-			}
-		}
-	}
+    static {
+        tokenNames = new String[_SYMBOLIC_NAMES.length];
+        for (int i = 0; i < tokenNames.length; i++) {
+            tokenNames[i] = VOCABULARY.getLiteralName(i);
+            if (tokenNames[i] == null) {
+                tokenNames[i] = VOCABULARY.getSymbolicName(i);
+            }
 
-	@Override
-	@Deprecated
-	public String[] getTokenNames() {
-		return tokenNames;
-	}
+            if (tokenNames[i] == null) {
+                tokenNames[i] = "<INVALID>";
+            }
+        }
+    }
 
-	@Override
+    @Override
+    @Deprecated
+    public String[] getTokenNames() {
+        return tokenNames;
+    }
 
-	public Vocabulary getVocabulary() {
-		return VOCABULARY;
-	}
+    @Override
+
+    public Vocabulary getVocabulary() {
+        return VOCABULARY;
+    }
 
 
-	public JsoniqLexer(CharStream input) {
-		super(input);
-		_interp = new LexerATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
-	}
+    public JsoniqLexer(CharStream input) {
+        super(input);
+        _interp = new LexerATNSimulator(this, _ATN, _decisionToDFA, _sharedContextCache);
+    }
 
-	@Override
-	public String getGrammarFileName() { return "Jsoniq.g4"; }
+    @Override
+    public String getGrammarFileName() {
+        return "Jsoniq.g4";
+    }
 
-	@Override
-	public String[] getRuleNames() { return ruleNames; }
+    @Override
+    public String[] getRuleNames() {
+        return ruleNames;
+    }
 
-	@Override
-	public String getSerializedATN() { return _serializedATN; }
+    @Override
+    public String getSerializedATN() {
+        return _serializedATN;
+    }
 
-	@Override
-	public String[] getChannelNames() { return channelNames; }
+    @Override
+    public String[] getChannelNames() {
+        return channelNames;
+    }
 
-	@Override
-	public String[] getModeNames() { return modeNames; }
+    @Override
+    public String[] getModeNames() {
+        return modeNames;
+    }
 
-	@Override
-	public ATN getATN() { return _ATN; }
+    @Override
+    public ATN getATN() {
+        return _ATN;
+    }
 
-	public static final String _serializedATN =
-		"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\2\u0086\u0474\b\1\4"+
-		"\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n"+
-		"\4\13\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22"+
-		"\t\22\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31"+
-		"\t\31\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t"+
-		" \4!\t!\4\"\t\"\4#\t#\4$\t$\4%\t%\4&\t&\4\'\t\'\4(\t(\4)\t)\4*\t*\4+\t"+
-		"+\4,\t,\4-\t-\4.\t.\4/\t/\4\60\t\60\4\61\t\61\4\62\t\62\4\63\t\63\4\64"+
-		"\t\64\4\65\t\65\4\66\t\66\4\67\t\67\48\t8\49\t9\4:\t:\4;\t;\4<\t<\4=\t"+
-		"=\4>\t>\4?\t?\4@\t@\4A\tA\4B\tB\4C\tC\4D\tD\4E\tE\4F\tF\4G\tG\4H\tH\4"+
-		"I\tI\4J\tJ\4K\tK\4L\tL\4M\tM\4N\tN\4O\tO\4P\tP\4Q\tQ\4R\tR\4S\tS\4T\t"+
-		"T\4U\tU\4V\tV\4W\tW\4X\tX\4Y\tY\4Z\tZ\4[\t[\4\\\t\\\4]\t]\4^\t^\4_\t_"+
-		"\4`\t`\4a\ta\4b\tb\4c\tc\4d\td\4e\te\4f\tf\4g\tg\4h\th\4i\ti\4j\tj\4k"+
-		"\tk\4l\tl\4m\tm\4n\tn\4o\to\4p\tp\4q\tq\4r\tr\4s\ts\4t\tt\4u\tu\4v\tv"+
-		"\4w\tw\4x\tx\4y\ty\4z\tz\4{\t{\4|\t|\4}\t}\4~\t~\4\177\t\177\4\u0080\t"+
-		"\u0080\4\u0081\t\u0081\4\u0082\t\u0082\4\u0083\t\u0083\4\u0084\t\u0084"+
-		"\4\u0085\t\u0085\4\u0086\t\u0086\4\u0087\t\u0087\4\u0088\t\u0088\4\u0089"+
-		"\t\u0089\4\u008a\t\u008a\4\u008b\t\u008b\3\2\3\2\3\3\3\3\3\3\3\3\3\3\3"+
-		"\3\3\3\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\5\3\5\3\6\3\6\3\6\3\6"+
-		"\3\6\3\6\3\6\3\6\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\b\3\b\3\b\3\b\3"+
-		"\b\3\b\3\b\3\b\3\t\3\t\3\t\3\t\3\t\3\t\3\t\3\t\3\t\3\t\3\n\3\n\3\n\3\n"+
-		"\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\13\3\13\3\f\3\f\3\f\3\f"+
-		"\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\r\3\r\3\r\3"+
-		"\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\16\3"+
-		"\16\3\16\3\16\3\16\3\16\3\16\3\16\3\16\3\17\3\17\3\17\3\17\3\17\3\17\3"+
-		"\17\3\17\3\17\3\17\3\17\3\20\3\20\3\20\3\20\3\21\3\21\3\21\3\21\3\21\3"+
-		"\21\3\21\3\21\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\23\3"+
-		"\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\24\3\24\3\24\3\24\3"+
-		"\24\3\24\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3"+
-		"\25\3\25\3\25\3\25\3\25\3\25\3\26\3\26\3\26\3\26\3\26\3\26\3\26\3\27\3"+
-		"\27\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\31\3\31\3\31\3\32\3"+
-		"\32\3\32\3\32\3\32\3\32\3\32\3\32\3\32\3\33\3\33\3\33\3\33\3\33\3\33\3"+
-		"\33\3\33\3\33\3\34\3\34\3\35\3\35\3\36\3\36\3\37\3\37\3 \3 \3!\3!\3\""+
-		"\3\"\3#\3#\3#\3$\3$\3$\3%\3%\3%\3&\3&\3&\3\'\3\'\3\'\3(\3(\3(\3)\3)\3"+
-		")\3*\3*\3+\3+\3+\3,\3,\3-\3-\3-\3.\3.\3.\3/\3/\3\60\3\60\3\61\3\61\3\61"+
-		"\3\61\3\62\3\62\3\62\3\62\3\62\3\63\3\63\3\63\3\63\3\64\3\64\3\65\3\65"+
-		"\3\66\3\66\3\67\3\67\38\38\38\39\39\3:\3:\3:\3;\3;\3;\3<\3<\3<\3<\3<\3"+
-		"=\3=\3=\3=\3=\3=\3=\3>\3>\3>\3>\3>\3>\3?\3?\3?\3?\3?\3?\3?\3@\3@\3@\3"+
-		"@\3@\3@\3@\3@\3A\3A\3A\3A\3A\3A\3A\3A\3B\3B\3B\3B\3B\3B\3B\3C\3C\3C\3"+
-		"C\3C\3C\3C\3C\3D\3D\3D\3D\3D\3D\3D\3D\3D\3E\3E\3E\3E\3E\3E\3E\3E\3E\3"+
-		"E\3E\3E\3E\3E\3E\3E\3E\3E\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3"+
-		"F\3F\3G\3G\3G\3G\3G\3G\3G\3G\3G\3G\3H\3H\3H\3H\3H\3H\3H\3H\3H\3H\3H\3"+
-		"H\3H\3I\3I\3I\3I\3I\3I\3I\3I\3I\3J\3J\3J\3J\3J\3K\3K\3K\3K\3K\3L\3L\3"+
-		"L\3L\3L\3L\3L\3M\3M\3M\3M\3M\3M\3M\3N\3N\3N\3N\3O\3O\3O\3O\3P\3P\3P\3"+
-		"P\3P\3P\3Q\3Q\3Q\3Q\3Q\3Q\3R\3R\3R\3S\3S\3S\3S\3S\3S\3T\3T\3T\3T\3T\3"+
-		"T\3T\3U\3U\3U\3V\3V\3V\3W\3W\3W\3X\3X\3X\3Y\3Y\3Y\3Y\3Y\3Y\3Y\3Y\3Y\3"+
-		"Z\3Z\3Z\3Z\3Z\3Z\3[\3[\3[\3[\3[\3[\3\\\3\\\3\\\3\\\3\\\3\\\3\\\3]\3]\3"+
-		"]\3]\3]\3]\3]\3]\3]\3]\3^\3^\3^\3^\3^\3^\3^\3^\3^\3^\3^\3_\3_\3_\3_\3"+
-		"_\3`\3`\3`\3`\3`\3`\3a\3a\3a\3a\3a\3a\3a\3a\3a\3a\3b\3b\3b\3b\3b\3b\3"+
-		"b\3b\3b\3b\3c\3c\3c\3c\3c\3c\3c\3c\3c\3d\3d\3d\3d\3d\3d\3e\3e\3e\3e\3"+
-		"e\3e\3e\3f\3f\3f\3f\3f\3g\3g\3g\3g\3h\3h\3h\3h\3h\3h\3i\3i\3i\3i\3i\3"+
-		"i\3i\3i\3j\3j\3j\3j\3j\3k\3k\3k\3k\3k\3l\3l\3l\3l\3l\3l\3l\3l\3l\3l\3"+
-		"l\3m\3m\3m\3n\3n\3n\3n\3o\3o\3o\3o\3p\3p\3p\3q\3q\3q\3q\3q\3q\3q\3q\3"+
-		"q\3r\3r\3r\3s\3s\3s\3s\3s\3s\3t\3t\3t\3t\3t\3u\3u\3u\3u\3u\3u\3u\3u\3"+
-		"u\3v\3v\3v\3v\3v\3v\3v\3v\3w\3w\3w\3w\3w\3w\3w\3x\3x\3x\3x\3x\3x\3x\3"+
-		"x\3x\3x\3y\3y\3y\7y\u03f5\ny\fy\16y\u03f8\13y\3y\3y\3z\3z\3z\5z\u03ff"+
-		"\nz\3{\3{\3{\3{\3{\3{\3|\3|\3}\3}\3~\3~\3~\3~\3~\3\177\3\177\5\177\u0412"+
-		"\n\177\3\u0080\3\u0080\3\u0080\5\u0080\u0417\n\u0080\3\u0081\3\u0081\3"+
-		"\u0081\3\u0081\3\u0081\3\u0081\3\u0081\3\u0081\3\u0081\5\u0081\u0422\n"+
-		"\u0081\3\u0082\3\u0082\3\u0083\3\u0083\3\u0083\3\u0083\3\u0083\7\u0083"+
-		"\u042b\n\u0083\f\u0083\16\u0083\u042e\13\u0083\5\u0083\u0430\n\u0083\3"+
-		"\u0084\3\u0084\3\u0084\3\u0084\3\u0084\7\u0084\u0437\n\u0084\f\u0084\16"+
-		"\u0084\u043a\13\u0084\5\u0084\u043c\n\u0084\5\u0084\u043e\n\u0084\3\u0084"+
-		"\3\u0084\5\u0084\u0442\n\u0084\3\u0084\3\u0084\3\u0085\6\u0085\u0447\n"+
-		"\u0085\r\u0085\16\u0085\u0448\3\u0086\3\u0086\3\u0086\3\u0086\3\u0087"+
-		"\3\u0087\7\u0087\u0451\n\u0087\f\u0087\16\u0087\u0454\13\u0087\3\u0088"+
-		"\5\u0088\u0457\n\u0088\3\u0089\3\u0089\5\u0089\u045b\n\u0089\3\u008a\3"+
-		"\u008a\3\u008a\3\u008a\3\u008a\3\u008a\3\u008a\3\u008a\7\u008a\u0465\n"+
-		"\u008a\f\u008a\16\u008a\u0468\13\u008a\3\u008a\6\u008a\u046b\n\u008a\r"+
-		"\u008a\16\u008a\u046c\3\u008a\3\u008a\3\u008a\3\u008a\3\u008b\3\u008b"+
-		"\2\2\u008c\3\3\5\4\7\5\t\6\13\7\r\b\17\t\21\n\23\13\25\f\27\r\31\16\33"+
-		"\17\35\20\37\21!\22#\23%\24\'\25)\26+\27-\30/\31\61\32\63\33\65\34\67"+
-		"\359\36;\37= ?!A\"C#E$G%I&K\'M(O)Q*S+U,W-Y.[/]\60_\61a\62c\63e\64g\65"+
-		"i\66k\67m8o9q:s;u<w=y>{?}@\177A\u0081B\u0083C\u0085D\u0087E\u0089F\u008b"+
-		"G\u008dH\u008fI\u0091J\u0093K\u0095L\u0097M\u0099N\u009bO\u009dP\u009f"+
-		"Q\u00a1R\u00a3S\u00a5T\u00a7U\u00a9V\u00abW\u00adX\u00afY\u00b1Z\u00b3"+
-		"[\u00b5\\\u00b7]\u00b9^\u00bb_\u00bd`\u00bfa\u00c1b\u00c3c\u00c5d\u00c7"+
-		"e\u00c9f\u00cbg\u00cdh\u00cfi\u00d1j\u00d3k\u00d5l\u00d7m\u00d9n\u00db"+
-		"o\u00ddp\u00dfq\u00e1r\u00e3s\u00e5t\u00e7u\u00e9v\u00ebw\u00edx\u00ef"+
-		"y\u00f1z\u00f3\2\u00f5\2\u00f7\2\u00f9{\u00fb|\u00fd}\u00ff~\u0101\177"+
-		"\u0103\u0080\u0105\u0081\u0107\u0082\u0109\2\u010b\u0083\u010d\u0084\u010f"+
-		"\2\u0111\2\u0113\u0085\u0115\u0086\3\2\17\4\2$$^^\n\2$$\61\61^^ddhhpp"+
-		"ttvv\5\2\62;CHch\3\2\62;\4\2GGgg\4\2--//\5\2\13\f\17\17\"\"\20\2C\\aa"+
-		"c|\u00c2\u00d8\u00da\u00f8\u00fa\u0301\u0372\u037f\u0381\u2001\u200e\u200f"+
-		"\u2072\u2191\u2c02\u2ff1\u3003\ud801\uf902\ufdd1\ufdf2\uffff\7\2//\62"+
-		";\u00b9\u00b9\u0302\u0371\u2041\u2042\3\2<<\3\2++\4\2**<<\7\2$$()>>}}"+
-		"\177\177\2\u0482\2\3\3\2\2\2\2\5\3\2\2\2\2\7\3\2\2\2\2\t\3\2\2\2\2\13"+
-		"\3\2\2\2\2\r\3\2\2\2\2\17\3\2\2\2\2\21\3\2\2\2\2\23\3\2\2\2\2\25\3\2\2"+
-		"\2\2\27\3\2\2\2\2\31\3\2\2\2\2\33\3\2\2\2\2\35\3\2\2\2\2\37\3\2\2\2\2"+
-		"!\3\2\2\2\2#\3\2\2\2\2%\3\2\2\2\2\'\3\2\2\2\2)\3\2\2\2\2+\3\2\2\2\2-\3"+
-		"\2\2\2\2/\3\2\2\2\2\61\3\2\2\2\2\63\3\2\2\2\2\65\3\2\2\2\2\67\3\2\2\2"+
-		"\29\3\2\2\2\2;\3\2\2\2\2=\3\2\2\2\2?\3\2\2\2\2A\3\2\2\2\2C\3\2\2\2\2E"+
-		"\3\2\2\2\2G\3\2\2\2\2I\3\2\2\2\2K\3\2\2\2\2M\3\2\2\2\2O\3\2\2\2\2Q\3\2"+
-		"\2\2\2S\3\2\2\2\2U\3\2\2\2\2W\3\2\2\2\2Y\3\2\2\2\2[\3\2\2\2\2]\3\2\2\2"+
-		"\2_\3\2\2\2\2a\3\2\2\2\2c\3\2\2\2\2e\3\2\2\2\2g\3\2\2\2\2i\3\2\2\2\2k"+
-		"\3\2\2\2\2m\3\2\2\2\2o\3\2\2\2\2q\3\2\2\2\2s\3\2\2\2\2u\3\2\2\2\2w\3\2"+
-		"\2\2\2y\3\2\2\2\2{\3\2\2\2\2}\3\2\2\2\2\177\3\2\2\2\2\u0081\3\2\2\2\2"+
-		"\u0083\3\2\2\2\2\u0085\3\2\2\2\2\u0087\3\2\2\2\2\u0089\3\2\2\2\2\u008b"+
-		"\3\2\2\2\2\u008d\3\2\2\2\2\u008f\3\2\2\2\2\u0091\3\2\2\2\2\u0093\3\2\2"+
-		"\2\2\u0095\3\2\2\2\2\u0097\3\2\2\2\2\u0099\3\2\2\2\2\u009b\3\2\2\2\2\u009d"+
-		"\3\2\2\2\2\u009f\3\2\2\2\2\u00a1\3\2\2\2\2\u00a3\3\2\2\2\2\u00a5\3\2\2"+
-		"\2\2\u00a7\3\2\2\2\2\u00a9\3\2\2\2\2\u00ab\3\2\2\2\2\u00ad\3\2\2\2\2\u00af"+
-		"\3\2\2\2\2\u00b1\3\2\2\2\2\u00b3\3\2\2\2\2\u00b5\3\2\2\2\2\u00b7\3\2\2"+
-		"\2\2\u00b9\3\2\2\2\2\u00bb\3\2\2\2\2\u00bd\3\2\2\2\2\u00bf\3\2\2\2\2\u00c1"+
-		"\3\2\2\2\2\u00c3\3\2\2\2\2\u00c5\3\2\2\2\2\u00c7\3\2\2\2\2\u00c9\3\2\2"+
-		"\2\2\u00cb\3\2\2\2\2\u00cd\3\2\2\2\2\u00cf\3\2\2\2\2\u00d1\3\2\2\2\2\u00d3"+
-		"\3\2\2\2\2\u00d5\3\2\2\2\2\u00d7\3\2\2\2\2\u00d9\3\2\2\2\2\u00db\3\2\2"+
-		"\2\2\u00dd\3\2\2\2\2\u00df\3\2\2\2\2\u00e1\3\2\2\2\2\u00e3\3\2\2\2\2\u00e5"+
-		"\3\2\2\2\2\u00e7\3\2\2\2\2\u00e9\3\2\2\2\2\u00eb\3\2\2\2\2\u00ed\3\2\2"+
-		"\2\2\u00ef\3\2\2\2\2\u00f1\3\2\2\2\2\u00f9\3\2\2\2\2\u00fb\3\2\2\2\2\u00fd"+
-		"\3\2\2\2\2\u00ff\3\2\2\2\2\u0101\3\2\2\2\2\u0103\3\2\2\2\2\u0105\3\2\2"+
-		"\2\2\u0107\3\2\2\2\2\u010b\3\2\2\2\2\u010d\3\2\2\2\2\u0113\3\2\2\2\2\u0115"+
-		"\3\2\2\2\3\u0117\3\2\2\2\5\u0119\3\2\2\2\7\u0120\3\2\2\2\t\u012a\3\2\2"+
-		"\2\13\u012c\3\2\2\2\r\u0134\3\2\2\2\17\u013d\3\2\2\2\21\u0145\3\2\2\2"+
-		"\23\u014f\3\2\2\2\25\u015e\3\2\2\2\27\u0160\3\2\2\2\31\u0172\3\2\2\2\33"+
-		"\u0185\3\2\2\2\35\u018e\3\2\2\2\37\u0199\3\2\2\2!\u019d\3\2\2\2#\u01a5"+
-		"\3\2\2\2%\u01af\3\2\2\2\'\u01ba\3\2\2\2)\u01c0\3\2\2\2+\u01d2\3\2\2\2"+
-		"-\u01d9\3\2\2\2/\u01db\3\2\2\2\61\u01e4\3\2\2\2\63\u01e7\3\2\2\2\65\u01f0"+
-		"\3\2\2\2\67\u01f9\3\2\2\29\u01fb\3\2\2\2;\u01fd\3\2\2\2=\u01ff\3\2\2\2"+
-		"?\u0201\3\2\2\2A\u0203\3\2\2\2C\u0205\3\2\2\2E\u0207\3\2\2\2G\u020a\3"+
-		"\2\2\2I\u020d\3\2\2\2K\u0210\3\2\2\2M\u0213\3\2\2\2O\u0216\3\2\2\2Q\u0219"+
-		"\3\2\2\2S\u021c\3\2\2\2U\u021e\3\2\2\2W\u0221\3\2\2\2Y\u0223\3\2\2\2["+
-		"\u0226\3\2\2\2]\u0229\3\2\2\2_\u022b\3\2\2\2a\u022d\3\2\2\2c\u0231\3\2"+
-		"\2\2e\u0236\3\2\2\2g\u023a\3\2\2\2i\u023c\3\2\2\2k\u023e\3\2\2\2m\u0240"+
-		"\3\2\2\2o\u0242\3\2\2\2q\u0245\3\2\2\2s\u0247\3\2\2\2u\u024a\3\2\2\2w"+
-		"\u024d\3\2\2\2y\u0252\3\2\2\2{\u0259\3\2\2\2}\u025f\3\2\2\2\177\u0266"+
-		"\3\2\2\2\u0081\u026e\3\2\2\2\u0083\u0276\3\2\2\2\u0085\u027d\3\2\2\2\u0087"+
-		"\u0285\3\2\2\2\u0089\u028e\3\2\2\2\u008b\u02a0\3\2\2\2\u008d\u02b0\3\2"+
-		"\2\2\u008f\u02ba\3\2\2\2\u0091\u02c7\3\2\2\2\u0093\u02d0\3\2\2\2\u0095"+
-		"\u02d5\3\2\2\2\u0097\u02da\3\2\2\2\u0099\u02e1\3\2\2\2\u009b\u02e8\3\2"+
-		"\2\2\u009d\u02ec\3\2\2\2\u009f\u02f0\3\2\2\2\u00a1\u02f6\3\2\2\2\u00a3"+
-		"\u02fc\3\2\2\2\u00a5\u02ff\3\2\2\2\u00a7\u0305\3\2\2\2\u00a9\u030c\3\2"+
-		"\2\2\u00ab\u030f\3\2\2\2\u00ad\u0312\3\2\2\2\u00af\u0315\3\2\2\2\u00b1"+
-		"\u0318\3\2\2\2\u00b3\u0321\3\2\2\2\u00b5\u0327\3\2\2\2\u00b7\u032d\3\2"+
-		"\2\2\u00b9\u0334\3\2\2\2\u00bb\u033e\3\2\2\2\u00bd\u0349\3\2\2\2\u00bf"+
-		"\u034e\3\2\2\2\u00c1\u0354\3\2\2\2\u00c3\u035e\3\2\2\2\u00c5\u0368\3\2"+
-		"\2\2\u00c7\u0371\3\2\2\2\u00c9\u0377\3\2\2\2\u00cb\u037e\3\2\2\2\u00cd"+
-		"\u0383\3\2\2\2\u00cf\u0387\3\2\2\2\u00d1\u038d\3\2\2\2\u00d3\u0395\3\2"+
-		"\2\2\u00d5\u039a\3\2\2\2\u00d7\u039f\3\2\2\2\u00d9\u03aa\3\2\2\2\u00db"+
-		"\u03ad\3\2\2\2\u00dd\u03b1\3\2\2\2\u00df\u03b5\3\2\2\2\u00e1\u03b8\3\2"+
-		"\2\2\u00e3\u03c1\3\2\2\2\u00e5\u03c4\3\2\2\2\u00e7\u03ca\3\2\2\2\u00e9"+
-		"\u03cf\3\2\2\2\u00eb\u03d8\3\2\2\2\u00ed\u03e0\3\2\2\2\u00ef\u03e7\3\2"+
-		"\2\2\u00f1\u03f1\3\2\2\2\u00f3\u03fb\3\2\2\2\u00f5\u0400\3\2\2\2\u00f7"+
-		"\u0406\3\2\2\2\u00f9\u0408\3\2\2\2\u00fb\u040a\3\2\2\2\u00fd\u0411\3\2"+
-		"\2\2\u00ff\u0416\3\2\2\2\u0101\u0421\3\2\2\2\u0103\u0423\3\2\2\2\u0105"+
-		"\u042f\3\2\2\2\u0107\u043d\3\2\2\2\u0109\u0446\3\2\2\2\u010b\u044a\3\2"+
-		"\2\2\u010d\u044e\3\2\2\2\u010f\u0456\3\2\2\2\u0111\u045a\3\2\2\2\u0113"+
-		"\u045c\3\2\2\2\u0115\u0472\3\2\2\2\u0117\u0118\7=\2\2\u0118\4\3\2\2\2"+
-		"\u0119\u011a\7o\2\2\u011a\u011b\7q\2\2\u011b\u011c\7f\2\2\u011c\u011d"+
-		"\7w\2\2\u011d\u011e\7n\2\2\u011e\u011f\7g\2\2\u011f\6\3\2\2\2\u0120\u0121"+
-		"\7p\2\2\u0121\u0122\7c\2\2\u0122\u0123\7o\2\2\u0123\u0124\7g\2\2\u0124"+
-		"\u0125\7u\2\2\u0125\u0126\7r\2\2\u0126\u0127\7c\2\2\u0127\u0128\7e\2\2"+
-		"\u0128\u0129\7g\2\2\u0129\b\3\2\2\2\u012a\u012b\7?\2\2\u012b\n\3\2\2\2"+
-		"\u012c\u012d\7f\2\2\u012d\u012e\7g\2\2\u012e\u012f\7e\2\2\u012f\u0130"+
-		"\7n\2\2\u0130\u0131\7c\2\2\u0131\u0132\7t\2\2\u0132\u0133\7g\2\2\u0133"+
-		"\f\3\2\2\2\u0134\u0135\7q\2\2\u0135\u0136\7t\2\2\u0136\u0137\7f\2\2\u0137"+
-		"\u0138\7g\2\2\u0138\u0139\7t\2\2\u0139\u013a\7k\2\2\u013a\u013b\7p\2\2"+
-		"\u013b\u013c\7i\2\2\u013c\16\3\2\2\2\u013d\u013e\7q\2\2\u013e\u013f\7"+
-		"t\2\2\u013f\u0140\7f\2\2\u0140\u0141\7g\2\2\u0141\u0142\7t\2\2\u0142\u0143"+
-		"\7g\2\2\u0143\u0144\7f\2\2\u0144\20\3\2\2\2\u0145\u0146\7w\2\2\u0146\u0147"+
-		"\7p\2\2\u0147\u0148\7q\2\2\u0148\u0149\7t\2\2\u0149\u014a\7f\2\2\u014a"+
-		"\u014b\7g\2\2\u014b\u014c\7t\2\2\u014c\u014d\7g\2\2\u014d\u014e\7f\2\2"+
-		"\u014e\22\3\2\2\2\u014f\u0150\7f\2\2\u0150\u0151\7g\2\2\u0151\u0152\7"+
-		"e\2\2\u0152\u0153\7k\2\2\u0153\u0154\7o\2\2\u0154\u0155\7c\2\2\u0155\u0156"+
-		"\7n\2\2\u0156\u0157\7/\2\2\u0157\u0158\7h\2\2\u0158\u0159\7q\2\2\u0159"+
-		"\u015a\7t\2\2\u015a\u015b\7o\2\2\u015b\u015c\7c\2\2\u015c\u015d\7v\2\2"+
-		"\u015d\24\3\2\2\2\u015e\u015f\7<\2\2\u015f\26\3\2\2\2\u0160\u0161\7f\2"+
-		"\2\u0161\u0162\7g\2\2\u0162\u0163\7e\2\2\u0163\u0164\7k\2\2\u0164\u0165"+
-		"\7o\2\2\u0165\u0166\7c\2\2\u0166\u0167\7n\2\2\u0167\u0168\7/\2\2\u0168"+
-		"\u0169\7u\2\2\u0169\u016a\7g\2\2\u016a\u016b\7r\2\2\u016b\u016c\7c\2\2"+
-		"\u016c\u016d\7t\2\2\u016d\u016e\7c\2\2\u016e\u016f\7v\2\2\u016f\u0170"+
-		"\7q\2\2\u0170\u0171\7t\2\2\u0171\30\3\2\2\2\u0172\u0173\7i\2\2\u0173\u0174"+
-		"\7t\2\2\u0174\u0175\7q\2\2\u0175\u0176\7w\2\2\u0176\u0177\7r\2\2\u0177"+
-		"\u0178\7k\2\2\u0178\u0179\7p\2\2\u0179\u017a\7i\2\2\u017a\u017b\7/\2\2"+
-		"\u017b\u017c\7u\2\2\u017c\u017d\7g\2\2\u017d\u017e\7r\2\2\u017e\u017f"+
-		"\7c\2\2\u017f\u0180\7t\2\2\u0180\u0181\7c\2\2\u0181\u0182\7v\2\2\u0182"+
-		"\u0183\7q\2\2\u0183\u0184\7t\2\2\u0184\32\3\2\2\2\u0185\u0186\7k\2\2\u0186"+
-		"\u0187\7p\2\2\u0187\u0188\7h\2\2\u0188\u0189\7k\2\2\u0189\u018a\7p\2\2"+
-		"\u018a\u018b\7k\2\2\u018b\u018c\7v\2\2\u018c\u018d\7{\2\2\u018d\34\3\2"+
-		"\2\2\u018e\u018f\7o\2\2\u018f\u0190\7k\2\2\u0190\u0191\7p\2\2\u0191\u0192"+
-		"\7w\2\2\u0192\u0193\7u\2\2\u0193\u0194\7/\2\2\u0194\u0195\7u\2\2\u0195"+
-		"\u0196\7k\2\2\u0196\u0197\7i\2\2\u0197\u0198\7p\2\2\u0198\36\3\2\2\2\u0199"+
-		"\u019a\7P\2\2\u019a\u019b\7c\2\2\u019b\u019c\7P\2\2\u019c \3\2\2\2\u019d"+
-		"\u019e\7r\2\2\u019e\u019f\7g\2\2\u019f\u01a0\7t\2\2\u01a0\u01a1\7e\2\2"+
-		"\u01a1\u01a2\7g\2\2\u01a2\u01a3\7p\2\2\u01a3\u01a4\7v\2\2\u01a4\"\3\2"+
-		"\2\2\u01a5\u01a6\7r\2\2\u01a6\u01a7\7g\2\2\u01a7\u01a8\7t\2\2\u01a8\u01a9"+
-		"\7/\2\2\u01a9\u01aa\7o\2\2\u01aa\u01ab\7k\2\2\u01ab\u01ac\7n\2\2\u01ac"+
-		"\u01ad\7n\2\2\u01ad\u01ae\7g\2\2\u01ae$\3\2\2\2\u01af\u01b0\7|\2\2\u01b0"+
-		"\u01b1\7g\2\2\u01b1\u01b2\7t\2\2\u01b2\u01b3\7q\2\2\u01b3\u01b4\7/\2\2"+
-		"\u01b4\u01b5\7f\2\2\u01b5\u01b6\7k\2\2\u01b6\u01b7\7i\2\2\u01b7\u01b8"+
-		"\7k\2\2\u01b8\u01b9\7v\2\2\u01b9&\3\2\2\2\u01ba\u01bb\7f\2\2\u01bb\u01bc"+
-		"\7k\2\2\u01bc\u01bd\7i\2\2\u01bd\u01be\7k\2\2\u01be\u01bf\7v\2\2\u01bf"+
-		"(\3\2\2\2\u01c0\u01c1\7r\2\2\u01c1\u01c2\7c\2\2\u01c2\u01c3\7v\2\2\u01c3"+
-		"\u01c4\7v\2\2\u01c4\u01c5\7g\2\2\u01c5\u01c6\7t\2\2\u01c6\u01c7\7p\2\2"+
-		"\u01c7\u01c8\7/\2\2\u01c8\u01c9\7u\2\2\u01c9\u01ca\7g\2\2\u01ca\u01cb"+
-		"\7r\2\2\u01cb\u01cc\7c\2\2\u01cc\u01cd\7t\2\2\u01cd\u01ce\7c\2\2\u01ce"+
-		"\u01cf\7v\2\2\u01cf\u01d0\7q\2\2\u01d0\u01d1\7t\2\2\u01d1*\3\2\2\2\u01d2"+
-		"\u01d3\7k\2\2\u01d3\u01d4\7o\2\2\u01d4\u01d5\7r\2\2\u01d5\u01d6\7q\2\2"+
-		"\u01d6\u01d7\7t\2\2\u01d7\u01d8\7v\2\2\u01d8,\3\2\2\2\u01d9\u01da\7.\2"+
-		"\2\u01da.\3\2\2\2\u01db\u01dc\7x\2\2\u01dc\u01dd\7c\2\2\u01dd\u01de\7"+
-		"t\2\2\u01de\u01df\7k\2\2\u01df\u01e0\7c\2\2\u01e0\u01e1\7d\2\2\u01e1\u01e2"+
-		"\7n\2\2\u01e2\u01e3\7g\2\2\u01e3\60\3\2\2\2\u01e4\u01e5\7<\2\2\u01e5\u01e6"+
-		"\7?\2\2\u01e6\62\3\2\2\2\u01e7\u01e8\7g\2\2\u01e8\u01e9\7z\2\2\u01e9\u01ea"+
-		"\7v\2\2\u01ea\u01eb\7g\2\2\u01eb\u01ec\7t\2\2\u01ec\u01ed\7p\2\2\u01ed"+
-		"\u01ee\7c\2\2\u01ee\u01ef\7n\2\2\u01ef\64\3\2\2\2\u01f0\u01f1\7h\2\2\u01f1"+
-		"\u01f2\7w\2\2\u01f2\u01f3\7p\2\2\u01f3\u01f4\7e\2\2\u01f4\u01f5\7v\2\2"+
-		"\u01f5\u01f6\7k\2\2\u01f6\u01f7\7q\2\2\u01f7\u01f8\7p\2\2\u01f8\66\3\2"+
-		"\2\2\u01f9\u01fa\7*\2\2\u01fa8\3\2\2\2\u01fb\u01fc\7+\2\2\u01fc:\3\2\2"+
-		"\2\u01fd\u01fe\7}\2\2\u01fe<\3\2\2\2\u01ff\u0200\7\177\2\2\u0200>\3\2"+
-		"\2\2\u0201\u0202\7&\2\2\u0202@\3\2\2\2\u0203\u0204\7~\2\2\u0204B\3\2\2"+
-		"\2\u0205\u0206\7,\2\2\u0206D\3\2\2\2\u0207\u0208\7g\2\2\u0208\u0209\7"+
-		"s\2\2\u0209F\3\2\2\2\u020a\u020b\7p\2\2\u020b\u020c\7g\2\2\u020cH\3\2"+
-		"\2\2\u020d\u020e\7n\2\2\u020e\u020f\7v\2\2\u020fJ\3\2\2\2\u0210\u0211"+
-		"\7n\2\2\u0211\u0212\7g\2\2\u0212L\3\2\2\2\u0213\u0214\7i\2\2\u0214\u0215"+
-		"\7v\2\2\u0215N\3\2\2\2\u0216\u0217\7i\2\2\u0217\u0218\7g\2\2\u0218P\3"+
-		"\2\2\2\u0219\u021a\7#\2\2\u021a\u021b\7?\2\2\u021bR\3\2\2\2\u021c\u021d"+
-		"\7>\2\2\u021dT\3\2\2\2\u021e\u021f\7>\2\2\u021f\u0220\7?\2\2\u0220V\3"+
-		"\2\2\2\u0221\u0222\7@\2\2\u0222X\3\2\2\2\u0223\u0224\7@\2\2\u0224\u0225"+
-		"\7?\2\2\u0225Z\3\2\2\2\u0226\u0227\7~\2\2\u0227\u0228\7~\2\2\u0228\\\3"+
-		"\2\2\2\u0229\u022a\7-\2\2\u022a^\3\2\2\2\u022b\u022c\7/\2\2\u022c`\3\2"+
-		"\2\2\u022d\u022e\7f\2\2\u022e\u022f\7k\2\2\u022f\u0230\7x\2\2\u0230b\3"+
-		"\2\2\2\u0231\u0232\7k\2\2\u0232\u0233\7f\2\2\u0233\u0234\7k\2\2\u0234"+
-		"\u0235\7x\2\2\u0235d\3\2\2\2\u0236\u0237\7o\2\2\u0237\u0238\7q\2\2\u0238"+
-		"\u0239\7f\2\2\u0239f\3\2\2\2\u023a\u023b\7#\2\2\u023bh\3\2\2\2\u023c\u023d"+
-		"\7]\2\2\u023dj\3\2\2\2\u023e\u023f\7_\2\2\u023fl\3\2\2\2\u0240\u0241\7"+
-		"\60\2\2\u0241n\3\2\2\2\u0242\u0243\7&\2\2\u0243\u0244\7&\2\2\u0244p\3"+
-		"\2\2\2\u0245\u0246\7%\2\2\u0246r\3\2\2\2\u0247\u0248\7}\2\2\u0248\u0249"+
-		"\7~\2\2\u0249t\3\2\2\2\u024a\u024b\7~\2\2\u024b\u024c\7\177\2\2\u024c"+
-		"v\3\2\2\2\u024d\u024e\7k\2\2\u024e\u024f\7v\2\2\u024f\u0250\7g\2\2\u0250"+
-		"\u0251\7o\2\2\u0251x\3\2\2\2\u0252\u0253\7q\2\2\u0253\u0254\7d\2\2\u0254"+
-		"\u0255\7l\2\2\u0255\u0256\7g\2\2\u0256\u0257\7e\2\2\u0257\u0258\7v\2\2"+
-		"\u0258z\3\2\2\2\u0259\u025a\7c\2\2\u025a\u025b\7t\2\2\u025b\u025c\7t\2"+
-		"\2\u025c\u025d\7c\2\2\u025d\u025e\7{\2\2\u025e|\3\2\2\2\u025f\u0260\7"+
-		"u\2\2\u0260\u0261\7v\2\2\u0261\u0262\7t\2\2\u0262\u0263\7k\2\2\u0263\u0264"+
-		"\7p\2\2\u0264\u0265\7i\2\2\u0265~\3\2\2\2\u0266\u0267\7k\2\2\u0267\u0268"+
-		"\7p\2\2\u0268\u0269\7v\2\2\u0269\u026a\7g\2\2\u026a\u026b\7i\2\2\u026b"+
-		"\u026c\7g\2\2\u026c\u026d\7t\2\2\u026d\u0080\3\2\2\2\u026e\u026f\7f\2"+
-		"\2\u026f\u0270\7g\2\2\u0270\u0271\7e\2\2\u0271\u0272\7k\2\2\u0272\u0273"+
-		"\7o\2\2\u0273\u0274\7c\2\2\u0274\u0275\7n\2\2\u0275\u0082\3\2\2\2\u0276"+
-		"\u0277\7f\2\2\u0277\u0278\7q\2\2\u0278\u0279\7w\2\2\u0279\u027a\7d\2\2"+
-		"\u027a\u027b\7n\2\2\u027b\u027c\7g\2\2\u027c\u0084\3\2\2\2\u027d\u027e"+
-		"\7d\2\2\u027e\u027f\7q\2\2\u027f\u0280\7q\2\2\u0280\u0281\7n\2\2\u0281"+
-		"\u0282\7g\2\2\u0282\u0283\7c\2\2\u0283\u0284\7p\2\2\u0284\u0086\3\2\2"+
-		"\2\u0285\u0286\7f\2\2\u0286\u0287\7w\2\2\u0287\u0288\7t\2\2\u0288\u0289"+
-		"\7c\2\2\u0289\u028a\7v\2\2\u028a\u028b\7k\2\2\u028b\u028c\7q\2\2\u028c"+
-		"\u028d\7p\2\2\u028d\u0088\3\2\2\2\u028e\u028f\7{\2\2\u028f\u0290\7g\2"+
-		"\2\u0290\u0291\7c\2\2\u0291\u0292\7t\2\2\u0292\u0293\7O\2\2\u0293\u0294"+
-		"\7q\2\2\u0294\u0295\7p\2\2\u0295\u0296\7v\2\2\u0296\u0297\7j\2\2\u0297"+
-		"\u0298\7F\2\2\u0298\u0299\7w\2\2\u0299\u029a\7t\2\2\u029a\u029b\7c\2\2"+
-		"\u029b\u029c\7v\2\2\u029c\u029d\7k\2\2\u029d\u029e\7q\2\2\u029e\u029f"+
-		"\7p\2\2\u029f\u008a\3\2\2\2\u02a0\u02a1\7f\2\2\u02a1\u02a2\7c\2\2\u02a2"+
-		"\u02a3\7{\2\2\u02a3\u02a4\7V\2\2\u02a4\u02a5\7k\2\2\u02a5\u02a6\7o\2\2"+
-		"\u02a6\u02a7\7g\2\2\u02a7\u02a8\7F\2\2\u02a8\u02a9\7w\2\2\u02a9\u02aa"+
-		"\7t\2\2\u02aa\u02ab\7c\2\2\u02ab\u02ac\7v\2\2\u02ac\u02ad\7k\2\2\u02ad"+
-		"\u02ae\7q\2\2\u02ae\u02af\7p\2\2\u02af\u008c\3\2\2\2\u02b0\u02b1\7j\2"+
-		"\2\u02b1\u02b2\7g\2\2\u02b2\u02b3\7z\2\2\u02b3\u02b4\7D\2\2\u02b4\u02b5"+
-		"\7k\2\2\u02b5\u02b6\7p\2\2\u02b6\u02b7\7c\2\2\u02b7\u02b8\7t\2\2\u02b8"+
-		"\u02b9\7{\2\2\u02b9\u008e\3\2\2\2\u02ba\u02bb\7d\2\2\u02bb\u02bc\7c\2"+
-		"\2\u02bc\u02bd\7u\2\2\u02bd\u02be\7g\2\2\u02be\u02bf\78\2\2\u02bf\u02c0"+
-		"\7\66\2\2\u02c0\u02c1\7D\2\2\u02c1\u02c2\7k\2\2\u02c2\u02c3\7p\2\2\u02c3"+
-		"\u02c4\7c\2\2\u02c4\u02c5\7t\2\2\u02c5\u02c6\7{\2\2\u02c6\u0090\3\2\2"+
-		"\2\u02c7\u02c8\7f\2\2\u02c8\u02c9\7c\2\2\u02c9\u02ca\7v\2\2\u02ca\u02cb"+
-		"\7g\2\2\u02cb\u02cc\7V\2\2\u02cc\u02cd\7k\2\2\u02cd\u02ce\7o\2\2\u02ce"+
-		"\u02cf\7g\2\2\u02cf\u0092\3\2\2\2\u02d0\u02d1\7f\2\2\u02d1\u02d2\7c\2"+
-		"\2\u02d2\u02d3\7v\2\2\u02d3\u02d4\7g\2\2\u02d4\u0094\3\2\2\2\u02d5\u02d6"+
-		"\7v\2\2\u02d6\u02d7\7k\2\2\u02d7\u02d8\7o\2\2\u02d8\u02d9\7g\2\2\u02d9"+
-		"\u0096\3\2\2\2\u02da\u02db\7c\2\2\u02db\u02dc\7p\2\2\u02dc\u02dd\7{\2"+
-		"\2\u02dd\u02de\7W\2\2\u02de\u02df\7T\2\2\u02df\u02e0\7K\2\2\u02e0\u0098"+
-		"\3\2\2\2\u02e1\u02e2\7c\2\2\u02e2\u02e3\7v\2\2\u02e3\u02e4\7q\2\2\u02e4"+
-		"\u02e5\7o\2\2\u02e5\u02e6\7k\2\2\u02e6\u02e7\7e\2\2\u02e7\u009a\3\2\2"+
-		"\2\u02e8\u02e9\7h\2\2\u02e9\u02ea\7q\2\2\u02ea\u02eb\7t\2\2\u02eb\u009c"+
-		"\3\2\2\2\u02ec\u02ed\7n\2\2\u02ed\u02ee\7g\2\2\u02ee\u02ef\7v\2\2\u02ef"+
-		"\u009e\3\2\2\2\u02f0\u02f1\7y\2\2\u02f1\u02f2\7j\2\2\u02f2\u02f3\7g\2"+
-		"\2\u02f3\u02f4\7t\2\2\u02f4\u02f5\7g\2\2\u02f5\u00a0\3\2\2\2\u02f6\u02f7"+
-		"\7i\2\2\u02f7\u02f8\7t\2\2\u02f8\u02f9\7q\2\2\u02f9\u02fa\7w\2\2\u02fa"+
-		"\u02fb\7r\2\2\u02fb\u00a2\3\2\2\2\u02fc\u02fd\7d\2\2\u02fd\u02fe\7{\2"+
-		"\2\u02fe\u00a4\3\2\2\2\u02ff\u0300\7q\2\2\u0300\u0301\7t\2\2\u0301\u0302"+
-		"\7f\2\2\u0302\u0303\7g\2\2\u0303\u0304\7t\2\2\u0304\u00a6\3\2\2\2\u0305"+
-		"\u0306\7t\2\2\u0306\u0307\7g\2\2\u0307\u0308\7v\2\2\u0308\u0309\7w\2\2"+
-		"\u0309\u030a\7t\2\2\u030a\u030b\7p\2\2\u030b\u00a8\3\2\2\2\u030c\u030d"+
-		"\7k\2\2\u030d\u030e\7h\2\2\u030e\u00aa\3\2\2\2\u030f\u0310\7k\2\2\u0310"+
-		"\u0311\7p\2\2\u0311\u00ac\3\2\2\2\u0312\u0313\7c\2\2\u0313\u0314\7u\2"+
-		"\2\u0314\u00ae\3\2\2\2\u0315\u0316\7c\2\2\u0316\u0317\7v\2\2\u0317\u00b0"+
-		"\3\2\2\2\u0318\u0319\7c\2\2\u0319\u031a\7n\2\2\u031a\u031b\7n\2\2\u031b"+
-		"\u031c\7q\2\2\u031c\u031d\7y\2\2\u031d\u031e\7k\2\2\u031e\u031f\7p\2\2"+
-		"\u031f\u0320\7i\2\2\u0320\u00b2\3\2\2\2\u0321\u0322\7g\2\2\u0322\u0323"+
-		"\7o\2\2\u0323\u0324\7r\2\2\u0324\u0325\7v\2\2\u0325\u0326\7{\2\2\u0326"+
-		"\u00b4\3\2\2\2\u0327\u0328\7e\2\2\u0328\u0329\7q\2\2\u0329\u032a\7w\2"+
-		"\2\u032a\u032b\7p\2\2\u032b\u032c\7v\2\2\u032c\u00b6\3\2\2\2\u032d\u032e"+
-		"\7u\2\2\u032e\u032f\7v\2\2\u032f\u0330\7c\2\2\u0330\u0331\7d\2\2\u0331"+
-		"\u0332\7n\2\2\u0332\u0333\7g\2\2\u0333\u00b8\3\2\2\2\u0334\u0335\7c\2"+
-		"\2\u0335\u0336\7u\2\2\u0336\u0337\7e\2\2\u0337\u0338\7g\2\2\u0338\u0339"+
-		"\7p\2\2\u0339\u033a\7f\2\2\u033a\u033b\7k\2\2\u033b\u033c\7p\2\2\u033c"+
-		"\u033d\7i\2\2\u033d\u00ba\3\2\2\2\u033e\u033f\7f\2\2\u033f\u0340\7g\2"+
-		"\2\u0340\u0341\7u\2\2\u0341\u0342\7e\2\2\u0342\u0343\7g\2\2\u0343\u0344"+
-		"\7p\2\2\u0344\u0345\7f\2\2\u0345\u0346\7k\2\2\u0346\u0347\7p\2\2\u0347"+
-		"\u0348\7i\2\2\u0348\u00bc\3\2\2\2\u0349\u034a\7u\2\2\u034a\u034b\7q\2"+
-		"\2\u034b\u034c\7o\2\2\u034c\u034d\7g\2\2\u034d\u00be\3\2\2\2\u034e\u034f"+
-		"\7g\2\2\u034f\u0350\7x\2\2\u0350\u0351\7g\2\2\u0351\u0352\7t\2\2\u0352"+
-		"\u0353\7{\2\2\u0353\u00c0\3\2\2\2\u0354\u0355\7u\2\2\u0355\u0356\7c\2"+
-		"\2\u0356\u0357\7v\2\2\u0357\u0358\7k\2\2\u0358\u0359\7u\2\2\u0359\u035a"+
-		"\7h\2\2\u035a\u035b\7k\2\2\u035b\u035c\7g\2\2\u035c\u035d\7u\2\2\u035d"+
-		"\u00c2\3\2\2\2\u035e\u035f\7e\2\2\u035f\u0360\7q\2\2\u0360\u0361\7n\2"+
-		"\2\u0361\u0362\7n\2\2\u0362\u0363\7c\2\2\u0363\u0364\7v\2\2\u0364\u0365"+
-		"\7k\2\2\u0365\u0366\7q\2\2\u0366\u0367\7p\2\2\u0367\u00c4\3\2\2\2\u0368"+
-		"\u0369\7i\2\2\u0369\u036a\7t\2\2\u036a\u036b\7g\2\2\u036b\u036c\7c\2\2"+
-		"\u036c\u036d\7v\2\2\u036d\u036e\7g\2\2\u036e\u036f\7u\2\2\u036f\u0370"+
-		"\7v\2\2\u0370\u00c6\3\2\2\2\u0371\u0372\7n\2\2\u0372\u0373\7g\2\2\u0373"+
-		"\u0374\7c\2\2\u0374\u0375\7u\2\2\u0375\u0376\7v\2\2\u0376\u00c8\3\2\2"+
-		"\2\u0377\u0378\7u\2\2\u0378\u0379\7y\2\2\u0379\u037a\7k\2\2\u037a\u037b"+
-		"\7v\2\2\u037b\u037c\7e\2\2\u037c\u037d\7j\2\2\u037d\u00ca\3\2\2\2\u037e"+
-		"\u037f\7e\2\2\u037f\u0380\7c\2\2\u0380\u0381\7u\2\2\u0381\u0382\7g\2\2"+
-		"\u0382\u00cc\3\2\2\2\u0383\u0384\7v\2\2\u0384\u0385\7t\2\2\u0385\u0386"+
-		"\7{\2\2\u0386\u00ce\3\2\2\2\u0387\u0388\7e\2\2\u0388\u0389\7c\2\2\u0389"+
-		"\u038a\7v\2\2\u038a\u038b\7e\2\2\u038b\u038c\7j\2\2\u038c\u00d0\3\2\2"+
-		"\2\u038d\u038e\7f\2\2\u038e\u038f\7g\2\2\u038f\u0390\7h\2\2\u0390\u0391"+
-		"\7c\2\2\u0391\u0392\7w\2\2\u0392\u0393\7n\2\2\u0393\u0394\7v\2\2\u0394"+
-		"\u00d2\3\2\2\2\u0395\u0396\7v\2\2\u0396\u0397\7j\2\2\u0397\u0398\7g\2"+
-		"\2\u0398\u0399\7p\2\2\u0399\u00d4\3\2\2\2\u039a\u039b\7g\2\2\u039b\u039c"+
-		"\7n\2\2\u039c\u039d\7u\2\2\u039d\u039e\7g\2\2\u039e\u00d6\3\2\2\2\u039f"+
-		"\u03a0\7v\2\2\u03a0\u03a1\7{\2\2\u03a1\u03a2\7r\2\2\u03a2\u03a3\7g\2\2"+
-		"\u03a3\u03a4\7u\2\2\u03a4\u03a5\7y\2\2\u03a5\u03a6\7k\2\2\u03a6\u03a7"+
-		"\7v\2\2\u03a7\u03a8\7e\2\2\u03a8\u03a9\7j\2\2\u03a9\u00d8\3\2\2\2\u03aa"+
-		"\u03ab\7q\2\2\u03ab\u03ac\7t\2\2\u03ac\u00da\3\2\2\2\u03ad\u03ae\7c\2"+
-		"\2\u03ae\u03af\7p\2\2\u03af\u03b0\7f\2\2\u03b0\u00dc\3\2\2\2\u03b1\u03b2"+
-		"\7p\2\2\u03b2\u03b3\7q\2\2\u03b3\u03b4\7v\2\2\u03b4\u00de\3\2\2\2\u03b5"+
-		"\u03b6\7v\2\2\u03b6\u03b7\7q\2\2\u03b7\u00e0\3\2\2\2\u03b8\u03b9\7k\2"+
-		"\2\u03b9\u03ba\7p\2\2\u03ba\u03bb\7u\2\2\u03bb\u03bc\7v\2\2\u03bc\u03bd"+
-		"\7c\2\2\u03bd\u03be\7p\2\2\u03be\u03bf\7e\2\2\u03bf\u03c0\7g\2\2\u03c0"+
-		"\u00e2\3\2\2\2\u03c1\u03c2\7q\2\2\u03c2\u03c3\7h\2\2\u03c3\u00e4\3\2\2"+
-		"\2\u03c4\u03c5\7v\2\2\u03c5\u03c6\7t\2\2\u03c6\u03c7\7g\2\2\u03c7\u03c8"+
-		"\7c\2\2\u03c8\u03c9\7v\2\2\u03c9\u00e6\3\2\2\2\u03ca\u03cb\7e\2\2\u03cb"+
-		"\u03cc\7c\2\2\u03cc\u03cd\7u\2\2\u03cd\u03ce\7v\2\2\u03ce\u00e8\3\2\2"+
-		"\2\u03cf\u03d0\7e\2\2\u03d0\u03d1\7c\2\2\u03d1\u03d2\7u\2\2\u03d2\u03d3"+
-		"\7v\2\2\u03d3\u03d4\7c\2\2\u03d4\u03d5\7d\2\2\u03d5\u03d6\7n\2\2\u03d6"+
-		"\u03d7\7g\2\2\u03d7\u00ea\3\2\2\2\u03d8\u03d9\7x\2\2\u03d9\u03da\7g\2"+
-		"\2\u03da\u03db\7t\2\2\u03db\u03dc\7u\2\2\u03dc\u03dd\7k\2\2\u03dd\u03de"+
-		"\7q\2\2\u03de\u03df\7p\2\2\u03df\u00ec\3\2\2\2\u03e0\u03e1\7l\2\2\u03e1"+
-		"\u03e2\7u\2\2\u03e2\u03e3\7q\2\2\u03e3\u03e4\7p\2\2\u03e4\u03e5\7k\2\2"+
-		"\u03e5\u03e6\7s\2\2\u03e6\u00ee\3\2\2\2\u03e7\u03e8\7l\2\2\u03e8\u03e9"+
-		"\7u\2\2\u03e9\u03ea\7q\2\2\u03ea\u03eb\7p\2\2\u03eb\u03ec\7/\2\2\u03ec"+
-		"\u03ed\7k\2\2\u03ed\u03ee\7v\2\2\u03ee\u03ef\7g\2\2\u03ef\u03f0\7o\2\2"+
-		"\u03f0\u00f0\3\2\2\2\u03f1\u03f6\7$\2\2\u03f2\u03f5\5\u00f3z\2\u03f3\u03f5"+
-		"\n\2\2\2\u03f4\u03f2\3\2\2\2\u03f4\u03f3\3\2\2\2\u03f5\u03f8\3\2\2\2\u03f6"+
-		"\u03f4\3\2\2\2\u03f6\u03f7\3\2\2\2\u03f7\u03f9\3\2\2\2\u03f8\u03f6\3\2"+
-		"\2\2\u03f9\u03fa\7$\2\2\u03fa\u00f2\3\2\2\2\u03fb\u03fe\7^\2\2\u03fc\u03ff"+
-		"\t\3\2\2\u03fd\u03ff\5\u00f5{\2\u03fe\u03fc\3\2\2\2\u03fe\u03fd\3\2\2"+
-		"\2\u03ff\u00f4\3\2\2\2\u0400\u0401\7w\2\2\u0401\u0402\5\u00f7|\2\u0402"+
-		"\u0403\5\u00f7|\2\u0403\u0404\5\u00f7|\2\u0404\u0405\5\u00f7|\2\u0405"+
-		"\u00f6\3\2\2\2\u0406\u0407\t\4\2\2\u0407\u00f8\3\2\2\2\u0408\u0409\7A"+
-		"\2\2\u0409\u00fa\3\2\2\2\u040a\u040b\7p\2\2\u040b\u040c\7w\2\2\u040c\u040d"+
-		"\7n\2\2\u040d\u040e\7n\2\2\u040e\u00fc\3\2\2\2\u040f\u0412\5\u00ff\u0080"+
-		"\2\u0410\u0412\5\u0101\u0081\2\u0411\u040f\3\2\2\2\u0411\u0410\3\2\2\2"+
-		"\u0412\u00fe\3\2\2\2\u0413\u0417\5\u0103\u0082\2\u0414\u0417\5\u0105\u0083"+
-		"\2\u0415\u0417\5\u0107\u0084\2\u0416\u0413\3\2\2\2\u0416\u0414\3\2\2\2"+
-		"\u0416\u0415\3\2\2\2\u0417\u0100\3\2\2\2\u0418\u0419\7v\2\2\u0419\u041a"+
-		"\7t\2\2\u041a\u041b\7w\2\2\u041b\u0422\7g\2\2\u041c\u041d\7h\2\2\u041d"+
-		"\u041e\7c\2\2\u041e\u041f\7n\2\2\u041f\u0420\7u\2\2\u0420\u0422\7g\2\2"+
-		"\u0421\u0418\3\2\2\2\u0421\u041c\3\2\2\2\u0422\u0102\3\2\2\2\u0423\u0424"+
-		"\5\u0109\u0085\2\u0424\u0104\3\2\2\2\u0425\u0426\7\60\2\2\u0426\u0430"+
-		"\5\u0109\u0085\2\u0427\u0428\5\u0109\u0085\2\u0428\u042c\7\60\2\2\u0429"+
-		"\u042b\t\5\2\2\u042a\u0429\3\2\2\2\u042b\u042e\3\2\2\2\u042c\u042a\3\2"+
-		"\2\2\u042c\u042d\3\2\2\2\u042d\u0430\3\2\2\2\u042e\u042c\3\2\2\2\u042f"+
-		"\u0425\3\2\2\2\u042f\u0427\3\2\2\2\u0430\u0106\3\2\2\2\u0431\u0432\7\60"+
-		"\2\2\u0432\u043e\5\u0109\u0085\2\u0433\u043b\5\u0109\u0085\2\u0434\u0438"+
-		"\7\60\2\2\u0435\u0437\t\5\2\2\u0436\u0435\3\2\2\2\u0437\u043a\3\2\2\2"+
-		"\u0438\u0436\3\2\2\2\u0438\u0439\3\2\2\2\u0439\u043c\3\2\2\2\u043a\u0438"+
-		"\3\2\2\2\u043b\u0434\3\2\2\2\u043b\u043c\3\2\2\2\u043c\u043e\3\2\2\2\u043d"+
-		"\u0431\3\2\2\2\u043d\u0433\3\2\2\2\u043e\u043f\3\2\2\2\u043f\u0441\t\6"+
-		"\2\2\u0440\u0442\t\7\2\2\u0441\u0440\3\2\2\2\u0441\u0442\3\2\2\2\u0442"+
-		"\u0443\3\2\2\2\u0443\u0444\5\u0109\u0085\2\u0444\u0108\3\2\2\2\u0445\u0447"+
-		"\t\5\2\2\u0446\u0445\3\2\2\2\u0447\u0448\3\2\2\2\u0448\u0446\3\2\2\2\u0448"+
-		"\u0449\3\2\2\2\u0449\u010a\3\2\2\2\u044a\u044b\t\b\2\2\u044b\u044c\3\2"+
-		"\2\2\u044c\u044d\b\u0086\2\2\u044d\u010c\3\2\2\2\u044e\u0452\5\u010f\u0088"+
-		"\2\u044f\u0451\5\u0111\u0089\2\u0450\u044f\3\2\2\2\u0451\u0454\3\2\2\2"+
-		"\u0452\u0450\3\2\2\2\u0452\u0453\3\2\2\2\u0453\u010e\3\2\2\2\u0454\u0452"+
-		"\3\2\2\2\u0455\u0457\t\t\2\2\u0456\u0455\3\2\2\2\u0457\u0110\3\2\2\2\u0458"+
-		"\u045b\5\u010f\u0088\2\u0459\u045b\t\n\2\2\u045a\u0458\3\2\2\2\u045a\u0459"+
-		"\3\2\2\2\u045b\u0112\3\2\2\2\u045c\u045d\7*\2\2\u045d\u0466\7<\2\2\u045e"+
-		"\u0465\5\u0113\u008a\2\u045f\u0460\7*\2\2\u0460\u0465\n\13\2\2\u0461\u0462"+
-		"\7<\2\2\u0462\u0465\n\f\2\2\u0463\u0465\n\r\2\2\u0464\u045e\3\2\2\2\u0464"+
-		"\u045f\3\2\2\2\u0464\u0461\3\2\2\2\u0464\u0463\3\2\2\2\u0465\u0468\3\2"+
-		"\2\2\u0466\u0464\3\2\2\2\u0466\u0467\3\2\2\2\u0467\u046a\3\2\2\2\u0468"+
-		"\u0466\3\2\2\2\u0469\u046b\7<\2\2\u046a\u0469\3\2\2\2\u046b\u046c\3\2"+
-		"\2\2\u046c\u046a\3\2\2\2\u046c\u046d\3\2\2\2\u046d\u046e\3\2\2\2\u046e"+
-		"\u046f\7+\2\2\u046f\u0470\3\2\2\2\u0470\u0471\b\u008a\2\2\u0471\u0114"+
-		"\3\2\2\2\u0472\u0473\n\16\2\2\u0473\u0116\3\2\2\2\26\2\u03f4\u03f6\u03fe"+
-		"\u0411\u0416\u0421\u042c\u042f\u0438\u043b\u043d\u0441\u0448\u0452\u0456"+
-		"\u045a\u0464\u0466\u046c\3\2\3\2";
-	public static final ATN _ATN =
-		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
-	static {
-		_decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
-		for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {
-			_decisionToDFA[i] = new DFA(_ATN.getDecisionState(i), i);
-		}
-	}
+    public static final String _serializedATN =
+            "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\2\u0086\u0474\b\1\4" +
+                    "\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n" +
+                    "\4\13\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22" +
+                    "\t\22\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31" +
+                    "\t\31\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t" +
+                    " \4!\t!\4\"\t\"\4#\t#\4$\t$\4%\t%\4&\t&\4\'\t\'\4(\t(\4)\t)\4*\t*\4+\t" +
+                    "+\4,\t,\4-\t-\4.\t.\4/\t/\4\60\t\60\4\61\t\61\4\62\t\62\4\63\t\63\4\64" +
+                    "\t\64\4\65\t\65\4\66\t\66\4\67\t\67\48\t8\49\t9\4:\t:\4;\t;\4<\t<\4=\t" +
+                    "=\4>\t>\4?\t?\4@\t@\4A\tA\4B\tB\4C\tC\4D\tD\4E\tE\4F\tF\4G\tG\4H\tH\4" +
+                    "I\tI\4J\tJ\4K\tK\4L\tL\4M\tM\4N\tN\4O\tO\4P\tP\4Q\tQ\4R\tR\4S\tS\4T\t" +
+                    "T\4U\tU\4V\tV\4W\tW\4X\tX\4Y\tY\4Z\tZ\4[\t[\4\\\t\\\4]\t]\4^\t^\4_\t_" +
+                    "\4`\t`\4a\ta\4b\tb\4c\tc\4d\td\4e\te\4f\tf\4g\tg\4h\th\4i\ti\4j\tj\4k" +
+                    "\tk\4l\tl\4m\tm\4n\tn\4o\to\4p\tp\4q\tq\4r\tr\4s\ts\4t\tt\4u\tu\4v\tv" +
+                    "\4w\tw\4x\tx\4y\ty\4z\tz\4{\t{\4|\t|\4}\t}\4~\t~\4\177\t\177\4\u0080\t" +
+                    "\u0080\4\u0081\t\u0081\4\u0082\t\u0082\4\u0083\t\u0083\4\u0084\t\u0084" +
+                    "\4\u0085\t\u0085\4\u0086\t\u0086\4\u0087\t\u0087\4\u0088\t\u0088\4\u0089" +
+                    "\t\u0089\4\u008a\t\u008a\4\u008b\t\u008b\3\2\3\2\3\3\3\3\3\3\3\3\3\3\3" +
+                    "\3\3\3\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\5\3\5\3\6\3\6\3\6\3\6" +
+                    "\3\6\3\6\3\6\3\6\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\7\3\b\3\b\3\b\3\b\3" +
+                    "\b\3\b\3\b\3\b\3\t\3\t\3\t\3\t\3\t\3\t\3\t\3\t\3\t\3\t\3\n\3\n\3\n\3\n" +
+                    "\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\n\3\13\3\13\3\f\3\f\3\f\3\f" +
+                    "\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\f\3\r\3\r\3\r\3" +
+                    "\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\16\3" +
+                    "\16\3\16\3\16\3\16\3\16\3\16\3\16\3\16\3\17\3\17\3\17\3\17\3\17\3\17\3" +
+                    "\17\3\17\3\17\3\17\3\17\3\20\3\20\3\20\3\20\3\21\3\21\3\21\3\21\3\21\3" +
+                    "\21\3\21\3\21\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\22\3\23\3" +
+                    "\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\23\3\24\3\24\3\24\3\24\3" +
+                    "\24\3\24\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3\25\3" +
+                    "\25\3\25\3\25\3\25\3\25\3\25\3\26\3\26\3\26\3\26\3\26\3\26\3\26\3\27\3" +
+                    "\27\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\30\3\31\3\31\3\31\3\32\3" +
+                    "\32\3\32\3\32\3\32\3\32\3\32\3\32\3\32\3\33\3\33\3\33\3\33\3\33\3\33\3" +
+                    "\33\3\33\3\33\3\34\3\34\3\35\3\35\3\36\3\36\3\37\3\37\3 \3 \3!\3!\3\"" +
+                    "\3\"\3#\3#\3#\3$\3$\3$\3%\3%\3%\3&\3&\3&\3\'\3\'\3\'\3(\3(\3(\3)\3)\3" +
+                    ")\3*\3*\3+\3+\3+\3,\3,\3-\3-\3-\3.\3.\3.\3/\3/\3\60\3\60\3\61\3\61\3\61" +
+                    "\3\61\3\62\3\62\3\62\3\62\3\62\3\63\3\63\3\63\3\63\3\64\3\64\3\65\3\65" +
+                    "\3\66\3\66\3\67\3\67\38\38\38\39\39\3:\3:\3:\3;\3;\3;\3<\3<\3<\3<\3<\3" +
+                    "=\3=\3=\3=\3=\3=\3=\3>\3>\3>\3>\3>\3>\3?\3?\3?\3?\3?\3?\3?\3@\3@\3@\3" +
+                    "@\3@\3@\3@\3@\3A\3A\3A\3A\3A\3A\3A\3A\3B\3B\3B\3B\3B\3B\3B\3C\3C\3C\3" +
+                    "C\3C\3C\3C\3C\3D\3D\3D\3D\3D\3D\3D\3D\3D\3E\3E\3E\3E\3E\3E\3E\3E\3E\3" +
+                    "E\3E\3E\3E\3E\3E\3E\3E\3E\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3F\3" +
+                    "F\3F\3G\3G\3G\3G\3G\3G\3G\3G\3G\3G\3H\3H\3H\3H\3H\3H\3H\3H\3H\3H\3H\3" +
+                    "H\3H\3I\3I\3I\3I\3I\3I\3I\3I\3I\3J\3J\3J\3J\3J\3K\3K\3K\3K\3K\3L\3L\3" +
+                    "L\3L\3L\3L\3L\3M\3M\3M\3M\3M\3M\3M\3N\3N\3N\3N\3O\3O\3O\3O\3P\3P\3P\3" +
+                    "P\3P\3P\3Q\3Q\3Q\3Q\3Q\3Q\3R\3R\3R\3S\3S\3S\3S\3S\3S\3T\3T\3T\3T\3T\3" +
+                    "T\3T\3U\3U\3U\3V\3V\3V\3W\3W\3W\3X\3X\3X\3Y\3Y\3Y\3Y\3Y\3Y\3Y\3Y\3Y\3" +
+                    "Z\3Z\3Z\3Z\3Z\3Z\3[\3[\3[\3[\3[\3[\3\\\3\\\3\\\3\\\3\\\3\\\3\\\3]\3]\3" +
+                    "]\3]\3]\3]\3]\3]\3]\3]\3^\3^\3^\3^\3^\3^\3^\3^\3^\3^\3^\3_\3_\3_\3_\3" +
+                    "_\3`\3`\3`\3`\3`\3`\3a\3a\3a\3a\3a\3a\3a\3a\3a\3a\3b\3b\3b\3b\3b\3b\3" +
+                    "b\3b\3b\3b\3c\3c\3c\3c\3c\3c\3c\3c\3c\3d\3d\3d\3d\3d\3d\3e\3e\3e\3e\3" +
+                    "e\3e\3e\3f\3f\3f\3f\3f\3g\3g\3g\3g\3h\3h\3h\3h\3h\3h\3i\3i\3i\3i\3i\3" +
+                    "i\3i\3i\3j\3j\3j\3j\3j\3k\3k\3k\3k\3k\3l\3l\3l\3l\3l\3l\3l\3l\3l\3l\3" +
+                    "l\3m\3m\3m\3n\3n\3n\3n\3o\3o\3o\3o\3p\3p\3p\3q\3q\3q\3q\3q\3q\3q\3q\3" +
+                    "q\3r\3r\3r\3s\3s\3s\3s\3s\3s\3t\3t\3t\3t\3t\3u\3u\3u\3u\3u\3u\3u\3u\3" +
+                    "u\3v\3v\3v\3v\3v\3v\3v\3v\3w\3w\3w\3w\3w\3w\3w\3x\3x\3x\3x\3x\3x\3x\3" +
+                    "x\3x\3x\3y\3y\3y\7y\u03f5\ny\fy\16y\u03f8\13y\3y\3y\3z\3z\3z\5z\u03ff" +
+                    "\nz\3{\3{\3{\3{\3{\3{\3|\3|\3}\3}\3~\3~\3~\3~\3~\3\177\3\177\5\177\u0412" +
+                    "\n\177\3\u0080\3\u0080\3\u0080\5\u0080\u0417\n\u0080\3\u0081\3\u0081\3" +
+                    "\u0081\3\u0081\3\u0081\3\u0081\3\u0081\3\u0081\3\u0081\5\u0081\u0422\n" +
+                    "\u0081\3\u0082\3\u0082\3\u0083\3\u0083\3\u0083\3\u0083\3\u0083\7\u0083" +
+                    "\u042b\n\u0083\f\u0083\16\u0083\u042e\13\u0083\5\u0083\u0430\n\u0083\3" +
+                    "\u0084\3\u0084\3\u0084\3\u0084\3\u0084\7\u0084\u0437\n\u0084\f\u0084\16" +
+                    "\u0084\u043a\13\u0084\5\u0084\u043c\n\u0084\5\u0084\u043e\n\u0084\3\u0084" +
+                    "\3\u0084\5\u0084\u0442\n\u0084\3\u0084\3\u0084\3\u0085\6\u0085\u0447\n" +
+                    "\u0085\r\u0085\16\u0085\u0448\3\u0086\3\u0086\3\u0086\3\u0086\3\u0087" +
+                    "\3\u0087\7\u0087\u0451\n\u0087\f\u0087\16\u0087\u0454\13\u0087\3\u0088" +
+                    "\5\u0088\u0457\n\u0088\3\u0089\3\u0089\5\u0089\u045b\n\u0089\3\u008a\3" +
+                    "\u008a\3\u008a\3\u008a\3\u008a\3\u008a\3\u008a\3\u008a\7\u008a\u0465\n" +
+                    "\u008a\f\u008a\16\u008a\u0468\13\u008a\3\u008a\6\u008a\u046b\n\u008a\r" +
+                    "\u008a\16\u008a\u046c\3\u008a\3\u008a\3\u008a\3\u008a\3\u008b\3\u008b" +
+                    "\2\2\u008c\3\3\5\4\7\5\t\6\13\7\r\b\17\t\21\n\23\13\25\f\27\r\31\16\33" +
+                    "\17\35\20\37\21!\22#\23%\24\'\25)\26+\27-\30/\31\61\32\63\33\65\34\67" +
+                    "\359\36;\37= ?!A\"C#E$G%I&K\'M(O)Q*S+U,W-Y.[/]\60_\61a\62c\63e\64g\65" +
+                    "i\66k\67m8o9q:s;u<w=y>{?}@\177A\u0081B\u0083C\u0085D\u0087E\u0089F\u008b" +
+                    "G\u008dH\u008fI\u0091J\u0093K\u0095L\u0097M\u0099N\u009bO\u009dP\u009f" +
+                    "Q\u00a1R\u00a3S\u00a5T\u00a7U\u00a9V\u00abW\u00adX\u00afY\u00b1Z\u00b3" +
+                    "[\u00b5\\\u00b7]\u00b9^\u00bb_\u00bd`\u00bfa\u00c1b\u00c3c\u00c5d\u00c7" +
+                    "e\u00c9f\u00cbg\u00cdh\u00cfi\u00d1j\u00d3k\u00d5l\u00d7m\u00d9n\u00db" +
+                    "o\u00ddp\u00dfq\u00e1r\u00e3s\u00e5t\u00e7u\u00e9v\u00ebw\u00edx\u00ef" +
+                    "y\u00f1z\u00f3\2\u00f5\2\u00f7\2\u00f9{\u00fb|\u00fd}\u00ff~\u0101\177" +
+                    "\u0103\u0080\u0105\u0081\u0107\u0082\u0109\2\u010b\u0083\u010d\u0084\u010f" +
+                    "\2\u0111\2\u0113\u0085\u0115\u0086\3\2\17\4\2$$^^\n\2$$\61\61^^ddhhpp" +
+                    "ttvv\5\2\62;CHch\3\2\62;\4\2GGgg\4\2--//\5\2\13\f\17\17\"\"\20\2C\\aa" +
+                    "c|\u00c2\u00d8\u00da\u00f8\u00fa\u0301\u0372\u037f\u0381\u2001\u200e\u200f" +
+                    "\u2072\u2191\u2c02\u2ff1\u3003\ud801\uf902\ufdd1\ufdf2\uffff\7\2//\62" +
+                    ";\u00b9\u00b9\u0302\u0371\u2041\u2042\3\2<<\3\2++\4\2**<<\7\2$$()>>}}" +
+                    "\177\177\2\u0482\2\3\3\2\2\2\2\5\3\2\2\2\2\7\3\2\2\2\2\t\3\2\2\2\2\13" +
+                    "\3\2\2\2\2\r\3\2\2\2\2\17\3\2\2\2\2\21\3\2\2\2\2\23\3\2\2\2\2\25\3\2\2" +
+                    "\2\2\27\3\2\2\2\2\31\3\2\2\2\2\33\3\2\2\2\2\35\3\2\2\2\2\37\3\2\2\2\2" +
+                    "!\3\2\2\2\2#\3\2\2\2\2%\3\2\2\2\2\'\3\2\2\2\2)\3\2\2\2\2+\3\2\2\2\2-\3" +
+                    "\2\2\2\2/\3\2\2\2\2\61\3\2\2\2\2\63\3\2\2\2\2\65\3\2\2\2\2\67\3\2\2\2" +
+                    "\29\3\2\2\2\2;\3\2\2\2\2=\3\2\2\2\2?\3\2\2\2\2A\3\2\2\2\2C\3\2\2\2\2E" +
+                    "\3\2\2\2\2G\3\2\2\2\2I\3\2\2\2\2K\3\2\2\2\2M\3\2\2\2\2O\3\2\2\2\2Q\3\2" +
+                    "\2\2\2S\3\2\2\2\2U\3\2\2\2\2W\3\2\2\2\2Y\3\2\2\2\2[\3\2\2\2\2]\3\2\2\2" +
+                    "\2_\3\2\2\2\2a\3\2\2\2\2c\3\2\2\2\2e\3\2\2\2\2g\3\2\2\2\2i\3\2\2\2\2k" +
+                    "\3\2\2\2\2m\3\2\2\2\2o\3\2\2\2\2q\3\2\2\2\2s\3\2\2\2\2u\3\2\2\2\2w\3\2" +
+                    "\2\2\2y\3\2\2\2\2{\3\2\2\2\2}\3\2\2\2\2\177\3\2\2\2\2\u0081\3\2\2\2\2" +
+                    "\u0083\3\2\2\2\2\u0085\3\2\2\2\2\u0087\3\2\2\2\2\u0089\3\2\2\2\2\u008b" +
+                    "\3\2\2\2\2\u008d\3\2\2\2\2\u008f\3\2\2\2\2\u0091\3\2\2\2\2\u0093\3\2\2" +
+                    "\2\2\u0095\3\2\2\2\2\u0097\3\2\2\2\2\u0099\3\2\2\2\2\u009b\3\2\2\2\2\u009d" +
+                    "\3\2\2\2\2\u009f\3\2\2\2\2\u00a1\3\2\2\2\2\u00a3\3\2\2\2\2\u00a5\3\2\2" +
+                    "\2\2\u00a7\3\2\2\2\2\u00a9\3\2\2\2\2\u00ab\3\2\2\2\2\u00ad\3\2\2\2\2\u00af" +
+                    "\3\2\2\2\2\u00b1\3\2\2\2\2\u00b3\3\2\2\2\2\u00b5\3\2\2\2\2\u00b7\3\2\2" +
+                    "\2\2\u00b9\3\2\2\2\2\u00bb\3\2\2\2\2\u00bd\3\2\2\2\2\u00bf\3\2\2\2\2\u00c1" +
+                    "\3\2\2\2\2\u00c3\3\2\2\2\2\u00c5\3\2\2\2\2\u00c7\3\2\2\2\2\u00c9\3\2\2" +
+                    "\2\2\u00cb\3\2\2\2\2\u00cd\3\2\2\2\2\u00cf\3\2\2\2\2\u00d1\3\2\2\2\2\u00d3" +
+                    "\3\2\2\2\2\u00d5\3\2\2\2\2\u00d7\3\2\2\2\2\u00d9\3\2\2\2\2\u00db\3\2\2" +
+                    "\2\2\u00dd\3\2\2\2\2\u00df\3\2\2\2\2\u00e1\3\2\2\2\2\u00e3\3\2\2\2\2\u00e5" +
+                    "\3\2\2\2\2\u00e7\3\2\2\2\2\u00e9\3\2\2\2\2\u00eb\3\2\2\2\2\u00ed\3\2\2" +
+                    "\2\2\u00ef\3\2\2\2\2\u00f1\3\2\2\2\2\u00f9\3\2\2\2\2\u00fb\3\2\2\2\2\u00fd" +
+                    "\3\2\2\2\2\u00ff\3\2\2\2\2\u0101\3\2\2\2\2\u0103\3\2\2\2\2\u0105\3\2\2" +
+                    "\2\2\u0107\3\2\2\2\2\u010b\3\2\2\2\2\u010d\3\2\2\2\2\u0113\3\2\2\2\2\u0115" +
+                    "\3\2\2\2\3\u0117\3\2\2\2\5\u0119\3\2\2\2\7\u0120\3\2\2\2\t\u012a\3\2\2" +
+                    "\2\13\u012c\3\2\2\2\r\u0134\3\2\2\2\17\u013d\3\2\2\2\21\u0145\3\2\2\2" +
+                    "\23\u014f\3\2\2\2\25\u015e\3\2\2\2\27\u0160\3\2\2\2\31\u0172\3\2\2\2\33" +
+                    "\u0185\3\2\2\2\35\u018e\3\2\2\2\37\u0199\3\2\2\2!\u019d\3\2\2\2#\u01a5" +
+                    "\3\2\2\2%\u01af\3\2\2\2\'\u01ba\3\2\2\2)\u01c0\3\2\2\2+\u01d2\3\2\2\2" +
+                    "-\u01d9\3\2\2\2/\u01db\3\2\2\2\61\u01e4\3\2\2\2\63\u01e7\3\2\2\2\65\u01f0" +
+                    "\3\2\2\2\67\u01f9\3\2\2\29\u01fb\3\2\2\2;\u01fd\3\2\2\2=\u01ff\3\2\2\2" +
+                    "?\u0201\3\2\2\2A\u0203\3\2\2\2C\u0205\3\2\2\2E\u0207\3\2\2\2G\u020a\3" +
+                    "\2\2\2I\u020d\3\2\2\2K\u0210\3\2\2\2M\u0213\3\2\2\2O\u0216\3\2\2\2Q\u0219" +
+                    "\3\2\2\2S\u021c\3\2\2\2U\u021e\3\2\2\2W\u0221\3\2\2\2Y\u0223\3\2\2\2[" +
+                    "\u0226\3\2\2\2]\u0229\3\2\2\2_\u022b\3\2\2\2a\u022d\3\2\2\2c\u0231\3\2" +
+                    "\2\2e\u0236\3\2\2\2g\u023a\3\2\2\2i\u023c\3\2\2\2k\u023e\3\2\2\2m\u0240" +
+                    "\3\2\2\2o\u0242\3\2\2\2q\u0245\3\2\2\2s\u0247\3\2\2\2u\u024a\3\2\2\2w" +
+                    "\u024d\3\2\2\2y\u0252\3\2\2\2{\u0259\3\2\2\2}\u025f\3\2\2\2\177\u0266" +
+                    "\3\2\2\2\u0081\u026e\3\2\2\2\u0083\u0276\3\2\2\2\u0085\u027d\3\2\2\2\u0087" +
+                    "\u0285\3\2\2\2\u0089\u028e\3\2\2\2\u008b\u02a0\3\2\2\2\u008d\u02b0\3\2" +
+                    "\2\2\u008f\u02ba\3\2\2\2\u0091\u02c7\3\2\2\2\u0093\u02d0\3\2\2\2\u0095" +
+                    "\u02d5\3\2\2\2\u0097\u02da\3\2\2\2\u0099\u02e1\3\2\2\2\u009b\u02e8\3\2" +
+                    "\2\2\u009d\u02ec\3\2\2\2\u009f\u02f0\3\2\2\2\u00a1\u02f6\3\2\2\2\u00a3" +
+                    "\u02fc\3\2\2\2\u00a5\u02ff\3\2\2\2\u00a7\u0305\3\2\2\2\u00a9\u030c\3\2" +
+                    "\2\2\u00ab\u030f\3\2\2\2\u00ad\u0312\3\2\2\2\u00af\u0315\3\2\2\2\u00b1" +
+                    "\u0318\3\2\2\2\u00b3\u0321\3\2\2\2\u00b5\u0327\3\2\2\2\u00b7\u032d\3\2" +
+                    "\2\2\u00b9\u0334\3\2\2\2\u00bb\u033e\3\2\2\2\u00bd\u0349\3\2\2\2\u00bf" +
+                    "\u034e\3\2\2\2\u00c1\u0354\3\2\2\2\u00c3\u035e\3\2\2\2\u00c5\u0368\3\2" +
+                    "\2\2\u00c7\u0371\3\2\2\2\u00c9\u0377\3\2\2\2\u00cb\u037e\3\2\2\2\u00cd" +
+                    "\u0383\3\2\2\2\u00cf\u0387\3\2\2\2\u00d1\u038d\3\2\2\2\u00d3\u0395\3\2" +
+                    "\2\2\u00d5\u039a\3\2\2\2\u00d7\u039f\3\2\2\2\u00d9\u03aa\3\2\2\2\u00db" +
+                    "\u03ad\3\2\2\2\u00dd\u03b1\3\2\2\2\u00df\u03b5\3\2\2\2\u00e1\u03b8\3\2" +
+                    "\2\2\u00e3\u03c1\3\2\2\2\u00e5\u03c4\3\2\2\2\u00e7\u03ca\3\2\2\2\u00e9" +
+                    "\u03cf\3\2\2\2\u00eb\u03d8\3\2\2\2\u00ed\u03e0\3\2\2\2\u00ef\u03e7\3\2" +
+                    "\2\2\u00f1\u03f1\3\2\2\2\u00f3\u03fb\3\2\2\2\u00f5\u0400\3\2\2\2\u00f7" +
+                    "\u0406\3\2\2\2\u00f9\u0408\3\2\2\2\u00fb\u040a\3\2\2\2\u00fd\u0411\3\2" +
+                    "\2\2\u00ff\u0416\3\2\2\2\u0101\u0421\3\2\2\2\u0103\u0423\3\2\2\2\u0105" +
+                    "\u042f\3\2\2\2\u0107\u043d\3\2\2\2\u0109\u0446\3\2\2\2\u010b\u044a\3\2" +
+                    "\2\2\u010d\u044e\3\2\2\2\u010f\u0456\3\2\2\2\u0111\u045a\3\2\2\2\u0113" +
+                    "\u045c\3\2\2\2\u0115\u0472\3\2\2\2\u0117\u0118\7=\2\2\u0118\4\3\2\2\2" +
+                    "\u0119\u011a\7o\2\2\u011a\u011b\7q\2\2\u011b\u011c\7f\2\2\u011c\u011d" +
+                    "\7w\2\2\u011d\u011e\7n\2\2\u011e\u011f\7g\2\2\u011f\6\3\2\2\2\u0120\u0121" +
+                    "\7p\2\2\u0121\u0122\7c\2\2\u0122\u0123\7o\2\2\u0123\u0124\7g\2\2\u0124" +
+                    "\u0125\7u\2\2\u0125\u0126\7r\2\2\u0126\u0127\7c\2\2\u0127\u0128\7e\2\2" +
+                    "\u0128\u0129\7g\2\2\u0129\b\3\2\2\2\u012a\u012b\7?\2\2\u012b\n\3\2\2\2" +
+                    "\u012c\u012d\7f\2\2\u012d\u012e\7g\2\2\u012e\u012f\7e\2\2\u012f\u0130" +
+                    "\7n\2\2\u0130\u0131\7c\2\2\u0131\u0132\7t\2\2\u0132\u0133\7g\2\2\u0133" +
+                    "\f\3\2\2\2\u0134\u0135\7q\2\2\u0135\u0136\7t\2\2\u0136\u0137\7f\2\2\u0137" +
+                    "\u0138\7g\2\2\u0138\u0139\7t\2\2\u0139\u013a\7k\2\2\u013a\u013b\7p\2\2" +
+                    "\u013b\u013c\7i\2\2\u013c\16\3\2\2\2\u013d\u013e\7q\2\2\u013e\u013f\7" +
+                    "t\2\2\u013f\u0140\7f\2\2\u0140\u0141\7g\2\2\u0141\u0142\7t\2\2\u0142\u0143" +
+                    "\7g\2\2\u0143\u0144\7f\2\2\u0144\20\3\2\2\2\u0145\u0146\7w\2\2\u0146\u0147" +
+                    "\7p\2\2\u0147\u0148\7q\2\2\u0148\u0149\7t\2\2\u0149\u014a\7f\2\2\u014a" +
+                    "\u014b\7g\2\2\u014b\u014c\7t\2\2\u014c\u014d\7g\2\2\u014d\u014e\7f\2\2" +
+                    "\u014e\22\3\2\2\2\u014f\u0150\7f\2\2\u0150\u0151\7g\2\2\u0151\u0152\7" +
+                    "e\2\2\u0152\u0153\7k\2\2\u0153\u0154\7o\2\2\u0154\u0155\7c\2\2\u0155\u0156" +
+                    "\7n\2\2\u0156\u0157\7/\2\2\u0157\u0158\7h\2\2\u0158\u0159\7q\2\2\u0159" +
+                    "\u015a\7t\2\2\u015a\u015b\7o\2\2\u015b\u015c\7c\2\2\u015c\u015d\7v\2\2" +
+                    "\u015d\24\3\2\2\2\u015e\u015f\7<\2\2\u015f\26\3\2\2\2\u0160\u0161\7f\2" +
+                    "\2\u0161\u0162\7g\2\2\u0162\u0163\7e\2\2\u0163\u0164\7k\2\2\u0164\u0165" +
+                    "\7o\2\2\u0165\u0166\7c\2\2\u0166\u0167\7n\2\2\u0167\u0168\7/\2\2\u0168" +
+                    "\u0169\7u\2\2\u0169\u016a\7g\2\2\u016a\u016b\7r\2\2\u016b\u016c\7c\2\2" +
+                    "\u016c\u016d\7t\2\2\u016d\u016e\7c\2\2\u016e\u016f\7v\2\2\u016f\u0170" +
+                    "\7q\2\2\u0170\u0171\7t\2\2\u0171\30\3\2\2\2\u0172\u0173\7i\2\2\u0173\u0174" +
+                    "\7t\2\2\u0174\u0175\7q\2\2\u0175\u0176\7w\2\2\u0176\u0177\7r\2\2\u0177" +
+                    "\u0178\7k\2\2\u0178\u0179\7p\2\2\u0179\u017a\7i\2\2\u017a\u017b\7/\2\2" +
+                    "\u017b\u017c\7u\2\2\u017c\u017d\7g\2\2\u017d\u017e\7r\2\2\u017e\u017f" +
+                    "\7c\2\2\u017f\u0180\7t\2\2\u0180\u0181\7c\2\2\u0181\u0182\7v\2\2\u0182" +
+                    "\u0183\7q\2\2\u0183\u0184\7t\2\2\u0184\32\3\2\2\2\u0185\u0186\7k\2\2\u0186" +
+                    "\u0187\7p\2\2\u0187\u0188\7h\2\2\u0188\u0189\7k\2\2\u0189\u018a\7p\2\2" +
+                    "\u018a\u018b\7k\2\2\u018b\u018c\7v\2\2\u018c\u018d\7{\2\2\u018d\34\3\2" +
+                    "\2\2\u018e\u018f\7o\2\2\u018f\u0190\7k\2\2\u0190\u0191\7p\2\2\u0191\u0192" +
+                    "\7w\2\2\u0192\u0193\7u\2\2\u0193\u0194\7/\2\2\u0194\u0195\7u\2\2\u0195" +
+                    "\u0196\7k\2\2\u0196\u0197\7i\2\2\u0197\u0198\7p\2\2\u0198\36\3\2\2\2\u0199" +
+                    "\u019a\7P\2\2\u019a\u019b\7c\2\2\u019b\u019c\7P\2\2\u019c \3\2\2\2\u019d" +
+                    "\u019e\7r\2\2\u019e\u019f\7g\2\2\u019f\u01a0\7t\2\2\u01a0\u01a1\7e\2\2" +
+                    "\u01a1\u01a2\7g\2\2\u01a2\u01a3\7p\2\2\u01a3\u01a4\7v\2\2\u01a4\"\3\2" +
+                    "\2\2\u01a5\u01a6\7r\2\2\u01a6\u01a7\7g\2\2\u01a7\u01a8\7t\2\2\u01a8\u01a9" +
+                    "\7/\2\2\u01a9\u01aa\7o\2\2\u01aa\u01ab\7k\2\2\u01ab\u01ac\7n\2\2\u01ac" +
+                    "\u01ad\7n\2\2\u01ad\u01ae\7g\2\2\u01ae$\3\2\2\2\u01af\u01b0\7|\2\2\u01b0" +
+                    "\u01b1\7g\2\2\u01b1\u01b2\7t\2\2\u01b2\u01b3\7q\2\2\u01b3\u01b4\7/\2\2" +
+                    "\u01b4\u01b5\7f\2\2\u01b5\u01b6\7k\2\2\u01b6\u01b7\7i\2\2\u01b7\u01b8" +
+                    "\7k\2\2\u01b8\u01b9\7v\2\2\u01b9&\3\2\2\2\u01ba\u01bb\7f\2\2\u01bb\u01bc" +
+                    "\7k\2\2\u01bc\u01bd\7i\2\2\u01bd\u01be\7k\2\2\u01be\u01bf\7v\2\2\u01bf" +
+                    "(\3\2\2\2\u01c0\u01c1\7r\2\2\u01c1\u01c2\7c\2\2\u01c2\u01c3\7v\2\2\u01c3" +
+                    "\u01c4\7v\2\2\u01c4\u01c5\7g\2\2\u01c5\u01c6\7t\2\2\u01c6\u01c7\7p\2\2" +
+                    "\u01c7\u01c8\7/\2\2\u01c8\u01c9\7u\2\2\u01c9\u01ca\7g\2\2\u01ca\u01cb" +
+                    "\7r\2\2\u01cb\u01cc\7c\2\2\u01cc\u01cd\7t\2\2\u01cd\u01ce\7c\2\2\u01ce" +
+                    "\u01cf\7v\2\2\u01cf\u01d0\7q\2\2\u01d0\u01d1\7t\2\2\u01d1*\3\2\2\2\u01d2" +
+                    "\u01d3\7k\2\2\u01d3\u01d4\7o\2\2\u01d4\u01d5\7r\2\2\u01d5\u01d6\7q\2\2" +
+                    "\u01d6\u01d7\7t\2\2\u01d7\u01d8\7v\2\2\u01d8,\3\2\2\2\u01d9\u01da\7.\2" +
+                    "\2\u01da.\3\2\2\2\u01db\u01dc\7x\2\2\u01dc\u01dd\7c\2\2\u01dd\u01de\7" +
+                    "t\2\2\u01de\u01df\7k\2\2\u01df\u01e0\7c\2\2\u01e0\u01e1\7d\2\2\u01e1\u01e2" +
+                    "\7n\2\2\u01e2\u01e3\7g\2\2\u01e3\60\3\2\2\2\u01e4\u01e5\7<\2\2\u01e5\u01e6" +
+                    "\7?\2\2\u01e6\62\3\2\2\2\u01e7\u01e8\7g\2\2\u01e8\u01e9\7z\2\2\u01e9\u01ea" +
+                    "\7v\2\2\u01ea\u01eb\7g\2\2\u01eb\u01ec\7t\2\2\u01ec\u01ed\7p\2\2\u01ed" +
+                    "\u01ee\7c\2\2\u01ee\u01ef\7n\2\2\u01ef\64\3\2\2\2\u01f0\u01f1\7h\2\2\u01f1" +
+                    "\u01f2\7w\2\2\u01f2\u01f3\7p\2\2\u01f3\u01f4\7e\2\2\u01f4\u01f5\7v\2\2" +
+                    "\u01f5\u01f6\7k\2\2\u01f6\u01f7\7q\2\2\u01f7\u01f8\7p\2\2\u01f8\66\3\2" +
+                    "\2\2\u01f9\u01fa\7*\2\2\u01fa8\3\2\2\2\u01fb\u01fc\7+\2\2\u01fc:\3\2\2" +
+                    "\2\u01fd\u01fe\7}\2\2\u01fe<\3\2\2\2\u01ff\u0200\7\177\2\2\u0200>\3\2" +
+                    "\2\2\u0201\u0202\7&\2\2\u0202@\3\2\2\2\u0203\u0204\7~\2\2\u0204B\3\2\2" +
+                    "\2\u0205\u0206\7,\2\2\u0206D\3\2\2\2\u0207\u0208\7g\2\2\u0208\u0209\7" +
+                    "s\2\2\u0209F\3\2\2\2\u020a\u020b\7p\2\2\u020b\u020c\7g\2\2\u020cH\3\2" +
+                    "\2\2\u020d\u020e\7n\2\2\u020e\u020f\7v\2\2\u020fJ\3\2\2\2\u0210\u0211" +
+                    "\7n\2\2\u0211\u0212\7g\2\2\u0212L\3\2\2\2\u0213\u0214\7i\2\2\u0214\u0215" +
+                    "\7v\2\2\u0215N\3\2\2\2\u0216\u0217\7i\2\2\u0217\u0218\7g\2\2\u0218P\3" +
+                    "\2\2\2\u0219\u021a\7#\2\2\u021a\u021b\7?\2\2\u021bR\3\2\2\2\u021c\u021d" +
+                    "\7>\2\2\u021dT\3\2\2\2\u021e\u021f\7>\2\2\u021f\u0220\7?\2\2\u0220V\3" +
+                    "\2\2\2\u0221\u0222\7@\2\2\u0222X\3\2\2\2\u0223\u0224\7@\2\2\u0224\u0225" +
+                    "\7?\2\2\u0225Z\3\2\2\2\u0226\u0227\7~\2\2\u0227\u0228\7~\2\2\u0228\\\3" +
+                    "\2\2\2\u0229\u022a\7-\2\2\u022a^\3\2\2\2\u022b\u022c\7/\2\2\u022c`\3\2" +
+                    "\2\2\u022d\u022e\7f\2\2\u022e\u022f\7k\2\2\u022f\u0230\7x\2\2\u0230b\3" +
+                    "\2\2\2\u0231\u0232\7k\2\2\u0232\u0233\7f\2\2\u0233\u0234\7k\2\2\u0234" +
+                    "\u0235\7x\2\2\u0235d\3\2\2\2\u0236\u0237\7o\2\2\u0237\u0238\7q\2\2\u0238" +
+                    "\u0239\7f\2\2\u0239f\3\2\2\2\u023a\u023b\7#\2\2\u023bh\3\2\2\2\u023c\u023d" +
+                    "\7]\2\2\u023dj\3\2\2\2\u023e\u023f\7_\2\2\u023fl\3\2\2\2\u0240\u0241\7" +
+                    "\60\2\2\u0241n\3\2\2\2\u0242\u0243\7&\2\2\u0243\u0244\7&\2\2\u0244p\3" +
+                    "\2\2\2\u0245\u0246\7%\2\2\u0246r\3\2\2\2\u0247\u0248\7}\2\2\u0248\u0249" +
+                    "\7~\2\2\u0249t\3\2\2\2\u024a\u024b\7~\2\2\u024b\u024c\7\177\2\2\u024c" +
+                    "v\3\2\2\2\u024d\u024e\7k\2\2\u024e\u024f\7v\2\2\u024f\u0250\7g\2\2\u0250" +
+                    "\u0251\7o\2\2\u0251x\3\2\2\2\u0252\u0253\7q\2\2\u0253\u0254\7d\2\2\u0254" +
+                    "\u0255\7l\2\2\u0255\u0256\7g\2\2\u0256\u0257\7e\2\2\u0257\u0258\7v\2\2" +
+                    "\u0258z\3\2\2\2\u0259\u025a\7c\2\2\u025a\u025b\7t\2\2\u025b\u025c\7t\2" +
+                    "\2\u025c\u025d\7c\2\2\u025d\u025e\7{\2\2\u025e|\3\2\2\2\u025f\u0260\7" +
+                    "u\2\2\u0260\u0261\7v\2\2\u0261\u0262\7t\2\2\u0262\u0263\7k\2\2\u0263\u0264" +
+                    "\7p\2\2\u0264\u0265\7i\2\2\u0265~\3\2\2\2\u0266\u0267\7k\2\2\u0267\u0268" +
+                    "\7p\2\2\u0268\u0269\7v\2\2\u0269\u026a\7g\2\2\u026a\u026b\7i\2\2\u026b" +
+                    "\u026c\7g\2\2\u026c\u026d\7t\2\2\u026d\u0080\3\2\2\2\u026e\u026f\7f\2" +
+                    "\2\u026f\u0270\7g\2\2\u0270\u0271\7e\2\2\u0271\u0272\7k\2\2\u0272\u0273" +
+                    "\7o\2\2\u0273\u0274\7c\2\2\u0274\u0275\7n\2\2\u0275\u0082\3\2\2\2\u0276" +
+                    "\u0277\7f\2\2\u0277\u0278\7q\2\2\u0278\u0279\7w\2\2\u0279\u027a\7d\2\2" +
+                    "\u027a\u027b\7n\2\2\u027b\u027c\7g\2\2\u027c\u0084\3\2\2\2\u027d\u027e" +
+                    "\7d\2\2\u027e\u027f\7q\2\2\u027f\u0280\7q\2\2\u0280\u0281\7n\2\2\u0281" +
+                    "\u0282\7g\2\2\u0282\u0283\7c\2\2\u0283\u0284\7p\2\2\u0284\u0086\3\2\2" +
+                    "\2\u0285\u0286\7f\2\2\u0286\u0287\7w\2\2\u0287\u0288\7t\2\2\u0288\u0289" +
+                    "\7c\2\2\u0289\u028a\7v\2\2\u028a\u028b\7k\2\2\u028b\u028c\7q\2\2\u028c" +
+                    "\u028d\7p\2\2\u028d\u0088\3\2\2\2\u028e\u028f\7{\2\2\u028f\u0290\7g\2" +
+                    "\2\u0290\u0291\7c\2\2\u0291\u0292\7t\2\2\u0292\u0293\7O\2\2\u0293\u0294" +
+                    "\7q\2\2\u0294\u0295\7p\2\2\u0295\u0296\7v\2\2\u0296\u0297\7j\2\2\u0297" +
+                    "\u0298\7F\2\2\u0298\u0299\7w\2\2\u0299\u029a\7t\2\2\u029a\u029b\7c\2\2" +
+                    "\u029b\u029c\7v\2\2\u029c\u029d\7k\2\2\u029d\u029e\7q\2\2\u029e\u029f" +
+                    "\7p\2\2\u029f\u008a\3\2\2\2\u02a0\u02a1\7f\2\2\u02a1\u02a2\7c\2\2\u02a2" +
+                    "\u02a3\7{\2\2\u02a3\u02a4\7V\2\2\u02a4\u02a5\7k\2\2\u02a5\u02a6\7o\2\2" +
+                    "\u02a6\u02a7\7g\2\2\u02a7\u02a8\7F\2\2\u02a8\u02a9\7w\2\2\u02a9\u02aa" +
+                    "\7t\2\2\u02aa\u02ab\7c\2\2\u02ab\u02ac\7v\2\2\u02ac\u02ad\7k\2\2\u02ad" +
+                    "\u02ae\7q\2\2\u02ae\u02af\7p\2\2\u02af\u008c\3\2\2\2\u02b0\u02b1\7j\2" +
+                    "\2\u02b1\u02b2\7g\2\2\u02b2\u02b3\7z\2\2\u02b3\u02b4\7D\2\2\u02b4\u02b5" +
+                    "\7k\2\2\u02b5\u02b6\7p\2\2\u02b6\u02b7\7c\2\2\u02b7\u02b8\7t\2\2\u02b8" +
+                    "\u02b9\7{\2\2\u02b9\u008e\3\2\2\2\u02ba\u02bb\7d\2\2\u02bb\u02bc\7c\2" +
+                    "\2\u02bc\u02bd\7u\2\2\u02bd\u02be\7g\2\2\u02be\u02bf\78\2\2\u02bf\u02c0" +
+                    "\7\66\2\2\u02c0\u02c1\7D\2\2\u02c1\u02c2\7k\2\2\u02c2\u02c3\7p\2\2\u02c3" +
+                    "\u02c4\7c\2\2\u02c4\u02c5\7t\2\2\u02c5\u02c6\7{\2\2\u02c6\u0090\3\2\2" +
+                    "\2\u02c7\u02c8\7f\2\2\u02c8\u02c9\7c\2\2\u02c9\u02ca\7v\2\2\u02ca\u02cb" +
+                    "\7g\2\2\u02cb\u02cc\7V\2\2\u02cc\u02cd\7k\2\2\u02cd\u02ce\7o\2\2\u02ce" +
+                    "\u02cf\7g\2\2\u02cf\u0092\3\2\2\2\u02d0\u02d1\7f\2\2\u02d1\u02d2\7c\2" +
+                    "\2\u02d2\u02d3\7v\2\2\u02d3\u02d4\7g\2\2\u02d4\u0094\3\2\2\2\u02d5\u02d6" +
+                    "\7v\2\2\u02d6\u02d7\7k\2\2\u02d7\u02d8\7o\2\2\u02d8\u02d9\7g\2\2\u02d9" +
+                    "\u0096\3\2\2\2\u02da\u02db\7c\2\2\u02db\u02dc\7p\2\2\u02dc\u02dd\7{\2" +
+                    "\2\u02dd\u02de\7W\2\2\u02de\u02df\7T\2\2\u02df\u02e0\7K\2\2\u02e0\u0098" +
+                    "\3\2\2\2\u02e1\u02e2\7c\2\2\u02e2\u02e3\7v\2\2\u02e3\u02e4\7q\2\2\u02e4" +
+                    "\u02e5\7o\2\2\u02e5\u02e6\7k\2\2\u02e6\u02e7\7e\2\2\u02e7\u009a\3\2\2" +
+                    "\2\u02e8\u02e9\7h\2\2\u02e9\u02ea\7q\2\2\u02ea\u02eb\7t\2\2\u02eb\u009c" +
+                    "\3\2\2\2\u02ec\u02ed\7n\2\2\u02ed\u02ee\7g\2\2\u02ee\u02ef\7v\2\2\u02ef" +
+                    "\u009e\3\2\2\2\u02f0\u02f1\7y\2\2\u02f1\u02f2\7j\2\2\u02f2\u02f3\7g\2" +
+                    "\2\u02f3\u02f4\7t\2\2\u02f4\u02f5\7g\2\2\u02f5\u00a0\3\2\2\2\u02f6\u02f7" +
+                    "\7i\2\2\u02f7\u02f8\7t\2\2\u02f8\u02f9\7q\2\2\u02f9\u02fa\7w\2\2\u02fa" +
+                    "\u02fb\7r\2\2\u02fb\u00a2\3\2\2\2\u02fc\u02fd\7d\2\2\u02fd\u02fe\7{\2" +
+                    "\2\u02fe\u00a4\3\2\2\2\u02ff\u0300\7q\2\2\u0300\u0301\7t\2\2\u0301\u0302" +
+                    "\7f\2\2\u0302\u0303\7g\2\2\u0303\u0304\7t\2\2\u0304\u00a6\3\2\2\2\u0305" +
+                    "\u0306\7t\2\2\u0306\u0307\7g\2\2\u0307\u0308\7v\2\2\u0308\u0309\7w\2\2" +
+                    "\u0309\u030a\7t\2\2\u030a\u030b\7p\2\2\u030b\u00a8\3\2\2\2\u030c\u030d" +
+                    "\7k\2\2\u030d\u030e\7h\2\2\u030e\u00aa\3\2\2\2\u030f\u0310\7k\2\2\u0310" +
+                    "\u0311\7p\2\2\u0311\u00ac\3\2\2\2\u0312\u0313\7c\2\2\u0313\u0314\7u\2" +
+                    "\2\u0314\u00ae\3\2\2\2\u0315\u0316\7c\2\2\u0316\u0317\7v\2\2\u0317\u00b0" +
+                    "\3\2\2\2\u0318\u0319\7c\2\2\u0319\u031a\7n\2\2\u031a\u031b\7n\2\2\u031b" +
+                    "\u031c\7q\2\2\u031c\u031d\7y\2\2\u031d\u031e\7k\2\2\u031e\u031f\7p\2\2" +
+                    "\u031f\u0320\7i\2\2\u0320\u00b2\3\2\2\2\u0321\u0322\7g\2\2\u0322\u0323" +
+                    "\7o\2\2\u0323\u0324\7r\2\2\u0324\u0325\7v\2\2\u0325\u0326\7{\2\2\u0326" +
+                    "\u00b4\3\2\2\2\u0327\u0328\7e\2\2\u0328\u0329\7q\2\2\u0329\u032a\7w\2" +
+                    "\2\u032a\u032b\7p\2\2\u032b\u032c\7v\2\2\u032c\u00b6\3\2\2\2\u032d\u032e" +
+                    "\7u\2\2\u032e\u032f\7v\2\2\u032f\u0330\7c\2\2\u0330\u0331\7d\2\2\u0331" +
+                    "\u0332\7n\2\2\u0332\u0333\7g\2\2\u0333\u00b8\3\2\2\2\u0334\u0335\7c\2" +
+                    "\2\u0335\u0336\7u\2\2\u0336\u0337\7e\2\2\u0337\u0338\7g\2\2\u0338\u0339" +
+                    "\7p\2\2\u0339\u033a\7f\2\2\u033a\u033b\7k\2\2\u033b\u033c\7p\2\2\u033c" +
+                    "\u033d\7i\2\2\u033d\u00ba\3\2\2\2\u033e\u033f\7f\2\2\u033f\u0340\7g\2" +
+                    "\2\u0340\u0341\7u\2\2\u0341\u0342\7e\2\2\u0342\u0343\7g\2\2\u0343\u0344" +
+                    "\7p\2\2\u0344\u0345\7f\2\2\u0345\u0346\7k\2\2\u0346\u0347\7p\2\2\u0347" +
+                    "\u0348\7i\2\2\u0348\u00bc\3\2\2\2\u0349\u034a\7u\2\2\u034a\u034b\7q\2" +
+                    "\2\u034b\u034c\7o\2\2\u034c\u034d\7g\2\2\u034d\u00be\3\2\2\2\u034e\u034f" +
+                    "\7g\2\2\u034f\u0350\7x\2\2\u0350\u0351\7g\2\2\u0351\u0352\7t\2\2\u0352" +
+                    "\u0353\7{\2\2\u0353\u00c0\3\2\2\2\u0354\u0355\7u\2\2\u0355\u0356\7c\2" +
+                    "\2\u0356\u0357\7v\2\2\u0357\u0358\7k\2\2\u0358\u0359\7u\2\2\u0359\u035a" +
+                    "\7h\2\2\u035a\u035b\7k\2\2\u035b\u035c\7g\2\2\u035c\u035d\7u\2\2\u035d" +
+                    "\u00c2\3\2\2\2\u035e\u035f\7e\2\2\u035f\u0360\7q\2\2\u0360\u0361\7n\2" +
+                    "\2\u0361\u0362\7n\2\2\u0362\u0363\7c\2\2\u0363\u0364\7v\2\2\u0364\u0365" +
+                    "\7k\2\2\u0365\u0366\7q\2\2\u0366\u0367\7p\2\2\u0367\u00c4\3\2\2\2\u0368" +
+                    "\u0369\7i\2\2\u0369\u036a\7t\2\2\u036a\u036b\7g\2\2\u036b\u036c\7c\2\2" +
+                    "\u036c\u036d\7v\2\2\u036d\u036e\7g\2\2\u036e\u036f\7u\2\2\u036f\u0370" +
+                    "\7v\2\2\u0370\u00c6\3\2\2\2\u0371\u0372\7n\2\2\u0372\u0373\7g\2\2\u0373" +
+                    "\u0374\7c\2\2\u0374\u0375\7u\2\2\u0375\u0376\7v\2\2\u0376\u00c8\3\2\2" +
+                    "\2\u0377\u0378\7u\2\2\u0378\u0379\7y\2\2\u0379\u037a\7k\2\2\u037a\u037b" +
+                    "\7v\2\2\u037b\u037c\7e\2\2\u037c\u037d\7j\2\2\u037d\u00ca\3\2\2\2\u037e" +
+                    "\u037f\7e\2\2\u037f\u0380\7c\2\2\u0380\u0381\7u\2\2\u0381\u0382\7g\2\2" +
+                    "\u0382\u00cc\3\2\2\2\u0383\u0384\7v\2\2\u0384\u0385\7t\2\2\u0385\u0386" +
+                    "\7{\2\2\u0386\u00ce\3\2\2\2\u0387\u0388\7e\2\2\u0388\u0389\7c\2\2\u0389" +
+                    "\u038a\7v\2\2\u038a\u038b\7e\2\2\u038b\u038c\7j\2\2\u038c\u00d0\3\2\2" +
+                    "\2\u038d\u038e\7f\2\2\u038e\u038f\7g\2\2\u038f\u0390\7h\2\2\u0390\u0391" +
+                    "\7c\2\2\u0391\u0392\7w\2\2\u0392\u0393\7n\2\2\u0393\u0394\7v\2\2\u0394" +
+                    "\u00d2\3\2\2\2\u0395\u0396\7v\2\2\u0396\u0397\7j\2\2\u0397\u0398\7g\2" +
+                    "\2\u0398\u0399\7p\2\2\u0399\u00d4\3\2\2\2\u039a\u039b\7g\2\2\u039b\u039c" +
+                    "\7n\2\2\u039c\u039d\7u\2\2\u039d\u039e\7g\2\2\u039e\u00d6\3\2\2\2\u039f" +
+                    "\u03a0\7v\2\2\u03a0\u03a1\7{\2\2\u03a1\u03a2\7r\2\2\u03a2\u03a3\7g\2\2" +
+                    "\u03a3\u03a4\7u\2\2\u03a4\u03a5\7y\2\2\u03a5\u03a6\7k\2\2\u03a6\u03a7" +
+                    "\7v\2\2\u03a7\u03a8\7e\2\2\u03a8\u03a9\7j\2\2\u03a9\u00d8\3\2\2\2\u03aa" +
+                    "\u03ab\7q\2\2\u03ab\u03ac\7t\2\2\u03ac\u00da\3\2\2\2\u03ad\u03ae\7c\2" +
+                    "\2\u03ae\u03af\7p\2\2\u03af\u03b0\7f\2\2\u03b0\u00dc\3\2\2\2\u03b1\u03b2" +
+                    "\7p\2\2\u03b2\u03b3\7q\2\2\u03b3\u03b4\7v\2\2\u03b4\u00de\3\2\2\2\u03b5" +
+                    "\u03b6\7v\2\2\u03b6\u03b7\7q\2\2\u03b7\u00e0\3\2\2\2\u03b8\u03b9\7k\2" +
+                    "\2\u03b9\u03ba\7p\2\2\u03ba\u03bb\7u\2\2\u03bb\u03bc\7v\2\2\u03bc\u03bd" +
+                    "\7c\2\2\u03bd\u03be\7p\2\2\u03be\u03bf\7e\2\2\u03bf\u03c0\7g\2\2\u03c0" +
+                    "\u00e2\3\2\2\2\u03c1\u03c2\7q\2\2\u03c2\u03c3\7h\2\2\u03c3\u00e4\3\2\2" +
+                    "\2\u03c4\u03c5\7v\2\2\u03c5\u03c6\7t\2\2\u03c6\u03c7\7g\2\2\u03c7\u03c8" +
+                    "\7c\2\2\u03c8\u03c9\7v\2\2\u03c9\u00e6\3\2\2\2\u03ca\u03cb\7e\2\2\u03cb" +
+                    "\u03cc\7c\2\2\u03cc\u03cd\7u\2\2\u03cd\u03ce\7v\2\2\u03ce\u00e8\3\2\2" +
+                    "\2\u03cf\u03d0\7e\2\2\u03d0\u03d1\7c\2\2\u03d1\u03d2\7u\2\2\u03d2\u03d3" +
+                    "\7v\2\2\u03d3\u03d4\7c\2\2\u03d4\u03d5\7d\2\2\u03d5\u03d6\7n\2\2\u03d6" +
+                    "\u03d7\7g\2\2\u03d7\u00ea\3\2\2\2\u03d8\u03d9\7x\2\2\u03d9\u03da\7g\2" +
+                    "\2\u03da\u03db\7t\2\2\u03db\u03dc\7u\2\2\u03dc\u03dd\7k\2\2\u03dd\u03de" +
+                    "\7q\2\2\u03de\u03df\7p\2\2\u03df\u00ec\3\2\2\2\u03e0\u03e1\7l\2\2\u03e1" +
+                    "\u03e2\7u\2\2\u03e2\u03e3\7q\2\2\u03e3\u03e4\7p\2\2\u03e4\u03e5\7k\2\2" +
+                    "\u03e5\u03e6\7s\2\2\u03e6\u00ee\3\2\2\2\u03e7\u03e8\7l\2\2\u03e8\u03e9" +
+                    "\7u\2\2\u03e9\u03ea\7q\2\2\u03ea\u03eb\7p\2\2\u03eb\u03ec\7/\2\2\u03ec" +
+                    "\u03ed\7k\2\2\u03ed\u03ee\7v\2\2\u03ee\u03ef\7g\2\2\u03ef\u03f0\7o\2\2" +
+                    "\u03f0\u00f0\3\2\2\2\u03f1\u03f6\7$\2\2\u03f2\u03f5\5\u00f3z\2\u03f3\u03f5" +
+                    "\n\2\2\2\u03f4\u03f2\3\2\2\2\u03f4\u03f3\3\2\2\2\u03f5\u03f8\3\2\2\2\u03f6" +
+                    "\u03f4\3\2\2\2\u03f6\u03f7\3\2\2\2\u03f7\u03f9\3\2\2\2\u03f8\u03f6\3\2" +
+                    "\2\2\u03f9\u03fa\7$\2\2\u03fa\u00f2\3\2\2\2\u03fb\u03fe\7^\2\2\u03fc\u03ff" +
+                    "\t\3\2\2\u03fd\u03ff\5\u00f5{\2\u03fe\u03fc\3\2\2\2\u03fe\u03fd\3\2\2" +
+                    "\2\u03ff\u00f4\3\2\2\2\u0400\u0401\7w\2\2\u0401\u0402\5\u00f7|\2\u0402" +
+                    "\u0403\5\u00f7|\2\u0403\u0404\5\u00f7|\2\u0404\u0405\5\u00f7|\2\u0405" +
+                    "\u00f6\3\2\2\2\u0406\u0407\t\4\2\2\u0407\u00f8\3\2\2\2\u0408\u0409\7A" +
+                    "\2\2\u0409\u00fa\3\2\2\2\u040a\u040b\7p\2\2\u040b\u040c\7w\2\2\u040c\u040d" +
+                    "\7n\2\2\u040d\u040e\7n\2\2\u040e\u00fc\3\2\2\2\u040f\u0412\5\u00ff\u0080" +
+                    "\2\u0410\u0412\5\u0101\u0081\2\u0411\u040f\3\2\2\2\u0411\u0410\3\2\2\2" +
+                    "\u0412\u00fe\3\2\2\2\u0413\u0417\5\u0103\u0082\2\u0414\u0417\5\u0105\u0083" +
+                    "\2\u0415\u0417\5\u0107\u0084\2\u0416\u0413\3\2\2\2\u0416\u0414\3\2\2\2" +
+                    "\u0416\u0415\3\2\2\2\u0417\u0100\3\2\2\2\u0418\u0419\7v\2\2\u0419\u041a" +
+                    "\7t\2\2\u041a\u041b\7w\2\2\u041b\u0422\7g\2\2\u041c\u041d\7h\2\2\u041d" +
+                    "\u041e\7c\2\2\u041e\u041f\7n\2\2\u041f\u0420\7u\2\2\u0420\u0422\7g\2\2" +
+                    "\u0421\u0418\3\2\2\2\u0421\u041c\3\2\2\2\u0422\u0102\3\2\2\2\u0423\u0424" +
+                    "\5\u0109\u0085\2\u0424\u0104\3\2\2\2\u0425\u0426\7\60\2\2\u0426\u0430" +
+                    "\5\u0109\u0085\2\u0427\u0428\5\u0109\u0085\2\u0428\u042c\7\60\2\2\u0429" +
+                    "\u042b\t\5\2\2\u042a\u0429\3\2\2\2\u042b\u042e\3\2\2\2\u042c\u042a\3\2" +
+                    "\2\2\u042c\u042d\3\2\2\2\u042d\u0430\3\2\2\2\u042e\u042c\3\2\2\2\u042f" +
+                    "\u0425\3\2\2\2\u042f\u0427\3\2\2\2\u0430\u0106\3\2\2\2\u0431\u0432\7\60" +
+                    "\2\2\u0432\u043e\5\u0109\u0085\2\u0433\u043b\5\u0109\u0085\2\u0434\u0438" +
+                    "\7\60\2\2\u0435\u0437\t\5\2\2\u0436\u0435\3\2\2\2\u0437\u043a\3\2\2\2" +
+                    "\u0438\u0436\3\2\2\2\u0438\u0439\3\2\2\2\u0439\u043c\3\2\2\2\u043a\u0438" +
+                    "\3\2\2\2\u043b\u0434\3\2\2\2\u043b\u043c\3\2\2\2\u043c\u043e\3\2\2\2\u043d" +
+                    "\u0431\3\2\2\2\u043d\u0433\3\2\2\2\u043e\u043f\3\2\2\2\u043f\u0441\t\6" +
+                    "\2\2\u0440\u0442\t\7\2\2\u0441\u0440\3\2\2\2\u0441\u0442\3\2\2\2\u0442" +
+                    "\u0443\3\2\2\2\u0443\u0444\5\u0109\u0085\2\u0444\u0108\3\2\2\2\u0445\u0447" +
+                    "\t\5\2\2\u0446\u0445\3\2\2\2\u0447\u0448\3\2\2\2\u0448\u0446\3\2\2\2\u0448" +
+                    "\u0449\3\2\2\2\u0449\u010a\3\2\2\2\u044a\u044b\t\b\2\2\u044b\u044c\3\2" +
+                    "\2\2\u044c\u044d\b\u0086\2\2\u044d\u010c\3\2\2\2\u044e\u0452\5\u010f\u0088" +
+                    "\2\u044f\u0451\5\u0111\u0089\2\u0450\u044f\3\2\2\2\u0451\u0454\3\2\2\2" +
+                    "\u0452\u0450\3\2\2\2\u0452\u0453\3\2\2\2\u0453\u010e\3\2\2\2\u0454\u0452" +
+                    "\3\2\2\2\u0455\u0457\t\t\2\2\u0456\u0455\3\2\2\2\u0457\u0110\3\2\2\2\u0458" +
+                    "\u045b\5\u010f\u0088\2\u0459\u045b\t\n\2\2\u045a\u0458\3\2\2\2\u045a\u0459" +
+                    "\3\2\2\2\u045b\u0112\3\2\2\2\u045c\u045d\7*\2\2\u045d\u0466\7<\2\2\u045e" +
+                    "\u0465\5\u0113\u008a\2\u045f\u0460\7*\2\2\u0460\u0465\n\13\2\2\u0461\u0462" +
+                    "\7<\2\2\u0462\u0465\n\f\2\2\u0463\u0465\n\r\2\2\u0464\u045e\3\2\2\2\u0464" +
+                    "\u045f\3\2\2\2\u0464\u0461\3\2\2\2\u0464\u0463\3\2\2\2\u0465\u0468\3\2" +
+                    "\2\2\u0466\u0464\3\2\2\2\u0466\u0467\3\2\2\2\u0467\u046a\3\2\2\2\u0468" +
+                    "\u0466\3\2\2\2\u0469\u046b\7<\2\2\u046a\u0469\3\2\2\2\u046b\u046c\3\2" +
+                    "\2\2\u046c\u046a\3\2\2\2\u046c\u046d\3\2\2\2\u046d\u046e\3\2\2\2\u046e" +
+                    "\u046f\7+\2\2\u046f\u0470\3\2\2\2\u0470\u0471\b\u008a\2\2\u0471\u0114" +
+                    "\3\2\2\2\u0472\u0473\n\16\2\2\u0473\u0116\3\2\2\2\26\2\u03f4\u03f6\u03fe" +
+                    "\u0411\u0416\u0421\u042c\u042f\u0438\u043b\u043d\u0441\u0448\u0452\u0456" +
+                    "\u045a\u0464\u0466\u046c\3\2\3\2";
+    public static final ATN _ATN =
+            new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+
+    static {
+        _decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
+        for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {
+            _decisionToDFA[i] = new DFA(_ATN.getDecisionState(i), i);
+        }
+    }
 }

--- a/src/main/java/org/rumbledb/parser/JsoniqParser.java
+++ b/src/main/java/org/rumbledb/parser/JsoniqParser.java
@@ -3,6890 +3,8067 @@
 // Java header
 package org.rumbledb.parser;
 
-import org.antlr.v4.runtime.atn.*;
+import org.antlr.v4.runtime.NoViableAltException;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.RuntimeMetaData;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.Vocabulary;
+import org.antlr.v4.runtime.VocabularyImpl;
+import org.antlr.v4.runtime.atn.ATN;
+import org.antlr.v4.runtime.atn.ATNDeserializer;
+import org.antlr.v4.runtime.atn.ParserATNSimulator;
+import org.antlr.v4.runtime.atn.PredictionContextCache;
 import org.antlr.v4.runtime.dfa.DFA;
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.misc.*;
-import org.antlr.v4.runtime.tree.*;
-import java.util.List;
-import java.util.Iterator;
+import org.antlr.v4.runtime.tree.ParseTreeVisitor;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
 import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class JsoniqParser extends Parser {
-	static { RuntimeMetaData.checkVersion("4.7", RuntimeMetaData.VERSION); }
-
-	protected static final DFA[] _decisionToDFA;
-	protected static final PredictionContextCache _sharedContextCache =
-		new PredictionContextCache();
-	public static final int
-		T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, T__5=6, T__6=7, T__7=8, T__8=9, 
-		T__9=10, T__10=11, T__11=12, T__12=13, T__13=14, T__14=15, T__15=16, T__16=17, 
-		T__17=18, T__18=19, T__19=20, T__20=21, T__21=22, T__22=23, T__23=24, 
-		T__24=25, T__25=26, T__26=27, T__27=28, T__28=29, T__29=30, T__30=31, 
-		T__31=32, T__32=33, T__33=34, T__34=35, T__35=36, T__36=37, T__37=38, 
-		T__38=39, T__39=40, T__40=41, T__41=42, T__42=43, T__43=44, T__44=45, 
-		T__45=46, T__46=47, T__47=48, T__48=49, T__49=50, T__50=51, T__51=52, 
-		T__52=53, T__53=54, T__54=55, T__55=56, T__56=57, T__57=58, T__58=59, 
-		T__59=60, T__60=61, T__61=62, T__62=63, T__63=64, T__64=65, T__65=66, 
-		T__66=67, T__67=68, T__68=69, T__69=70, T__70=71, T__71=72, T__72=73, 
-		T__73=74, T__74=75, T__75=76, Kfor=77, Klet=78, Kwhere=79, Kgroup=80, 
-		Kby=81, Korder=82, Kreturn=83, Kif=84, Kin=85, Kas=86, Kat=87, Kallowing=88, 
-		Kempty=89, Kcount=90, Kstable=91, Kascending=92, Kdescending=93, Ksome=94, 
-		Kevery=95, Ksatisfies=96, Kcollation=97, Kgreatest=98, Kleast=99, Kswitch=100, 
-		Kcase=101, Ktry=102, Kcatch=103, Kdefault=104, Kthen=105, Kelse=106, Ktypeswitch=107, 
-		Kor=108, Kand=109, Knot=110, Kto=111, Kinstance=112, Kof=113, Ktreat=114, 
-		Kcast=115, Kcastable=116, Kversion=117, Kjsoniq=118, Kjson=119, STRING=120, 
-		ArgumentPlaceholder=121, NullLiteral=122, Literal=123, NumericLiteral=124, 
-		BooleanLiteral=125, IntegerLiteral=126, DecimalLiteral=127, DoubleLiteral=128, 
-		WS=129, NCName=130, XQComment=131, ContentChar=132;
-	public static final int
-		RULE_module = 0, RULE_mainModule = 1, RULE_libraryModule = 2, RULE_prolog = 3, 
-		RULE_defaultCollationDecl = 4, RULE_orderingModeDecl = 5, RULE_emptyOrderDecl = 6, 
-		RULE_decimalFormatDecl = 7, RULE_dfPropertyName = 8, RULE_moduleImport = 9, 
-		RULE_varDecl = 10, RULE_functionDecl = 11, RULE_paramList = 12, RULE_param = 13, 
-		RULE_expr = 14, RULE_exprSingle = 15, RULE_flowrExpr = 16, RULE_forClause = 17, 
-		RULE_forVar = 18, RULE_letClause = 19, RULE_letVar = 20, RULE_whereClause = 21, 
-		RULE_groupByClause = 22, RULE_groupByVar = 23, RULE_orderByClause = 24, 
-		RULE_orderByExpr = 25, RULE_countClause = 26, RULE_quantifiedExpr = 27, 
-		RULE_quantifiedExprVar = 28, RULE_switchExpr = 29, RULE_switchCaseClause = 30, 
-		RULE_typeSwitchExpr = 31, RULE_caseClause = 32, RULE_ifExpr = 33, RULE_tryCatchExpr = 34, 
-		RULE_orExpr = 35, RULE_andExpr = 36, RULE_notExpr = 37, RULE_comparisonExpr = 38, 
-		RULE_stringConcatExpr = 39, RULE_rangeExpr = 40, RULE_additiveExpr = 41, 
-		RULE_multiplicativeExpr = 42, RULE_instanceOfExpr = 43, RULE_treatExpr = 44, 
-		RULE_castableExpr = 45, RULE_castExpr = 46, RULE_unaryExpr = 47, RULE_simpleMapExpr = 48, 
-		RULE_postFixExpr = 49, RULE_arrayLookup = 50, RULE_arrayUnboxing = 51, 
-		RULE_predicate = 52, RULE_objectLookup = 53, RULE_primaryExpr = 54, RULE_varRef = 55, 
-		RULE_parenthesizedExpr = 56, RULE_contextItemExpr = 57, RULE_orderedExpr = 58, 
-		RULE_unorderedExpr = 59, RULE_functionCall = 60, RULE_argumentList = 61, 
-		RULE_argument = 62, RULE_functionItemExpr = 63, RULE_namedFunctionRef = 64, 
-		RULE_inlineFunctionExpr = 65, RULE_sequenceType = 66, RULE_objectConstructor = 67, 
-		RULE_itemType = 68, RULE_jSONItemTest = 69, RULE_keyWordString = 70, RULE_keyWordInteger = 71, 
-		RULE_keyWordDecimal = 72, RULE_keyWordDouble = 73, RULE_keyWordBoolean = 74, 
-		RULE_keyWordDuration = 75, RULE_keyWordYearMonthDuration = 76, RULE_keyWordDayTimeDuration = 77, 
-		RULE_keyWordHexBinary = 78, RULE_keyWordBase64Binary = 79, RULE_keyWordDateTime = 80, 
-		RULE_keyWordDate = 81, RULE_keyWordTime = 82, RULE_keyWordAnyURI = 83, 
-		RULE_typesKeywords = 84, RULE_singleType = 85, RULE_atomicType = 86, RULE_nCNameOrKeyWord = 87, 
-		RULE_pairConstructor = 88, RULE_arrayConstructor = 89, RULE_uriLiteral = 90, 
-		RULE_stringLiteral = 91, RULE_keyWords = 92;
-	public static final String[] ruleNames = {
-		"module", "mainModule", "libraryModule", "prolog", "defaultCollationDecl", 
-		"orderingModeDecl", "emptyOrderDecl", "decimalFormatDecl", "dfPropertyName", 
-		"moduleImport", "varDecl", "functionDecl", "paramList", "param", "expr", 
-		"exprSingle", "flowrExpr", "forClause", "forVar", "letClause", "letVar", 
-		"whereClause", "groupByClause", "groupByVar", "orderByClause", "orderByExpr", 
-		"countClause", "quantifiedExpr", "quantifiedExprVar", "switchExpr", "switchCaseClause", 
-		"typeSwitchExpr", "caseClause", "ifExpr", "tryCatchExpr", "orExpr", "andExpr", 
-		"notExpr", "comparisonExpr", "stringConcatExpr", "rangeExpr", "additiveExpr", 
-		"multiplicativeExpr", "instanceOfExpr", "treatExpr", "castableExpr", "castExpr", 
-		"unaryExpr", "simpleMapExpr", "postFixExpr", "arrayLookup", "arrayUnboxing", 
-		"predicate", "objectLookup", "primaryExpr", "varRef", "parenthesizedExpr", 
-		"contextItemExpr", "orderedExpr", "unorderedExpr", "functionCall", "argumentList", 
-		"argument", "functionItemExpr", "namedFunctionRef", "inlineFunctionExpr", 
-		"sequenceType", "objectConstructor", "itemType", "jSONItemTest", "keyWordString", 
-		"keyWordInteger", "keyWordDecimal", "keyWordDouble", "keyWordBoolean", 
-		"keyWordDuration", "keyWordYearMonthDuration", "keyWordDayTimeDuration", 
-		"keyWordHexBinary", "keyWordBase64Binary", "keyWordDateTime", "keyWordDate", 
-		"keyWordTime", "keyWordAnyURI", "typesKeywords", "singleType", "atomicType", 
-		"nCNameOrKeyWord", "pairConstructor", "arrayConstructor", "uriLiteral", 
-		"stringLiteral", "keyWords"
-	};
-
-	private static final String[] _LITERAL_NAMES = {
-		null, "';'", "'module'", "'namespace'", "'='", "'declare'", "'ordering'", 
-		"'ordered'", "'unordered'", "'decimal-format'", "':'", "'decimal-separator'", 
-		"'grouping-separator'", "'infinity'", "'minus-sign'", "'NaN'", "'percent'", 
-		"'per-mille'", "'zero-digit'", "'digit'", "'pattern-separator'", "'import'", 
-		"','", "'variable'", "':='", "'external'", "'function'", "'('", "')'", 
-		"'{'", "'}'", "'$'", "'|'", "'*'", "'eq'", "'ne'", "'lt'", "'le'", "'gt'", 
-		"'ge'", "'!='", "'<'", "'<='", "'>'", "'>='", "'||'", "'+'", "'-'", "'div'", 
-		"'idiv'", "'mod'", "'!'", "'['", "']'", "'.'", "'$$'", "'#'", "'{|'", 
-		"'|}'", "'item'", "'object'", "'array'", "'string'", "'integer'", "'decimal'", 
-		"'double'", "'boolean'", "'duration'", "'yearMonthDuration'", "'dayTimeDuration'", 
-		"'hexBinary'", "'base64Binary'", "'dateTime'", "'date'", "'time'", "'anyURI'", 
-		"'atomic'", "'for'", "'let'", "'where'", "'group'", "'by'", "'order'", 
-		"'return'", "'if'", "'in'", "'as'", "'at'", "'allowing'", "'empty'", "'count'", 
-		"'stable'", "'ascending'", "'descending'", "'some'", "'every'", "'satisfies'", 
-		"'collation'", "'greatest'", "'least'", "'switch'", "'case'", "'try'", 
-		"'catch'", "'default'", "'then'", "'else'", "'typeswitch'", "'or'", "'and'", 
-		"'not'", "'to'", "'instance'", "'of'", "'treat'", "'cast'", "'castable'", 
-		"'version'", "'jsoniq'", "'json-item'", null, "'?'", "'null'"
-	};
-	private static final String[] _SYMBOLIC_NAMES = {
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, null, null, null, null, null, null, null, 
-		null, null, null, null, null, "Kfor", "Klet", "Kwhere", "Kgroup", "Kby", 
-		"Korder", "Kreturn", "Kif", "Kin", "Kas", "Kat", "Kallowing", "Kempty", 
-		"Kcount", "Kstable", "Kascending", "Kdescending", "Ksome", "Kevery", "Ksatisfies", 
-		"Kcollation", "Kgreatest", "Kleast", "Kswitch", "Kcase", "Ktry", "Kcatch", 
-		"Kdefault", "Kthen", "Kelse", "Ktypeswitch", "Kor", "Kand", "Knot", "Kto", 
-		"Kinstance", "Kof", "Ktreat", "Kcast", "Kcastable", "Kversion", "Kjsoniq", 
-		"Kjson", "STRING", "ArgumentPlaceholder", "NullLiteral", "Literal", "NumericLiteral", 
-		"BooleanLiteral", "IntegerLiteral", "DecimalLiteral", "DoubleLiteral", 
-		"WS", "NCName", "XQComment", "ContentChar"
-	};
-	public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
-
-	/**
-	 * @deprecated Use {@link #VOCABULARY} instead.
-	 */
-	@Deprecated
-	public static final String[] tokenNames;
-	static {
-		tokenNames = new String[_SYMBOLIC_NAMES.length];
-		for (int i = 0; i < tokenNames.length; i++) {
-			tokenNames[i] = VOCABULARY.getLiteralName(i);
-			if (tokenNames[i] == null) {
-				tokenNames[i] = VOCABULARY.getSymbolicName(i);
-			}
-
-			if (tokenNames[i] == null) {
-				tokenNames[i] = "<INVALID>";
-			}
-		}
-	}
-
-	@Override
-	@Deprecated
-	public String[] getTokenNames() {
-		return tokenNames;
-	}
-
-	@Override
-
-	public Vocabulary getVocabulary() {
-		return VOCABULARY;
-	}
-
-	@Override
-	public String getGrammarFileName() { return "Jsoniq.g4"; }
-
-	@Override
-	public String[] getRuleNames() { return ruleNames; }
-
-	@Override
-	public String getSerializedATN() { return _serializedATN; }
-
-	@Override
-	public ATN getATN() { return _ATN; }
-
-	public JsoniqParser(TokenStream input) {
-		super(input);
-		_interp = new ParserATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
-	}
-	public static class ModuleContext extends ParserRuleContext {
-		public StringLiteralContext vers;
-		public MainModuleContext main;
-		public LibraryModuleContext libraryModule() {
-			return getRuleContext(LibraryModuleContext.class,0);
-		}
-		public TerminalNode Kjsoniq() { return getToken(JsoniqParser.Kjsoniq, 0); }
-		public TerminalNode Kversion() { return getToken(JsoniqParser.Kversion, 0); }
-		public MainModuleContext mainModule() {
-			return getRuleContext(MainModuleContext.class,0);
-		}
-		public StringLiteralContext stringLiteral() {
-			return getRuleContext(StringLiteralContext.class,0);
-		}
-		public ModuleContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_module; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitModule(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ModuleContext module() throws RecognitionException {
-		ModuleContext _localctx = new ModuleContext(_ctx, getState());
-		enterRule(_localctx, 0, RULE_module);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(191);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,0,_ctx) ) {
-			case 1:
-				{
-				setState(186);
-				match(Kjsoniq);
-				setState(187);
-				match(Kversion);
-				setState(188);
-				((ModuleContext)_localctx).vers = stringLiteral();
-				setState(189);
-				match(T__0);
-				}
-				break;
-			}
-			setState(195);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__1:
-				{
-				setState(193);
-				libraryModule();
-				}
-				break;
-			case T__4:
-			case T__6:
-			case T__7:
-			case T__9:
-			case T__20:
-			case T__25:
-			case T__26:
-			case T__28:
-			case T__30:
-			case T__45:
-			case T__46:
-			case T__51:
-			case T__54:
-			case T__56:
-			case T__61:
-			case T__62:
-			case T__63:
-			case T__64:
-			case T__65:
-			case T__66:
-			case T__67:
-			case T__68:
-			case T__69:
-			case T__70:
-			case T__71:
-			case T__72:
-			case T__73:
-			case T__74:
-			case Kfor:
-			case Klet:
-			case Kwhere:
-			case Kgroup:
-			case Kby:
-			case Korder:
-			case Kreturn:
-			case Kif:
-			case Kin:
-			case Kas:
-			case Kat:
-			case Kallowing:
-			case Kempty:
-			case Kcount:
-			case Kstable:
-			case Kascending:
-			case Kdescending:
-			case Ksome:
-			case Kevery:
-			case Ksatisfies:
-			case Kcollation:
-			case Kgreatest:
-			case Kleast:
-			case Kswitch:
-			case Kcase:
-			case Ktry:
-			case Kcatch:
-			case Kdefault:
-			case Kthen:
-			case Kelse:
-			case Ktypeswitch:
-			case Kor:
-			case Kand:
-			case Knot:
-			case Kto:
-			case Kinstance:
-			case Kof:
-			case Ktreat:
-			case Kcast:
-			case Kcastable:
-			case Kversion:
-			case Kjsoniq:
-			case Kjson:
-			case STRING:
-			case NullLiteral:
-			case Literal:
-			case NCName:
-				{
-				setState(194);
-				((ModuleContext)_localctx).main = mainModule();
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class MainModuleContext extends ParserRuleContext {
-		public PrologContext prolog() {
-			return getRuleContext(PrologContext.class,0);
-		}
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public MainModuleContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_mainModule; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitMainModule(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final MainModuleContext mainModule() throws RecognitionException {
-		MainModuleContext _localctx = new MainModuleContext(_ctx, getState());
-		enterRule(_localctx, 2, RULE_mainModule);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(197);
-			prolog();
-			setState(198);
-			expr();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class LibraryModuleContext extends ParserRuleContext {
-		public TerminalNode NCName() { return getToken(JsoniqParser.NCName, 0); }
-		public UriLiteralContext uriLiteral() {
-			return getRuleContext(UriLiteralContext.class,0);
-		}
-		public PrologContext prolog() {
-			return getRuleContext(PrologContext.class,0);
-		}
-		public LibraryModuleContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_libraryModule; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitLibraryModule(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final LibraryModuleContext libraryModule() throws RecognitionException {
-		LibraryModuleContext _localctx = new LibraryModuleContext(_ctx, getState());
-		enterRule(_localctx, 4, RULE_libraryModule);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(200);
-			match(T__1);
-			setState(201);
-			match(T__2);
-			setState(202);
-			match(NCName);
-			setState(203);
-			match(T__3);
-			setState(204);
-			uriLiteral();
-			setState(205);
-			match(T__0);
-			setState(206);
-			prolog();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class PrologContext extends ParserRuleContext {
-		public List<DefaultCollationDeclContext> defaultCollationDecl() {
-			return getRuleContexts(DefaultCollationDeclContext.class);
-		}
-		public DefaultCollationDeclContext defaultCollationDecl(int i) {
-			return getRuleContext(DefaultCollationDeclContext.class,i);
-		}
-		public List<OrderingModeDeclContext> orderingModeDecl() {
-			return getRuleContexts(OrderingModeDeclContext.class);
-		}
-		public OrderingModeDeclContext orderingModeDecl(int i) {
-			return getRuleContext(OrderingModeDeclContext.class,i);
-		}
-		public List<EmptyOrderDeclContext> emptyOrderDecl() {
-			return getRuleContexts(EmptyOrderDeclContext.class);
-		}
-		public EmptyOrderDeclContext emptyOrderDecl(int i) {
-			return getRuleContext(EmptyOrderDeclContext.class,i);
-		}
-		public List<DecimalFormatDeclContext> decimalFormatDecl() {
-			return getRuleContexts(DecimalFormatDeclContext.class);
-		}
-		public DecimalFormatDeclContext decimalFormatDecl(int i) {
-			return getRuleContext(DecimalFormatDeclContext.class,i);
-		}
-		public List<ModuleImportContext> moduleImport() {
-			return getRuleContexts(ModuleImportContext.class);
-		}
-		public ModuleImportContext moduleImport(int i) {
-			return getRuleContext(ModuleImportContext.class,i);
-		}
-		public List<FunctionDeclContext> functionDecl() {
-			return getRuleContexts(FunctionDeclContext.class);
-		}
-		public FunctionDeclContext functionDecl(int i) {
-			return getRuleContext(FunctionDeclContext.class,i);
-		}
-		public List<VarDeclContext> varDecl() {
-			return getRuleContexts(VarDeclContext.class);
-		}
-		public VarDeclContext varDecl(int i) {
-			return getRuleContext(VarDeclContext.class,i);
-		}
-		public PrologContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_prolog; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitProlog(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final PrologContext prolog() throws RecognitionException {
-		PrologContext _localctx = new PrologContext(_ctx, getState());
-		enterRule(_localctx, 6, RULE_prolog);
-		int _la;
-		try {
-			int _alt;
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(219);
-			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,3,_ctx);
-			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
-				if ( _alt==1 ) {
-					{
-					{
-					setState(213);
-					_errHandler.sync(this);
-					switch ( getInterpreter().adaptivePredict(_input,2,_ctx) ) {
-					case 1:
-						{
-						setState(208);
-						defaultCollationDecl();
-						}
-						break;
-					case 2:
-						{
-						setState(209);
-						orderingModeDecl();
-						}
-						break;
-					case 3:
-						{
-						setState(210);
-						emptyOrderDecl();
-						}
-						break;
-					case 4:
-						{
-						setState(211);
-						decimalFormatDecl();
-						}
-						break;
-					case 5:
-						{
-						setState(212);
-						moduleImport();
-						}
-						break;
-					}
-					setState(215);
-					match(T__0);
-					}
-					} 
-				}
-				setState(221);
-				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,3,_ctx);
-			}
-			setState(230);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__4) {
-				{
-				{
-				setState(224);
-				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,4,_ctx) ) {
-				case 1:
-					{
-					setState(222);
-					functionDecl();
-					}
-					break;
-				case 2:
-					{
-					setState(223);
-					varDecl();
-					}
-					break;
-				}
-				setState(226);
-				match(T__0);
-				}
-				}
-				setState(232);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class DefaultCollationDeclContext extends ParserRuleContext {
-		public TerminalNode Kdefault() { return getToken(JsoniqParser.Kdefault, 0); }
-		public TerminalNode Kcollation() { return getToken(JsoniqParser.Kcollation, 0); }
-		public UriLiteralContext uriLiteral() {
-			return getRuleContext(UriLiteralContext.class,0);
-		}
-		public DefaultCollationDeclContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_defaultCollationDecl; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitDefaultCollationDecl(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final DefaultCollationDeclContext defaultCollationDecl() throws RecognitionException {
-		DefaultCollationDeclContext _localctx = new DefaultCollationDeclContext(_ctx, getState());
-		enterRule(_localctx, 8, RULE_defaultCollationDecl);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(233);
-			match(T__4);
-			setState(234);
-			match(Kdefault);
-			setState(235);
-			match(Kcollation);
-			setState(236);
-			uriLiteral();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class OrderingModeDeclContext extends ParserRuleContext {
-		public OrderingModeDeclContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_orderingModeDecl; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitOrderingModeDecl(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final OrderingModeDeclContext orderingModeDecl() throws RecognitionException {
-		OrderingModeDeclContext _localctx = new OrderingModeDeclContext(_ctx, getState());
-		enterRule(_localctx, 10, RULE_orderingModeDecl);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(238);
-			match(T__4);
-			setState(239);
-			match(T__5);
-			setState(240);
-			_la = _input.LA(1);
-			if ( !(_la==T__6 || _la==T__7) ) {
-			_errHandler.recoverInline(this);
-			}
-			else {
-				if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-				_errHandler.reportMatch(this);
-				consume();
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class EmptyOrderDeclContext extends ParserRuleContext {
-		public TerminalNode Kdefault() { return getToken(JsoniqParser.Kdefault, 0); }
-		public TerminalNode Kempty() { return getToken(JsoniqParser.Kempty, 0); }
-		public TerminalNode Kgreatest() { return getToken(JsoniqParser.Kgreatest, 0); }
-		public TerminalNode Kleast() { return getToken(JsoniqParser.Kleast, 0); }
-		public EmptyOrderDeclContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_emptyOrderDecl; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitEmptyOrderDecl(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final EmptyOrderDeclContext emptyOrderDecl() throws RecognitionException {
-		EmptyOrderDeclContext _localctx = new EmptyOrderDeclContext(_ctx, getState());
-		enterRule(_localctx, 12, RULE_emptyOrderDecl);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(242);
-			match(T__4);
-			setState(243);
-			match(Kdefault);
-			setState(244);
-			match(Korder);
-			setState(245);
-			match(Kempty);
-			setState(246);
-			_la = _input.LA(1);
-			if ( !(_la==Kgreatest || _la==Kleast) ) {
-			_errHandler.recoverInline(this);
-			}
-			else {
-				if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-				_errHandler.reportMatch(this);
-				consume();
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class DecimalFormatDeclContext extends ParserRuleContext {
-		public List<DfPropertyNameContext> dfPropertyName() {
-			return getRuleContexts(DfPropertyNameContext.class);
-		}
-		public DfPropertyNameContext dfPropertyName(int i) {
-			return getRuleContext(DfPropertyNameContext.class,i);
-		}
-		public List<StringLiteralContext> stringLiteral() {
-			return getRuleContexts(StringLiteralContext.class);
-		}
-		public StringLiteralContext stringLiteral(int i) {
-			return getRuleContext(StringLiteralContext.class,i);
-		}
-		public List<TerminalNode> NCName() { return getTokens(JsoniqParser.NCName); }
-		public TerminalNode NCName(int i) {
-			return getToken(JsoniqParser.NCName, i);
-		}
-		public TerminalNode Kdefault() { return getToken(JsoniqParser.Kdefault, 0); }
-		public DecimalFormatDeclContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_decimalFormatDecl; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitDecimalFormatDecl(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final DecimalFormatDeclContext decimalFormatDecl() throws RecognitionException {
-		DecimalFormatDeclContext _localctx = new DecimalFormatDeclContext(_ctx, getState());
-		enterRule(_localctx, 14, RULE_decimalFormatDecl);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(248);
-			match(T__4);
-			setState(257);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__8:
-				{
-				{
-				setState(249);
-				match(T__8);
-				setState(252);
-				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,6,_ctx) ) {
-				case 1:
-					{
-					setState(250);
-					match(NCName);
-					setState(251);
-					match(T__9);
-					}
-					break;
-				}
-				setState(254);
-				match(NCName);
-				}
-				}
-				break;
-			case Kdefault:
-				{
-				{
-				setState(255);
-				match(Kdefault);
-				setState(256);
-				match(T__8);
-				}
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-			setState(265);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__10) | (1L << T__11) | (1L << T__12) | (1L << T__13) | (1L << T__14) | (1L << T__15) | (1L << T__16) | (1L << T__17) | (1L << T__18) | (1L << T__19))) != 0)) {
-				{
-				{
-				setState(259);
-				dfPropertyName();
-				setState(260);
-				match(T__3);
-				setState(261);
-				stringLiteral();
-				}
-				}
-				setState(267);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class DfPropertyNameContext extends ParserRuleContext {
-		public DfPropertyNameContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_dfPropertyName; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitDfPropertyName(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final DfPropertyNameContext dfPropertyName() throws RecognitionException {
-		DfPropertyNameContext _localctx = new DfPropertyNameContext(_ctx, getState());
-		enterRule(_localctx, 16, RULE_dfPropertyName);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(268);
-			_la = _input.LA(1);
-			if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__10) | (1L << T__11) | (1L << T__12) | (1L << T__13) | (1L << T__14) | (1L << T__15) | (1L << T__16) | (1L << T__17) | (1L << T__18) | (1L << T__19))) != 0)) ) {
-			_errHandler.recoverInline(this);
-			}
-			else {
-				if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-				_errHandler.reportMatch(this);
-				consume();
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ModuleImportContext extends ParserRuleContext {
-		public List<UriLiteralContext> uriLiteral() {
-			return getRuleContexts(UriLiteralContext.class);
-		}
-		public UriLiteralContext uriLiteral(int i) {
-			return getRuleContext(UriLiteralContext.class,i);
-		}
-		public TerminalNode NCName() { return getToken(JsoniqParser.NCName, 0); }
-		public TerminalNode Kat() { return getToken(JsoniqParser.Kat, 0); }
-		public ModuleImportContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_moduleImport; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitModuleImport(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ModuleImportContext moduleImport() throws RecognitionException {
-		ModuleImportContext _localctx = new ModuleImportContext(_ctx, getState());
-		enterRule(_localctx, 18, RULE_moduleImport);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(270);
-			match(T__20);
-			setState(271);
-			match(T__1);
-			setState(275);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==T__2) {
-				{
-				setState(272);
-				match(T__2);
-				setState(273);
-				match(NCName);
-				setState(274);
-				match(T__3);
-				}
-			}
-
-			setState(277);
-			uriLiteral();
-			setState(287);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kat) {
-				{
-				setState(278);
-				match(Kat);
-				setState(279);
-				uriLiteral();
-				setState(284);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-				while (_la==T__21) {
-					{
-					{
-					setState(280);
-					match(T__21);
-					setState(281);
-					uriLiteral();
-					}
-					}
-					setState(286);
-					_errHandler.sync(this);
-					_la = _input.LA(1);
-				}
-				}
-			}
-
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class VarDeclContext extends ParserRuleContext {
-		public Token external;
-		public VarRefContext varRef() {
-			return getRuleContext(VarRefContext.class,0);
-		}
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public VarDeclContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_varDecl; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitVarDecl(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final VarDeclContext varDecl() throws RecognitionException {
-		VarDeclContext _localctx = new VarDeclContext(_ctx, getState());
-		enterRule(_localctx, 20, RULE_varDecl);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(289);
-			match(T__4);
-			setState(290);
-			match(T__22);
-			setState(291);
-			varRef();
-			setState(294);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kas) {
-				{
-				setState(292);
-				match(Kas);
-				setState(293);
-				sequenceType();
-				}
-			}
-
-			setState(303);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__23:
-				{
-				{
-				setState(296);
-				match(T__23);
-				setState(297);
-				exprSingle();
-				}
-				}
-				break;
-			case T__24:
-				{
-				{
-				setState(298);
-				((VarDeclContext)_localctx).external = match(T__24);
-				setState(301);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-				if (_la==T__23) {
-					{
-					setState(299);
-					match(T__23);
-					setState(300);
-					exprSingle();
-					}
-				}
-
-				}
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class FunctionDeclContext extends ParserRuleContext {
-		public Token namespace;
-		public Token fn_name;
-		public SequenceTypeContext return_type;
-		public ExprContext fn_body;
-		public List<TerminalNode> NCName() { return getTokens(JsoniqParser.NCName); }
-		public TerminalNode NCName(int i) {
-			return getToken(JsoniqParser.NCName, i);
-		}
-		public ParamListContext paramList() {
-			return getRuleContext(ParamListContext.class,0);
-		}
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public FunctionDeclContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_functionDecl; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitFunctionDecl(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final FunctionDeclContext functionDecl() throws RecognitionException {
-		FunctionDeclContext _localctx = new FunctionDeclContext(_ctx, getState());
-		enterRule(_localctx, 22, RULE_functionDecl);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(305);
-			match(T__4);
-			setState(306);
-			match(T__25);
-			setState(309);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,15,_ctx) ) {
-			case 1:
-				{
-				setState(307);
-				((FunctionDeclContext)_localctx).namespace = match(NCName);
-				setState(308);
-				match(T__9);
-				}
-				break;
-			}
-			setState(311);
-			((FunctionDeclContext)_localctx).fn_name = match(NCName);
-			setState(312);
-			match(T__26);
-			setState(314);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==T__30) {
-				{
-				setState(313);
-				paramList();
-				}
-			}
-
-			setState(316);
-			match(T__27);
-			setState(319);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kas) {
-				{
-				setState(317);
-				match(Kas);
-				setState(318);
-				((FunctionDeclContext)_localctx).return_type = sequenceType();
-				}
-			}
-
-			setState(326);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__28:
-				{
-				setState(321);
-				match(T__28);
-				setState(322);
-				((FunctionDeclContext)_localctx).fn_body = expr();
-				setState(323);
-				match(T__29);
-				}
-				break;
-			case T__24:
-				{
-				setState(325);
-				match(T__24);
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ParamListContext extends ParserRuleContext {
-		public List<ParamContext> param() {
-			return getRuleContexts(ParamContext.class);
-		}
-		public ParamContext param(int i) {
-			return getRuleContext(ParamContext.class,i);
-		}
-		public ParamListContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_paramList; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitParamList(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ParamListContext paramList() throws RecognitionException {
-		ParamListContext _localctx = new ParamListContext(_ctx, getState());
-		enterRule(_localctx, 24, RULE_paramList);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(328);
-			param();
-			setState(333);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__21) {
-				{
-				{
-				setState(329);
-				match(T__21);
-				setState(330);
-				param();
-				}
-				}
-				setState(335);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ParamContext extends ParserRuleContext {
-		public TerminalNode NCName() { return getToken(JsoniqParser.NCName, 0); }
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public ParamContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_param; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitParam(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ParamContext param() throws RecognitionException {
-		ParamContext _localctx = new ParamContext(_ctx, getState());
-		enterRule(_localctx, 26, RULE_param);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(336);
-			match(T__30);
-			setState(337);
-			match(NCName);
-			setState(340);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kas) {
-				{
-				setState(338);
-				match(Kas);
-				setState(339);
-				sequenceType();
-				}
-			}
-
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ExprContext extends ParserRuleContext {
-		public List<ExprSingleContext> exprSingle() {
-			return getRuleContexts(ExprSingleContext.class);
-		}
-		public ExprSingleContext exprSingle(int i) {
-			return getRuleContext(ExprSingleContext.class,i);
-		}
-		public ExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_expr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ExprContext expr() throws RecognitionException {
-		ExprContext _localctx = new ExprContext(_ctx, getState());
-		enterRule(_localctx, 28, RULE_expr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(342);
-			exprSingle();
-			setState(347);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__21) {
-				{
-				{
-				setState(343);
-				match(T__21);
-				setState(344);
-				exprSingle();
-				}
-				}
-				setState(349);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ExprSingleContext extends ParserRuleContext {
-		public FlowrExprContext flowrExpr() {
-			return getRuleContext(FlowrExprContext.class,0);
-		}
-		public QuantifiedExprContext quantifiedExpr() {
-			return getRuleContext(QuantifiedExprContext.class,0);
-		}
-		public SwitchExprContext switchExpr() {
-			return getRuleContext(SwitchExprContext.class,0);
-		}
-		public TypeSwitchExprContext typeSwitchExpr() {
-			return getRuleContext(TypeSwitchExprContext.class,0);
-		}
-		public IfExprContext ifExpr() {
-			return getRuleContext(IfExprContext.class,0);
-		}
-		public TryCatchExprContext tryCatchExpr() {
-			return getRuleContext(TryCatchExprContext.class,0);
-		}
-		public OrExprContext orExpr() {
-			return getRuleContext(OrExprContext.class,0);
-		}
-		public ExprSingleContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_exprSingle; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitExprSingle(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ExprSingleContext exprSingle() throws RecognitionException {
-		ExprSingleContext _localctx = new ExprSingleContext(_ctx, getState());
-		enterRule(_localctx, 30, RULE_exprSingle);
-		try {
-			setState(357);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,22,_ctx) ) {
-			case 1:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(350);
-				flowrExpr();
-				}
-				break;
-			case 2:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(351);
-				quantifiedExpr();
-				}
-				break;
-			case 3:
-				enterOuterAlt(_localctx, 3);
-				{
-				setState(352);
-				switchExpr();
-				}
-				break;
-			case 4:
-				enterOuterAlt(_localctx, 4);
-				{
-				setState(353);
-				typeSwitchExpr();
-				}
-				break;
-			case 5:
-				enterOuterAlt(_localctx, 5);
-				{
-				setState(354);
-				ifExpr();
-				}
-				break;
-			case 6:
-				enterOuterAlt(_localctx, 6);
-				{
-				setState(355);
-				tryCatchExpr();
-				}
-				break;
-			case 7:
-				enterOuterAlt(_localctx, 7);
-				{
-				setState(356);
-				orExpr();
-				}
-				break;
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class FlowrExprContext extends ParserRuleContext {
-		public ForClauseContext start_for;
-		public LetClauseContext start_let;
-		public ExprSingleContext return_expr;
-		public TerminalNode Kreturn() { return getToken(JsoniqParser.Kreturn, 0); }
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public List<ForClauseContext> forClause() {
-			return getRuleContexts(ForClauseContext.class);
-		}
-		public ForClauseContext forClause(int i) {
-			return getRuleContext(ForClauseContext.class,i);
-		}
-		public List<LetClauseContext> letClause() {
-			return getRuleContexts(LetClauseContext.class);
-		}
-		public LetClauseContext letClause(int i) {
-			return getRuleContext(LetClauseContext.class,i);
-		}
-		public List<WhereClauseContext> whereClause() {
-			return getRuleContexts(WhereClauseContext.class);
-		}
-		public WhereClauseContext whereClause(int i) {
-			return getRuleContext(WhereClauseContext.class,i);
-		}
-		public List<GroupByClauseContext> groupByClause() {
-			return getRuleContexts(GroupByClauseContext.class);
-		}
-		public GroupByClauseContext groupByClause(int i) {
-			return getRuleContext(GroupByClauseContext.class,i);
-		}
-		public List<OrderByClauseContext> orderByClause() {
-			return getRuleContexts(OrderByClauseContext.class);
-		}
-		public OrderByClauseContext orderByClause(int i) {
-			return getRuleContext(OrderByClauseContext.class,i);
-		}
-		public List<CountClauseContext> countClause() {
-			return getRuleContexts(CountClauseContext.class);
-		}
-		public CountClauseContext countClause(int i) {
-			return getRuleContext(CountClauseContext.class,i);
-		}
-		public FlowrExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_flowrExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitFlowrExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final FlowrExprContext flowrExpr() throws RecognitionException {
-		FlowrExprContext _localctx = new FlowrExprContext(_ctx, getState());
-		enterRule(_localctx, 32, RULE_flowrExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(361);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case Kfor:
-				{
-				setState(359);
-				((FlowrExprContext)_localctx).start_for = forClause();
-				}
-				break;
-			case Klet:
-				{
-				setState(360);
-				((FlowrExprContext)_localctx).start_let = letClause();
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-			setState(371);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (((((_la - 77)) & ~0x3f) == 0 && ((1L << (_la - 77)) & ((1L << (Kfor - 77)) | (1L << (Klet - 77)) | (1L << (Kwhere - 77)) | (1L << (Kgroup - 77)) | (1L << (Korder - 77)) | (1L << (Kcount - 77)) | (1L << (Kstable - 77)))) != 0)) {
-				{
-				setState(369);
-				_errHandler.sync(this);
-				switch (_input.LA(1)) {
-				case Kfor:
-					{
-					setState(363);
-					forClause();
-					}
-					break;
-				case Kwhere:
-					{
-					setState(364);
-					whereClause();
-					}
-					break;
-				case Klet:
-					{
-					setState(365);
-					letClause();
-					}
-					break;
-				case Kgroup:
-					{
-					setState(366);
-					groupByClause();
-					}
-					break;
-				case Korder:
-				case Kstable:
-					{
-					setState(367);
-					orderByClause();
-					}
-					break;
-				case Kcount:
-					{
-					setState(368);
-					countClause();
-					}
-					break;
-				default:
-					throw new NoViableAltException(this);
-				}
-				}
-				setState(373);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			setState(374);
-			match(Kreturn);
-			setState(375);
-			((FlowrExprContext)_localctx).return_expr = exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ForClauseContext extends ParserRuleContext {
-		public ForVarContext forVar;
-		public List<ForVarContext> vars = new ArrayList<ForVarContext>();
-		public TerminalNode Kfor() { return getToken(JsoniqParser.Kfor, 0); }
-		public List<ForVarContext> forVar() {
-			return getRuleContexts(ForVarContext.class);
-		}
-		public ForVarContext forVar(int i) {
-			return getRuleContext(ForVarContext.class,i);
-		}
-		public ForClauseContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_forClause; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitForClause(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ForClauseContext forClause() throws RecognitionException {
-		ForClauseContext _localctx = new ForClauseContext(_ctx, getState());
-		enterRule(_localctx, 34, RULE_forClause);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(377);
-			match(Kfor);
-			setState(378);
-			((ForClauseContext)_localctx).forVar = forVar();
-			((ForClauseContext)_localctx).vars.add(((ForClauseContext)_localctx).forVar);
-			setState(383);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__21) {
-				{
-				{
-				setState(379);
-				match(T__21);
-				setState(380);
-				((ForClauseContext)_localctx).forVar = forVar();
-				((ForClauseContext)_localctx).vars.add(((ForClauseContext)_localctx).forVar);
-				}
-				}
-				setState(385);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ForVarContext extends ParserRuleContext {
-		public VarRefContext var_ref;
-		public SequenceTypeContext seq;
-		public Token flag;
-		public VarRefContext at;
-		public ExprSingleContext ex;
-		public TerminalNode Kin() { return getToken(JsoniqParser.Kin, 0); }
-		public List<VarRefContext> varRef() {
-			return getRuleContexts(VarRefContext.class);
-		}
-		public VarRefContext varRef(int i) {
-			return getRuleContext(VarRefContext.class,i);
-		}
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public TerminalNode Kempty() { return getToken(JsoniqParser.Kempty, 0); }
-		public TerminalNode Kat() { return getToken(JsoniqParser.Kat, 0); }
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public TerminalNode Kallowing() { return getToken(JsoniqParser.Kallowing, 0); }
-		public ForVarContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_forVar; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitForVar(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ForVarContext forVar() throws RecognitionException {
-		ForVarContext _localctx = new ForVarContext(_ctx, getState());
-		enterRule(_localctx, 36, RULE_forVar);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(386);
-			((ForVarContext)_localctx).var_ref = varRef();
-			setState(389);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kas) {
-				{
-				setState(387);
-				match(Kas);
-				setState(388);
-				((ForVarContext)_localctx).seq = sequenceType();
-				}
-			}
-
-			setState(393);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kallowing) {
-				{
-				setState(391);
-				((ForVarContext)_localctx).flag = match(Kallowing);
-				setState(392);
-				match(Kempty);
-				}
-			}
-
-			setState(397);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kat) {
-				{
-				setState(395);
-				match(Kat);
-				setState(396);
-				((ForVarContext)_localctx).at = varRef();
-				}
-			}
-
-			setState(399);
-			match(Kin);
-			setState(400);
-			((ForVarContext)_localctx).ex = exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class LetClauseContext extends ParserRuleContext {
-		public LetVarContext letVar;
-		public List<LetVarContext> vars = new ArrayList<LetVarContext>();
-		public TerminalNode Klet() { return getToken(JsoniqParser.Klet, 0); }
-		public List<LetVarContext> letVar() {
-			return getRuleContexts(LetVarContext.class);
-		}
-		public LetVarContext letVar(int i) {
-			return getRuleContext(LetVarContext.class,i);
-		}
-		public LetClauseContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_letClause; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitLetClause(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final LetClauseContext letClause() throws RecognitionException {
-		LetClauseContext _localctx = new LetClauseContext(_ctx, getState());
-		enterRule(_localctx, 38, RULE_letClause);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(402);
-			match(Klet);
-			setState(403);
-			((LetClauseContext)_localctx).letVar = letVar();
-			((LetClauseContext)_localctx).vars.add(((LetClauseContext)_localctx).letVar);
-			setState(408);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__21) {
-				{
-				{
-				setState(404);
-				match(T__21);
-				setState(405);
-				((LetClauseContext)_localctx).letVar = letVar();
-				((LetClauseContext)_localctx).vars.add(((LetClauseContext)_localctx).letVar);
-				}
-				}
-				setState(410);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class LetVarContext extends ParserRuleContext {
-		public VarRefContext var_ref;
-		public SequenceTypeContext seq;
-		public ExprSingleContext ex;
-		public VarRefContext varRef() {
-			return getRuleContext(VarRefContext.class,0);
-		}
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public LetVarContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_letVar; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitLetVar(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final LetVarContext letVar() throws RecognitionException {
-		LetVarContext _localctx = new LetVarContext(_ctx, getState());
-		enterRule(_localctx, 40, RULE_letVar);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(411);
-			((LetVarContext)_localctx).var_ref = varRef();
-			setState(414);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kas) {
-				{
-				setState(412);
-				match(Kas);
-				setState(413);
-				((LetVarContext)_localctx).seq = sequenceType();
-				}
-			}
-
-			setState(416);
-			match(T__23);
-			setState(417);
-			((LetVarContext)_localctx).ex = exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class WhereClauseContext extends ParserRuleContext {
-		public TerminalNode Kwhere() { return getToken(JsoniqParser.Kwhere, 0); }
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public WhereClauseContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_whereClause; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitWhereClause(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final WhereClauseContext whereClause() throws RecognitionException {
-		WhereClauseContext _localctx = new WhereClauseContext(_ctx, getState());
-		enterRule(_localctx, 42, RULE_whereClause);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(419);
-			match(Kwhere);
-			setState(420);
-			exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class GroupByClauseContext extends ParserRuleContext {
-		public GroupByVarContext groupByVar;
-		public List<GroupByVarContext> vars = new ArrayList<GroupByVarContext>();
-		public TerminalNode Kgroup() { return getToken(JsoniqParser.Kgroup, 0); }
-		public TerminalNode Kby() { return getToken(JsoniqParser.Kby, 0); }
-		public List<GroupByVarContext> groupByVar() {
-			return getRuleContexts(GroupByVarContext.class);
-		}
-		public GroupByVarContext groupByVar(int i) {
-			return getRuleContext(GroupByVarContext.class,i);
-		}
-		public GroupByClauseContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_groupByClause; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitGroupByClause(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final GroupByClauseContext groupByClause() throws RecognitionException {
-		GroupByClauseContext _localctx = new GroupByClauseContext(_ctx, getState());
-		enterRule(_localctx, 44, RULE_groupByClause);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(422);
-			match(Kgroup);
-			setState(423);
-			match(Kby);
-			setState(424);
-			((GroupByClauseContext)_localctx).groupByVar = groupByVar();
-			((GroupByClauseContext)_localctx).vars.add(((GroupByClauseContext)_localctx).groupByVar);
-			setState(429);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__21) {
-				{
-				{
-				setState(425);
-				match(T__21);
-				setState(426);
-				((GroupByClauseContext)_localctx).groupByVar = groupByVar();
-				((GroupByClauseContext)_localctx).vars.add(((GroupByClauseContext)_localctx).groupByVar);
-				}
-				}
-				setState(431);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class GroupByVarContext extends ParserRuleContext {
-		public VarRefContext var_ref;
-		public SequenceTypeContext seq;
-		public Token decl;
-		public ExprSingleContext ex;
-		public UriLiteralContext uri;
-		public VarRefContext varRef() {
-			return getRuleContext(VarRefContext.class,0);
-		}
-		public TerminalNode Kcollation() { return getToken(JsoniqParser.Kcollation, 0); }
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public UriLiteralContext uriLiteral() {
-			return getRuleContext(UriLiteralContext.class,0);
-		}
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public GroupByVarContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_groupByVar; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitGroupByVar(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final GroupByVarContext groupByVar() throws RecognitionException {
-		GroupByVarContext _localctx = new GroupByVarContext(_ctx, getState());
-		enterRule(_localctx, 46, RULE_groupByVar);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(432);
-			((GroupByVarContext)_localctx).var_ref = varRef();
-			setState(439);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==T__23 || _la==Kas) {
-				{
-				setState(435);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-				if (_la==Kas) {
-					{
-					setState(433);
-					match(Kas);
-					setState(434);
-					((GroupByVarContext)_localctx).seq = sequenceType();
-					}
-				}
-
-				setState(437);
-				((GroupByVarContext)_localctx).decl = match(T__23);
-				setState(438);
-				((GroupByVarContext)_localctx).ex = exprSingle();
-				}
-			}
-
-			setState(443);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kcollation) {
-				{
-				setState(441);
-				match(Kcollation);
-				setState(442);
-				((GroupByVarContext)_localctx).uri = uriLiteral();
-				}
-			}
-
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class OrderByClauseContext extends ParserRuleContext {
-		public Token stb;
-		public List<OrderByExprContext> orderByExpr() {
-			return getRuleContexts(OrderByExprContext.class);
-		}
-		public OrderByExprContext orderByExpr(int i) {
-			return getRuleContext(OrderByExprContext.class,i);
-		}
-		public TerminalNode Korder() { return getToken(JsoniqParser.Korder, 0); }
-		public TerminalNode Kby() { return getToken(JsoniqParser.Kby, 0); }
-		public TerminalNode Kstable() { return getToken(JsoniqParser.Kstable, 0); }
-		public OrderByClauseContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_orderByClause; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitOrderByClause(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final OrderByClauseContext orderByClause() throws RecognitionException {
-		OrderByClauseContext _localctx = new OrderByClauseContext(_ctx, getState());
-		enterRule(_localctx, 48, RULE_orderByClause);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(450);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case Korder:
-				{
-				{
-				setState(445);
-				match(Korder);
-				setState(446);
-				match(Kby);
-				}
-				}
-				break;
-			case Kstable:
-				{
-				{
-				setState(447);
-				((OrderByClauseContext)_localctx).stb = match(Kstable);
-				setState(448);
-				match(Korder);
-				setState(449);
-				match(Kby);
-				}
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-			setState(452);
-			orderByExpr();
-			setState(457);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__21) {
-				{
-				{
-				setState(453);
-				match(T__21);
-				setState(454);
-				orderByExpr();
-				}
-				}
-				setState(459);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class OrderByExprContext extends ParserRuleContext {
-		public ExprSingleContext ex;
-		public Token desc;
-		public Token gr;
-		public Token ls;
-		public UriLiteralContext uril;
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public TerminalNode Kascending() { return getToken(JsoniqParser.Kascending, 0); }
-		public TerminalNode Kempty() { return getToken(JsoniqParser.Kempty, 0); }
-		public TerminalNode Kcollation() { return getToken(JsoniqParser.Kcollation, 0); }
-		public TerminalNode Kdescending() { return getToken(JsoniqParser.Kdescending, 0); }
-		public UriLiteralContext uriLiteral() {
-			return getRuleContext(UriLiteralContext.class,0);
-		}
-		public TerminalNode Kgreatest() { return getToken(JsoniqParser.Kgreatest, 0); }
-		public TerminalNode Kleast() { return getToken(JsoniqParser.Kleast, 0); }
-		public OrderByExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_orderByExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitOrderByExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final OrderByExprContext orderByExpr() throws RecognitionException {
-		OrderByExprContext _localctx = new OrderByExprContext(_ctx, getState());
-		enterRule(_localctx, 50, RULE_orderByExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(460);
-			((OrderByExprContext)_localctx).ex = exprSingle();
-			setState(463);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case Kascending:
-				{
-				setState(461);
-				match(Kascending);
-				}
-				break;
-			case Kdescending:
-				{
-				setState(462);
-				((OrderByExprContext)_localctx).desc = match(Kdescending);
-				}
-				break;
-			case T__21:
-			case Kfor:
-			case Klet:
-			case Kwhere:
-			case Kgroup:
-			case Korder:
-			case Kreturn:
-			case Kempty:
-			case Kcount:
-			case Kstable:
-			case Kcollation:
-				break;
-			default:
-				break;
-			}
-			setState(470);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kempty) {
-				{
-				setState(465);
-				match(Kempty);
-				setState(468);
-				_errHandler.sync(this);
-				switch (_input.LA(1)) {
-				case Kgreatest:
-					{
-					setState(466);
-					((OrderByExprContext)_localctx).gr = match(Kgreatest);
-					}
-					break;
-				case Kleast:
-					{
-					setState(467);
-					((OrderByExprContext)_localctx).ls = match(Kleast);
-					}
-					break;
-				default:
-					throw new NoViableAltException(this);
-				}
-				}
-			}
-
-			setState(474);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kcollation) {
-				{
-				setState(472);
-				match(Kcollation);
-				setState(473);
-				((OrderByExprContext)_localctx).uril = uriLiteral();
-				}
-			}
-
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class CountClauseContext extends ParserRuleContext {
-		public TerminalNode Kcount() { return getToken(JsoniqParser.Kcount, 0); }
-		public VarRefContext varRef() {
-			return getRuleContext(VarRefContext.class,0);
-		}
-		public CountClauseContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_countClause; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitCountClause(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final CountClauseContext countClause() throws RecognitionException {
-		CountClauseContext _localctx = new CountClauseContext(_ctx, getState());
-		enterRule(_localctx, 52, RULE_countClause);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(476);
-			match(Kcount);
-			setState(477);
-			varRef();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class QuantifiedExprContext extends ParserRuleContext {
-		public Token so;
-		public Token ev;
-		public QuantifiedExprVarContext quantifiedExprVar;
-		public List<QuantifiedExprVarContext> vars = new ArrayList<QuantifiedExprVarContext>();
-		public TerminalNode Ksatisfies() { return getToken(JsoniqParser.Ksatisfies, 0); }
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public List<QuantifiedExprVarContext> quantifiedExprVar() {
-			return getRuleContexts(QuantifiedExprVarContext.class);
-		}
-		public QuantifiedExprVarContext quantifiedExprVar(int i) {
-			return getRuleContext(QuantifiedExprVarContext.class,i);
-		}
-		public TerminalNode Ksome() { return getToken(JsoniqParser.Ksome, 0); }
-		public TerminalNode Kevery() { return getToken(JsoniqParser.Kevery, 0); }
-		public QuantifiedExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_quantifiedExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitQuantifiedExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final QuantifiedExprContext quantifiedExpr() throws RecognitionException {
-		QuantifiedExprContext _localctx = new QuantifiedExprContext(_ctx, getState());
-		enterRule(_localctx, 54, RULE_quantifiedExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(481);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case Ksome:
-				{
-				setState(479);
-				((QuantifiedExprContext)_localctx).so = match(Ksome);
-				}
-				break;
-			case Kevery:
-				{
-				setState(480);
-				((QuantifiedExprContext)_localctx).ev = match(Kevery);
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-			setState(483);
-			((QuantifiedExprContext)_localctx).quantifiedExprVar = quantifiedExprVar();
-			((QuantifiedExprContext)_localctx).vars.add(((QuantifiedExprContext)_localctx).quantifiedExprVar);
-			setState(488);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__21) {
-				{
-				{
-				setState(484);
-				match(T__21);
-				setState(485);
-				((QuantifiedExprContext)_localctx).quantifiedExprVar = quantifiedExprVar();
-				((QuantifiedExprContext)_localctx).vars.add(((QuantifiedExprContext)_localctx).quantifiedExprVar);
-				}
-				}
-				setState(490);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			setState(491);
-			match(Ksatisfies);
-			setState(492);
-			exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class QuantifiedExprVarContext extends ParserRuleContext {
-		public VarRefContext varRef() {
-			return getRuleContext(VarRefContext.class,0);
-		}
-		public TerminalNode Kin() { return getToken(JsoniqParser.Kin, 0); }
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public QuantifiedExprVarContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_quantifiedExprVar; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitQuantifiedExprVar(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final QuantifiedExprVarContext quantifiedExprVar() throws RecognitionException {
-		QuantifiedExprVarContext _localctx = new QuantifiedExprVarContext(_ctx, getState());
-		enterRule(_localctx, 56, RULE_quantifiedExprVar);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(494);
-			varRef();
-			setState(497);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kas) {
-				{
-				setState(495);
-				match(Kas);
-				setState(496);
-				sequenceType();
-				}
-			}
-
-			setState(499);
-			match(Kin);
-			setState(500);
-			exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class SwitchExprContext extends ParserRuleContext {
-		public ExprContext cond;
-		public SwitchCaseClauseContext switchCaseClause;
-		public List<SwitchCaseClauseContext> cases = new ArrayList<SwitchCaseClauseContext>();
-		public ExprSingleContext def;
-		public TerminalNode Kswitch() { return getToken(JsoniqParser.Kswitch, 0); }
-		public TerminalNode Kdefault() { return getToken(JsoniqParser.Kdefault, 0); }
-		public TerminalNode Kreturn() { return getToken(JsoniqParser.Kreturn, 0); }
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public List<SwitchCaseClauseContext> switchCaseClause() {
-			return getRuleContexts(SwitchCaseClauseContext.class);
-		}
-		public SwitchCaseClauseContext switchCaseClause(int i) {
-			return getRuleContext(SwitchCaseClauseContext.class,i);
-		}
-		public SwitchExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_switchExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitSwitchExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final SwitchExprContext switchExpr() throws RecognitionException {
-		SwitchExprContext _localctx = new SwitchExprContext(_ctx, getState());
-		enterRule(_localctx, 58, RULE_switchExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(502);
-			match(Kswitch);
-			setState(503);
-			match(T__26);
-			setState(504);
-			((SwitchExprContext)_localctx).cond = expr();
-			setState(505);
-			match(T__27);
-			setState(507); 
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			do {
-				{
-				{
-				setState(506);
-				((SwitchExprContext)_localctx).switchCaseClause = switchCaseClause();
-				((SwitchExprContext)_localctx).cases.add(((SwitchExprContext)_localctx).switchCaseClause);
-				}
-				}
-				setState(509); 
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			} while ( _la==Kcase );
-			setState(511);
-			match(Kdefault);
-			setState(512);
-			match(Kreturn);
-			setState(513);
-			((SwitchExprContext)_localctx).def = exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class SwitchCaseClauseContext extends ParserRuleContext {
-		public ExprSingleContext exprSingle;
-		public List<ExprSingleContext> cond = new ArrayList<ExprSingleContext>();
-		public ExprSingleContext ret;
-		public TerminalNode Kreturn() { return getToken(JsoniqParser.Kreturn, 0); }
-		public List<ExprSingleContext> exprSingle() {
-			return getRuleContexts(ExprSingleContext.class);
-		}
-		public ExprSingleContext exprSingle(int i) {
-			return getRuleContext(ExprSingleContext.class,i);
-		}
-		public List<TerminalNode> Kcase() { return getTokens(JsoniqParser.Kcase); }
-		public TerminalNode Kcase(int i) {
-			return getToken(JsoniqParser.Kcase, i);
-		}
-		public SwitchCaseClauseContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_switchCaseClause; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitSwitchCaseClause(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final SwitchCaseClauseContext switchCaseClause() throws RecognitionException {
-		SwitchCaseClauseContext _localctx = new SwitchCaseClauseContext(_ctx, getState());
-		enterRule(_localctx, 60, RULE_switchCaseClause);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(517); 
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			do {
-				{
-				{
-				setState(515);
-				match(Kcase);
-				setState(516);
-				((SwitchCaseClauseContext)_localctx).exprSingle = exprSingle();
-				((SwitchCaseClauseContext)_localctx).cond.add(((SwitchCaseClauseContext)_localctx).exprSingle);
-				}
-				}
-				setState(519); 
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			} while ( _la==Kcase );
-			setState(521);
-			match(Kreturn);
-			setState(522);
-			((SwitchCaseClauseContext)_localctx).ret = exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class TypeSwitchExprContext extends ParserRuleContext {
-		public ExprContext cond;
-		public CaseClauseContext caseClause;
-		public List<CaseClauseContext> cses = new ArrayList<CaseClauseContext>();
-		public VarRefContext var_ref;
-		public ExprSingleContext def;
-		public TerminalNode Ktypeswitch() { return getToken(JsoniqParser.Ktypeswitch, 0); }
-		public TerminalNode Kdefault() { return getToken(JsoniqParser.Kdefault, 0); }
-		public TerminalNode Kreturn() { return getToken(JsoniqParser.Kreturn, 0); }
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public List<CaseClauseContext> caseClause() {
-			return getRuleContexts(CaseClauseContext.class);
-		}
-		public CaseClauseContext caseClause(int i) {
-			return getRuleContext(CaseClauseContext.class,i);
-		}
-		public VarRefContext varRef() {
-			return getRuleContext(VarRefContext.class,0);
-		}
-		public TypeSwitchExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_typeSwitchExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitTypeSwitchExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final TypeSwitchExprContext typeSwitchExpr() throws RecognitionException {
-		TypeSwitchExprContext _localctx = new TypeSwitchExprContext(_ctx, getState());
-		enterRule(_localctx, 62, RULE_typeSwitchExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(524);
-			match(Ktypeswitch);
-			setState(525);
-			match(T__26);
-			setState(526);
-			((TypeSwitchExprContext)_localctx).cond = expr();
-			setState(527);
-			match(T__27);
-			setState(529); 
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			do {
-				{
-				{
-				setState(528);
-				((TypeSwitchExprContext)_localctx).caseClause = caseClause();
-				((TypeSwitchExprContext)_localctx).cses.add(((TypeSwitchExprContext)_localctx).caseClause);
-				}
-				}
-				setState(531); 
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			} while ( _la==Kcase );
-			setState(533);
-			match(Kdefault);
-			setState(535);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==T__30) {
-				{
-				setState(534);
-				((TypeSwitchExprContext)_localctx).var_ref = varRef();
-				}
-			}
-
-			setState(537);
-			match(Kreturn);
-			setState(538);
-			((TypeSwitchExprContext)_localctx).def = exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class CaseClauseContext extends ParserRuleContext {
-		public VarRefContext var_ref;
-		public SequenceTypeContext sequenceType;
-		public List<SequenceTypeContext> union = new ArrayList<SequenceTypeContext>();
-		public ExprSingleContext ret;
-		public TerminalNode Kcase() { return getToken(JsoniqParser.Kcase, 0); }
-		public TerminalNode Kreturn() { return getToken(JsoniqParser.Kreturn, 0); }
-		public List<SequenceTypeContext> sequenceType() {
-			return getRuleContexts(SequenceTypeContext.class);
-		}
-		public SequenceTypeContext sequenceType(int i) {
-			return getRuleContext(SequenceTypeContext.class,i);
-		}
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public VarRefContext varRef() {
-			return getRuleContext(VarRefContext.class,0);
-		}
-		public CaseClauseContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_caseClause; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitCaseClause(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final CaseClauseContext caseClause() throws RecognitionException {
-		CaseClauseContext _localctx = new CaseClauseContext(_ctx, getState());
-		enterRule(_localctx, 64, RULE_caseClause);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(540);
-			match(Kcase);
-			setState(544);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==T__30) {
-				{
-				setState(541);
-				((CaseClauseContext)_localctx).var_ref = varRef();
-				setState(542);
-				match(Kas);
-				}
-			}
-
-			setState(546);
-			((CaseClauseContext)_localctx).sequenceType = sequenceType();
-			((CaseClauseContext)_localctx).union.add(((CaseClauseContext)_localctx).sequenceType);
-			setState(551);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__31) {
-				{
-				{
-				setState(547);
-				match(T__31);
-				setState(548);
-				((CaseClauseContext)_localctx).sequenceType = sequenceType();
-				((CaseClauseContext)_localctx).union.add(((CaseClauseContext)_localctx).sequenceType);
-				}
-				}
-				setState(553);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			setState(554);
-			match(Kreturn);
-			setState(555);
-			((CaseClauseContext)_localctx).ret = exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class IfExprContext extends ParserRuleContext {
-		public ExprContext test_condition;
-		public ExprSingleContext branch;
-		public ExprSingleContext else_branch;
-		public TerminalNode Kif() { return getToken(JsoniqParser.Kif, 0); }
-		public TerminalNode Kthen() { return getToken(JsoniqParser.Kthen, 0); }
-		public TerminalNode Kelse() { return getToken(JsoniqParser.Kelse, 0); }
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public List<ExprSingleContext> exprSingle() {
-			return getRuleContexts(ExprSingleContext.class);
-		}
-		public ExprSingleContext exprSingle(int i) {
-			return getRuleContext(ExprSingleContext.class,i);
-		}
-		public IfExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_ifExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitIfExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final IfExprContext ifExpr() throws RecognitionException {
-		IfExprContext _localctx = new IfExprContext(_ctx, getState());
-		enterRule(_localctx, 66, RULE_ifExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(557);
-			match(Kif);
-			setState(558);
-			match(T__26);
-			setState(559);
-			((IfExprContext)_localctx).test_condition = expr();
-			setState(560);
-			match(T__27);
-			setState(561);
-			match(Kthen);
-			setState(562);
-			((IfExprContext)_localctx).branch = exprSingle();
-			setState(563);
-			match(Kelse);
-			setState(564);
-			((IfExprContext)_localctx).else_branch = exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class TryCatchExprContext extends ParserRuleContext {
-		public TerminalNode Ktry() { return getToken(JsoniqParser.Ktry, 0); }
-		public List<ExprContext> expr() {
-			return getRuleContexts(ExprContext.class);
-		}
-		public ExprContext expr(int i) {
-			return getRuleContext(ExprContext.class,i);
-		}
-		public TerminalNode Kcatch() { return getToken(JsoniqParser.Kcatch, 0); }
-		public TryCatchExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_tryCatchExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitTryCatchExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final TryCatchExprContext tryCatchExpr() throws RecognitionException {
-		TryCatchExprContext _localctx = new TryCatchExprContext(_ctx, getState());
-		enterRule(_localctx, 68, RULE_tryCatchExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(566);
-			match(Ktry);
-			setState(567);
-			match(T__28);
-			setState(568);
-			expr();
-			setState(569);
-			match(T__29);
-			setState(570);
-			match(Kcatch);
-			setState(571);
-			match(T__32);
-			setState(572);
-			match(T__28);
-			setState(573);
-			expr();
-			setState(574);
-			match(T__29);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class OrExprContext extends ParserRuleContext {
-		public AndExprContext main_expr;
-		public AndExprContext andExpr;
-		public List<AndExprContext> rhs = new ArrayList<AndExprContext>();
-		public List<AndExprContext> andExpr() {
-			return getRuleContexts(AndExprContext.class);
-		}
-		public AndExprContext andExpr(int i) {
-			return getRuleContext(AndExprContext.class,i);
-		}
-		public List<TerminalNode> Kor() { return getTokens(JsoniqParser.Kor); }
-		public TerminalNode Kor(int i) {
-			return getToken(JsoniqParser.Kor, i);
-		}
-		public OrExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_orExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitOrExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final OrExprContext orExpr() throws RecognitionException {
-		OrExprContext _localctx = new OrExprContext(_ctx, getState());
-		enterRule(_localctx, 70, RULE_orExpr);
-		try {
-			int _alt;
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(576);
-			((OrExprContext)_localctx).main_expr = andExpr();
-			setState(581);
-			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,51,_ctx);
-			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
-				if ( _alt==1 ) {
-					{
-					{
-					setState(577);
-					match(Kor);
-					setState(578);
-					((OrExprContext)_localctx).andExpr = andExpr();
-					((OrExprContext)_localctx).rhs.add(((OrExprContext)_localctx).andExpr);
-					}
-					} 
-				}
-				setState(583);
-				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,51,_ctx);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class AndExprContext extends ParserRuleContext {
-		public NotExprContext main_expr;
-		public NotExprContext notExpr;
-		public List<NotExprContext> rhs = new ArrayList<NotExprContext>();
-		public List<NotExprContext> notExpr() {
-			return getRuleContexts(NotExprContext.class);
-		}
-		public NotExprContext notExpr(int i) {
-			return getRuleContext(NotExprContext.class,i);
-		}
-		public List<TerminalNode> Kand() { return getTokens(JsoniqParser.Kand); }
-		public TerminalNode Kand(int i) {
-			return getToken(JsoniqParser.Kand, i);
-		}
-		public AndExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_andExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitAndExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final AndExprContext andExpr() throws RecognitionException {
-		AndExprContext _localctx = new AndExprContext(_ctx, getState());
-		enterRule(_localctx, 72, RULE_andExpr);
-		try {
-			int _alt;
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(584);
-			((AndExprContext)_localctx).main_expr = notExpr();
-			setState(589);
-			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,52,_ctx);
-			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
-				if ( _alt==1 ) {
-					{
-					{
-					setState(585);
-					match(Kand);
-					setState(586);
-					((AndExprContext)_localctx).notExpr = notExpr();
-					((AndExprContext)_localctx).rhs.add(((AndExprContext)_localctx).notExpr);
-					}
-					} 
-				}
-				setState(591);
-				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,52,_ctx);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class NotExprContext extends ParserRuleContext {
-		public Token Knot;
-		public List<Token> op = new ArrayList<Token>();
-		public ComparisonExprContext main_expr;
-		public ComparisonExprContext comparisonExpr() {
-			return getRuleContext(ComparisonExprContext.class,0);
-		}
-		public TerminalNode Knot() { return getToken(JsoniqParser.Knot, 0); }
-		public NotExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_notExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitNotExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final NotExprContext notExpr() throws RecognitionException {
-		NotExprContext _localctx = new NotExprContext(_ctx, getState());
-		enterRule(_localctx, 74, RULE_notExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(593);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,53,_ctx) ) {
-			case 1:
-				{
-				setState(592);
-				((NotExprContext)_localctx).Knot = match(Knot);
-				((NotExprContext)_localctx).op.add(((NotExprContext)_localctx).Knot);
-				}
-				break;
-			}
-			setState(595);
-			((NotExprContext)_localctx).main_expr = comparisonExpr();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ComparisonExprContext extends ParserRuleContext {
-		public StringConcatExprContext main_expr;
-		public Token s34;
-		public List<Token> op = new ArrayList<Token>();
-		public Token s35;
-		public Token s36;
-		public Token s37;
-		public Token s38;
-		public Token s39;
-		public Token s4;
-		public Token s40;
-		public Token s41;
-		public Token s42;
-		public Token s43;
-		public Token s44;
-		public Token _tset1051;
-		public StringConcatExprContext stringConcatExpr;
-		public List<StringConcatExprContext> rhs = new ArrayList<StringConcatExprContext>();
-		public List<StringConcatExprContext> stringConcatExpr() {
-			return getRuleContexts(StringConcatExprContext.class);
-		}
-		public StringConcatExprContext stringConcatExpr(int i) {
-			return getRuleContext(StringConcatExprContext.class,i);
-		}
-		public ComparisonExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_comparisonExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitComparisonExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ComparisonExprContext comparisonExpr() throws RecognitionException {
-		ComparisonExprContext _localctx = new ComparisonExprContext(_ctx, getState());
-		enterRule(_localctx, 76, RULE_comparisonExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(597);
-			((ComparisonExprContext)_localctx).main_expr = stringConcatExpr();
-			setState(600);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__3) | (1L << T__33) | (1L << T__34) | (1L << T__35) | (1L << T__36) | (1L << T__37) | (1L << T__38) | (1L << T__39) | (1L << T__40) | (1L << T__41) | (1L << T__42) | (1L << T__43))) != 0)) {
-				{
-				setState(598);
-				((ComparisonExprContext)_localctx)._tset1051 = _input.LT(1);
-				_la = _input.LA(1);
-				if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__3) | (1L << T__33) | (1L << T__34) | (1L << T__35) | (1L << T__36) | (1L << T__37) | (1L << T__38) | (1L << T__39) | (1L << T__40) | (1L << T__41) | (1L << T__42) | (1L << T__43))) != 0)) ) {
-					((ComparisonExprContext)_localctx)._tset1051 = (Token)_errHandler.recoverInline(this);
-				}
-				else {
-					if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-					_errHandler.reportMatch(this);
-					consume();
-				}
-				((ComparisonExprContext)_localctx).op.add(((ComparisonExprContext)_localctx)._tset1051);
-				setState(599);
-				((ComparisonExprContext)_localctx).stringConcatExpr = stringConcatExpr();
-				((ComparisonExprContext)_localctx).rhs.add(((ComparisonExprContext)_localctx).stringConcatExpr);
-				}
-			}
-
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class StringConcatExprContext extends ParserRuleContext {
-		public RangeExprContext main_expr;
-		public RangeExprContext rangeExpr;
-		public List<RangeExprContext> rhs = new ArrayList<RangeExprContext>();
-		public List<RangeExprContext> rangeExpr() {
-			return getRuleContexts(RangeExprContext.class);
-		}
-		public RangeExprContext rangeExpr(int i) {
-			return getRuleContext(RangeExprContext.class,i);
-		}
-		public StringConcatExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_stringConcatExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitStringConcatExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final StringConcatExprContext stringConcatExpr() throws RecognitionException {
-		StringConcatExprContext _localctx = new StringConcatExprContext(_ctx, getState());
-		enterRule(_localctx, 78, RULE_stringConcatExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(602);
-			((StringConcatExprContext)_localctx).main_expr = rangeExpr();
-			setState(607);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__44) {
-				{
-				{
-				setState(603);
-				match(T__44);
-				setState(604);
-				((StringConcatExprContext)_localctx).rangeExpr = rangeExpr();
-				((StringConcatExprContext)_localctx).rhs.add(((StringConcatExprContext)_localctx).rangeExpr);
-				}
-				}
-				setState(609);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class RangeExprContext extends ParserRuleContext {
-		public AdditiveExprContext main_expr;
-		public AdditiveExprContext additiveExpr;
-		public List<AdditiveExprContext> rhs = new ArrayList<AdditiveExprContext>();
-		public List<AdditiveExprContext> additiveExpr() {
-			return getRuleContexts(AdditiveExprContext.class);
-		}
-		public AdditiveExprContext additiveExpr(int i) {
-			return getRuleContext(AdditiveExprContext.class,i);
-		}
-		public TerminalNode Kto() { return getToken(JsoniqParser.Kto, 0); }
-		public RangeExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_rangeExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitRangeExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final RangeExprContext rangeExpr() throws RecognitionException {
-		RangeExprContext _localctx = new RangeExprContext(_ctx, getState());
-		enterRule(_localctx, 80, RULE_rangeExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(610);
-			((RangeExprContext)_localctx).main_expr = additiveExpr();
-			setState(613);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,56,_ctx) ) {
-			case 1:
-				{
-				setState(611);
-				match(Kto);
-				setState(612);
-				((RangeExprContext)_localctx).additiveExpr = additiveExpr();
-				((RangeExprContext)_localctx).rhs.add(((RangeExprContext)_localctx).additiveExpr);
-				}
-				break;
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class AdditiveExprContext extends ParserRuleContext {
-		public MultiplicativeExprContext main_expr;
-		public Token s46;
-		public List<Token> op = new ArrayList<Token>();
-		public Token s47;
-		public Token _tset1160;
-		public MultiplicativeExprContext multiplicativeExpr;
-		public List<MultiplicativeExprContext> rhs = new ArrayList<MultiplicativeExprContext>();
-		public List<MultiplicativeExprContext> multiplicativeExpr() {
-			return getRuleContexts(MultiplicativeExprContext.class);
-		}
-		public MultiplicativeExprContext multiplicativeExpr(int i) {
-			return getRuleContext(MultiplicativeExprContext.class,i);
-		}
-		public AdditiveExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_additiveExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitAdditiveExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final AdditiveExprContext additiveExpr() throws RecognitionException {
-		AdditiveExprContext _localctx = new AdditiveExprContext(_ctx, getState());
-		enterRule(_localctx, 82, RULE_additiveExpr);
-		int _la;
-		try {
-			int _alt;
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(615);
-			((AdditiveExprContext)_localctx).main_expr = multiplicativeExpr();
-			setState(620);
-			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,57,_ctx);
-			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
-				if ( _alt==1 ) {
-					{
-					{
-					setState(616);
-					((AdditiveExprContext)_localctx)._tset1160 = _input.LT(1);
-					_la = _input.LA(1);
-					if ( !(_la==T__45 || _la==T__46) ) {
-						((AdditiveExprContext)_localctx)._tset1160 = (Token)_errHandler.recoverInline(this);
-					}
-					else {
-						if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-						_errHandler.reportMatch(this);
-						consume();
-					}
-					((AdditiveExprContext)_localctx).op.add(((AdditiveExprContext)_localctx)._tset1160);
-					setState(617);
-					((AdditiveExprContext)_localctx).multiplicativeExpr = multiplicativeExpr();
-					((AdditiveExprContext)_localctx).rhs.add(((AdditiveExprContext)_localctx).multiplicativeExpr);
-					}
-					} 
-				}
-				setState(622);
-				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,57,_ctx);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class MultiplicativeExprContext extends ParserRuleContext {
-		public InstanceOfExprContext main_expr;
-		public Token s33;
-		public List<Token> op = new ArrayList<Token>();
-		public Token s48;
-		public Token s49;
-		public Token s50;
-		public Token _tset1188;
-		public InstanceOfExprContext instanceOfExpr;
-		public List<InstanceOfExprContext> rhs = new ArrayList<InstanceOfExprContext>();
-		public List<InstanceOfExprContext> instanceOfExpr() {
-			return getRuleContexts(InstanceOfExprContext.class);
-		}
-		public InstanceOfExprContext instanceOfExpr(int i) {
-			return getRuleContext(InstanceOfExprContext.class,i);
-		}
-		public MultiplicativeExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_multiplicativeExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitMultiplicativeExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final MultiplicativeExprContext multiplicativeExpr() throws RecognitionException {
-		MultiplicativeExprContext _localctx = new MultiplicativeExprContext(_ctx, getState());
-		enterRule(_localctx, 84, RULE_multiplicativeExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(623);
-			((MultiplicativeExprContext)_localctx).main_expr = instanceOfExpr();
-			setState(628);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__32) | (1L << T__47) | (1L << T__48) | (1L << T__49))) != 0)) {
-				{
-				{
-				setState(624);
-				((MultiplicativeExprContext)_localctx)._tset1188 = _input.LT(1);
-				_la = _input.LA(1);
-				if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__32) | (1L << T__47) | (1L << T__48) | (1L << T__49))) != 0)) ) {
-					((MultiplicativeExprContext)_localctx)._tset1188 = (Token)_errHandler.recoverInline(this);
-				}
-				else {
-					if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-					_errHandler.reportMatch(this);
-					consume();
-				}
-				((MultiplicativeExprContext)_localctx).op.add(((MultiplicativeExprContext)_localctx)._tset1188);
-				setState(625);
-				((MultiplicativeExprContext)_localctx).instanceOfExpr = instanceOfExpr();
-				((MultiplicativeExprContext)_localctx).rhs.add(((MultiplicativeExprContext)_localctx).instanceOfExpr);
-				}
-				}
-				setState(630);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class InstanceOfExprContext extends ParserRuleContext {
-		public TreatExprContext main_expr;
-		public SequenceTypeContext seq;
-		public TreatExprContext treatExpr() {
-			return getRuleContext(TreatExprContext.class,0);
-		}
-		public TerminalNode Kinstance() { return getToken(JsoniqParser.Kinstance, 0); }
-		public TerminalNode Kof() { return getToken(JsoniqParser.Kof, 0); }
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public InstanceOfExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_instanceOfExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitInstanceOfExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final InstanceOfExprContext instanceOfExpr() throws RecognitionException {
-		InstanceOfExprContext _localctx = new InstanceOfExprContext(_ctx, getState());
-		enterRule(_localctx, 86, RULE_instanceOfExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(631);
-			((InstanceOfExprContext)_localctx).main_expr = treatExpr();
-			setState(635);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,59,_ctx) ) {
-			case 1:
-				{
-				setState(632);
-				match(Kinstance);
-				setState(633);
-				match(Kof);
-				setState(634);
-				((InstanceOfExprContext)_localctx).seq = sequenceType();
-				}
-				break;
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class TreatExprContext extends ParserRuleContext {
-		public CastableExprContext main_expr;
-		public SequenceTypeContext seq;
-		public CastableExprContext castableExpr() {
-			return getRuleContext(CastableExprContext.class,0);
-		}
-		public TerminalNode Ktreat() { return getToken(JsoniqParser.Ktreat, 0); }
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public TreatExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_treatExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitTreatExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final TreatExprContext treatExpr() throws RecognitionException {
-		TreatExprContext _localctx = new TreatExprContext(_ctx, getState());
-		enterRule(_localctx, 88, RULE_treatExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(637);
-			((TreatExprContext)_localctx).main_expr = castableExpr();
-			setState(641);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,60,_ctx) ) {
-			case 1:
-				{
-				setState(638);
-				match(Ktreat);
-				setState(639);
-				match(Kas);
-				setState(640);
-				((TreatExprContext)_localctx).seq = sequenceType();
-				}
-				break;
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class CastableExprContext extends ParserRuleContext {
-		public CastExprContext main_expr;
-		public SingleTypeContext single;
-		public CastExprContext castExpr() {
-			return getRuleContext(CastExprContext.class,0);
-		}
-		public TerminalNode Kcastable() { return getToken(JsoniqParser.Kcastable, 0); }
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public SingleTypeContext singleType() {
-			return getRuleContext(SingleTypeContext.class,0);
-		}
-		public CastableExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_castableExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitCastableExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final CastableExprContext castableExpr() throws RecognitionException {
-		CastableExprContext _localctx = new CastableExprContext(_ctx, getState());
-		enterRule(_localctx, 90, RULE_castableExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(643);
-			((CastableExprContext)_localctx).main_expr = castExpr();
-			setState(647);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,61,_ctx) ) {
-			case 1:
-				{
-				setState(644);
-				match(Kcastable);
-				setState(645);
-				match(Kas);
-				setState(646);
-				((CastableExprContext)_localctx).single = singleType();
-				}
-				break;
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class CastExprContext extends ParserRuleContext {
-		public UnaryExprContext main_expr;
-		public SingleTypeContext single;
-		public UnaryExprContext unaryExpr() {
-			return getRuleContext(UnaryExprContext.class,0);
-		}
-		public TerminalNode Kcast() { return getToken(JsoniqParser.Kcast, 0); }
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public SingleTypeContext singleType() {
-			return getRuleContext(SingleTypeContext.class,0);
-		}
-		public CastExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_castExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitCastExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final CastExprContext castExpr() throws RecognitionException {
-		CastExprContext _localctx = new CastExprContext(_ctx, getState());
-		enterRule(_localctx, 92, RULE_castExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(649);
-			((CastExprContext)_localctx).main_expr = unaryExpr();
-			setState(653);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,62,_ctx) ) {
-			case 1:
-				{
-				setState(650);
-				match(Kcast);
-				setState(651);
-				match(Kas);
-				setState(652);
-				((CastExprContext)_localctx).single = singleType();
-				}
-				break;
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class UnaryExprContext extends ParserRuleContext {
-		public Token s47;
-		public List<Token> op = new ArrayList<Token>();
-		public Token s46;
-		public Token _tset1305;
-		public SimpleMapExprContext main_expr;
-		public SimpleMapExprContext simpleMapExpr() {
-			return getRuleContext(SimpleMapExprContext.class,0);
-		}
-		public UnaryExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_unaryExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitUnaryExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final UnaryExprContext unaryExpr() throws RecognitionException {
-		UnaryExprContext _localctx = new UnaryExprContext(_ctx, getState());
-		enterRule(_localctx, 94, RULE_unaryExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(658);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__45 || _la==T__46) {
-				{
-				{
-				setState(655);
-				((UnaryExprContext)_localctx)._tset1305 = _input.LT(1);
-				_la = _input.LA(1);
-				if ( !(_la==T__45 || _la==T__46) ) {
-					((UnaryExprContext)_localctx)._tset1305 = (Token)_errHandler.recoverInline(this);
-				}
-				else {
-					if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-					_errHandler.reportMatch(this);
-					consume();
-				}
-				((UnaryExprContext)_localctx).op.add(((UnaryExprContext)_localctx)._tset1305);
-				}
-				}
-				setState(660);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			setState(661);
-			((UnaryExprContext)_localctx).main_expr = simpleMapExpr();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class SimpleMapExprContext extends ParserRuleContext {
-		public PostFixExprContext main_expr;
-		public List<PostFixExprContext> postFixExpr() {
-			return getRuleContexts(PostFixExprContext.class);
-		}
-		public PostFixExprContext postFixExpr(int i) {
-			return getRuleContext(PostFixExprContext.class,i);
-		}
-		public SimpleMapExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_simpleMapExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitSimpleMapExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final SimpleMapExprContext simpleMapExpr() throws RecognitionException {
-		SimpleMapExprContext _localctx = new SimpleMapExprContext(_ctx, getState());
-		enterRule(_localctx, 96, RULE_simpleMapExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(663);
-			((SimpleMapExprContext)_localctx).main_expr = postFixExpr();
-			setState(668);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (_la==T__50) {
-				{
-				{
-				setState(664);
-				match(T__50);
-				setState(665);
-				postFixExpr();
-				}
-				}
-				setState(670);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class PostFixExprContext extends ParserRuleContext {
-		public PrimaryExprContext main_expr;
-		public PrimaryExprContext primaryExpr() {
-			return getRuleContext(PrimaryExprContext.class,0);
-		}
-		public List<ArrayLookupContext> arrayLookup() {
-			return getRuleContexts(ArrayLookupContext.class);
-		}
-		public ArrayLookupContext arrayLookup(int i) {
-			return getRuleContext(ArrayLookupContext.class,i);
-		}
-		public List<PredicateContext> predicate() {
-			return getRuleContexts(PredicateContext.class);
-		}
-		public PredicateContext predicate(int i) {
-			return getRuleContext(PredicateContext.class,i);
-		}
-		public List<ObjectLookupContext> objectLookup() {
-			return getRuleContexts(ObjectLookupContext.class);
-		}
-		public ObjectLookupContext objectLookup(int i) {
-			return getRuleContext(ObjectLookupContext.class,i);
-		}
-		public List<ArrayUnboxingContext> arrayUnboxing() {
-			return getRuleContexts(ArrayUnboxingContext.class);
-		}
-		public ArrayUnboxingContext arrayUnboxing(int i) {
-			return getRuleContext(ArrayUnboxingContext.class,i);
-		}
-		public List<ArgumentListContext> argumentList() {
-			return getRuleContexts(ArgumentListContext.class);
-		}
-		public ArgumentListContext argumentList(int i) {
-			return getRuleContext(ArgumentListContext.class,i);
-		}
-		public PostFixExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_postFixExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitPostFixExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final PostFixExprContext postFixExpr() throws RecognitionException {
-		PostFixExprContext _localctx = new PostFixExprContext(_ctx, getState());
-		enterRule(_localctx, 98, RULE_postFixExpr);
-		try {
-			int _alt;
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(671);
-			((PostFixExprContext)_localctx).main_expr = primaryExpr();
-			setState(679);
-			_errHandler.sync(this);
-			_alt = getInterpreter().adaptivePredict(_input,66,_ctx);
-			while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
-				if ( _alt==1 ) {
-					{
-					setState(677);
-					_errHandler.sync(this);
-					switch ( getInterpreter().adaptivePredict(_input,65,_ctx) ) {
-					case 1:
-						{
-						setState(672);
-						arrayLookup();
-						}
-						break;
-					case 2:
-						{
-						setState(673);
-						predicate();
-						}
-						break;
-					case 3:
-						{
-						setState(674);
-						objectLookup();
-						}
-						break;
-					case 4:
-						{
-						setState(675);
-						arrayUnboxing();
-						}
-						break;
-					case 5:
-						{
-						setState(676);
-						argumentList();
-						}
-						break;
-					}
-					} 
-				}
-				setState(681);
-				_errHandler.sync(this);
-				_alt = getInterpreter().adaptivePredict(_input,66,_ctx);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ArrayLookupContext extends ParserRuleContext {
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public ArrayLookupContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_arrayLookup; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitArrayLookup(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ArrayLookupContext arrayLookup() throws RecognitionException {
-		ArrayLookupContext _localctx = new ArrayLookupContext(_ctx, getState());
-		enterRule(_localctx, 100, RULE_arrayLookup);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(682);
-			match(T__51);
-			setState(683);
-			match(T__51);
-			setState(684);
-			expr();
-			setState(685);
-			match(T__52);
-			setState(686);
-			match(T__52);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ArrayUnboxingContext extends ParserRuleContext {
-		public ArrayUnboxingContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_arrayUnboxing; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitArrayUnboxing(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ArrayUnboxingContext arrayUnboxing() throws RecognitionException {
-		ArrayUnboxingContext _localctx = new ArrayUnboxingContext(_ctx, getState());
-		enterRule(_localctx, 102, RULE_arrayUnboxing);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(688);
-			match(T__51);
-			setState(689);
-			match(T__52);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class PredicateContext extends ParserRuleContext {
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public PredicateContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_predicate; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitPredicate(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final PredicateContext predicate() throws RecognitionException {
-		PredicateContext _localctx = new PredicateContext(_ctx, getState());
-		enterRule(_localctx, 104, RULE_predicate);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(691);
-			match(T__51);
-			setState(692);
-			expr();
-			setState(693);
-			match(T__52);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ObjectLookupContext extends ParserRuleContext {
-		public KeyWordsContext kw;
-		public StringLiteralContext lt;
-		public Token nc;
-		public ParenthesizedExprContext pe;
-		public VarRefContext vr;
-		public ContextItemExprContext ci;
-		public TypesKeywordsContext tkw;
-		public KeyWordsContext keyWords() {
-			return getRuleContext(KeyWordsContext.class,0);
-		}
-		public StringLiteralContext stringLiteral() {
-			return getRuleContext(StringLiteralContext.class,0);
-		}
-		public TerminalNode NCName() { return getToken(JsoniqParser.NCName, 0); }
-		public ParenthesizedExprContext parenthesizedExpr() {
-			return getRuleContext(ParenthesizedExprContext.class,0);
-		}
-		public VarRefContext varRef() {
-			return getRuleContext(VarRefContext.class,0);
-		}
-		public ContextItemExprContext contextItemExpr() {
-			return getRuleContext(ContextItemExprContext.class,0);
-		}
-		public TypesKeywordsContext typesKeywords() {
-			return getRuleContext(TypesKeywordsContext.class,0);
-		}
-		public ObjectLookupContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_objectLookup; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitObjectLookup(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ObjectLookupContext objectLookup() throws RecognitionException {
-		ObjectLookupContext _localctx = new ObjectLookupContext(_ctx, getState());
-		enterRule(_localctx, 106, RULE_objectLookup);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(695);
-			match(T__53);
-			setState(703);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case Kfor:
-			case Klet:
-			case Kwhere:
-			case Kgroup:
-			case Kby:
-			case Korder:
-			case Kreturn:
-			case Kif:
-			case Kin:
-			case Kas:
-			case Kat:
-			case Kallowing:
-			case Kempty:
-			case Kcount:
-			case Kstable:
-			case Kascending:
-			case Kdescending:
-			case Ksome:
-			case Kevery:
-			case Ksatisfies:
-			case Kcollation:
-			case Kgreatest:
-			case Kleast:
-			case Kswitch:
-			case Kcase:
-			case Ktry:
-			case Kcatch:
-			case Kdefault:
-			case Kthen:
-			case Kelse:
-			case Ktypeswitch:
-			case Kor:
-			case Kand:
-			case Knot:
-			case Kto:
-			case Kinstance:
-			case Kof:
-			case Ktreat:
-			case Kcast:
-			case Kcastable:
-			case Kversion:
-			case Kjsoniq:
-			case Kjson:
-				{
-				setState(696);
-				((ObjectLookupContext)_localctx).kw = keyWords();
-				}
-				break;
-			case STRING:
-				{
-				setState(697);
-				((ObjectLookupContext)_localctx).lt = stringLiteral();
-				}
-				break;
-			case NCName:
-				{
-				setState(698);
-				((ObjectLookupContext)_localctx).nc = match(NCName);
-				}
-				break;
-			case T__26:
-				{
-				setState(699);
-				((ObjectLookupContext)_localctx).pe = parenthesizedExpr();
-				}
-				break;
-			case T__30:
-				{
-				setState(700);
-				((ObjectLookupContext)_localctx).vr = varRef();
-				}
-				break;
-			case T__54:
-				{
-				setState(701);
-				((ObjectLookupContext)_localctx).ci = contextItemExpr();
-				}
-				break;
-			case T__61:
-			case T__62:
-			case T__63:
-			case T__64:
-			case T__65:
-			case T__66:
-			case T__67:
-			case T__68:
-			case T__69:
-			case T__70:
-			case T__71:
-			case T__72:
-			case T__73:
-			case T__74:
-				{
-				setState(702);
-				((ObjectLookupContext)_localctx).tkw = typesKeywords();
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class PrimaryExprContext extends ParserRuleContext {
-		public TerminalNode NullLiteral() { return getToken(JsoniqParser.NullLiteral, 0); }
-		public TerminalNode Literal() { return getToken(JsoniqParser.Literal, 0); }
-		public StringLiteralContext stringLiteral() {
-			return getRuleContext(StringLiteralContext.class,0);
-		}
-		public VarRefContext varRef() {
-			return getRuleContext(VarRefContext.class,0);
-		}
-		public ParenthesizedExprContext parenthesizedExpr() {
-			return getRuleContext(ParenthesizedExprContext.class,0);
-		}
-		public ContextItemExprContext contextItemExpr() {
-			return getRuleContext(ContextItemExprContext.class,0);
-		}
-		public ObjectConstructorContext objectConstructor() {
-			return getRuleContext(ObjectConstructorContext.class,0);
-		}
-		public FunctionCallContext functionCall() {
-			return getRuleContext(FunctionCallContext.class,0);
-		}
-		public OrderedExprContext orderedExpr() {
-			return getRuleContext(OrderedExprContext.class,0);
-		}
-		public UnorderedExprContext unorderedExpr() {
-			return getRuleContext(UnorderedExprContext.class,0);
-		}
-		public ArrayConstructorContext arrayConstructor() {
-			return getRuleContext(ArrayConstructorContext.class,0);
-		}
-		public FunctionItemExprContext functionItemExpr() {
-			return getRuleContext(FunctionItemExprContext.class,0);
-		}
-		public PrimaryExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_primaryExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitPrimaryExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final PrimaryExprContext primaryExpr() throws RecognitionException {
-		PrimaryExprContext _localctx = new PrimaryExprContext(_ctx, getState());
-		enterRule(_localctx, 108, RULE_primaryExpr);
-		try {
-			setState(717);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,68,_ctx) ) {
-			case 1:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(705);
-				match(NullLiteral);
-				}
-				break;
-			case 2:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(706);
-				match(Literal);
-				}
-				break;
-			case 3:
-				enterOuterAlt(_localctx, 3);
-				{
-				setState(707);
-				stringLiteral();
-				}
-				break;
-			case 4:
-				enterOuterAlt(_localctx, 4);
-				{
-				setState(708);
-				varRef();
-				}
-				break;
-			case 5:
-				enterOuterAlt(_localctx, 5);
-				{
-				setState(709);
-				parenthesizedExpr();
-				}
-				break;
-			case 6:
-				enterOuterAlt(_localctx, 6);
-				{
-				setState(710);
-				contextItemExpr();
-				}
-				break;
-			case 7:
-				enterOuterAlt(_localctx, 7);
-				{
-				setState(711);
-				objectConstructor();
-				}
-				break;
-			case 8:
-				enterOuterAlt(_localctx, 8);
-				{
-				setState(712);
-				functionCall();
-				}
-				break;
-			case 9:
-				enterOuterAlt(_localctx, 9);
-				{
-				setState(713);
-				orderedExpr();
-				}
-				break;
-			case 10:
-				enterOuterAlt(_localctx, 10);
-				{
-				setState(714);
-				unorderedExpr();
-				}
-				break;
-			case 11:
-				enterOuterAlt(_localctx, 11);
-				{
-				setState(715);
-				arrayConstructor();
-				}
-				break;
-			case 12:
-				enterOuterAlt(_localctx, 12);
-				{
-				setState(716);
-				functionItemExpr();
-				}
-				break;
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class VarRefContext extends ParserRuleContext {
-		public Token ns;
-		public Token name;
-		public List<TerminalNode> NCName() { return getTokens(JsoniqParser.NCName); }
-		public TerminalNode NCName(int i) {
-			return getToken(JsoniqParser.NCName, i);
-		}
-		public VarRefContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_varRef; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitVarRef(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final VarRefContext varRef() throws RecognitionException {
-		VarRefContext _localctx = new VarRefContext(_ctx, getState());
-		enterRule(_localctx, 110, RULE_varRef);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(719);
-			match(T__30);
-			setState(722);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,69,_ctx) ) {
-			case 1:
-				{
-				setState(720);
-				((VarRefContext)_localctx).ns = match(NCName);
-				setState(721);
-				match(T__9);
-				}
-				break;
-			}
-			setState(724);
-			((VarRefContext)_localctx).name = match(NCName);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ParenthesizedExprContext extends ParserRuleContext {
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public ParenthesizedExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_parenthesizedExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitParenthesizedExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ParenthesizedExprContext parenthesizedExpr() throws RecognitionException {
-		ParenthesizedExprContext _localctx = new ParenthesizedExprContext(_ctx, getState());
-		enterRule(_localctx, 112, RULE_parenthesizedExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(726);
-			match(T__26);
-			setState(728);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & ((1L << (T__6 - 7)) | (1L << (T__7 - 7)) | (1L << (T__9 - 7)) | (1L << (T__25 - 7)) | (1L << (T__26 - 7)) | (1L << (T__28 - 7)) | (1L << (T__30 - 7)) | (1L << (T__45 - 7)) | (1L << (T__46 - 7)) | (1L << (T__51 - 7)) | (1L << (T__54 - 7)) | (1L << (T__56 - 7)) | (1L << (T__61 - 7)) | (1L << (T__62 - 7)) | (1L << (T__63 - 7)) | (1L << (T__64 - 7)) | (1L << (T__65 - 7)) | (1L << (T__66 - 7)) | (1L << (T__67 - 7)) | (1L << (T__68 - 7)) | (1L << (T__69 - 7)))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (T__70 - 71)) | (1L << (T__71 - 71)) | (1L << (T__72 - 71)) | (1L << (T__73 - 71)) | (1L << (T__74 - 71)) | (1L << (Kfor - 71)) | (1L << (Klet - 71)) | (1L << (Kwhere - 71)) | (1L << (Kgroup - 71)) | (1L << (Kby - 71)) | (1L << (Korder - 71)) | (1L << (Kreturn - 71)) | (1L << (Kif - 71)) | (1L << (Kin - 71)) | (1L << (Kas - 71)) | (1L << (Kat - 71)) | (1L << (Kallowing - 71)) | (1L << (Kempty - 71)) | (1L << (Kcount - 71)) | (1L << (Kstable - 71)) | (1L << (Kascending - 71)) | (1L << (Kdescending - 71)) | (1L << (Ksome - 71)) | (1L << (Kevery - 71)) | (1L << (Ksatisfies - 71)) | (1L << (Kcollation - 71)) | (1L << (Kgreatest - 71)) | (1L << (Kleast - 71)) | (1L << (Kswitch - 71)) | (1L << (Kcase - 71)) | (1L << (Ktry - 71)) | (1L << (Kcatch - 71)) | (1L << (Kdefault - 71)) | (1L << (Kthen - 71)) | (1L << (Kelse - 71)) | (1L << (Ktypeswitch - 71)) | (1L << (Kor - 71)) | (1L << (Kand - 71)) | (1L << (Knot - 71)) | (1L << (Kto - 71)) | (1L << (Kinstance - 71)) | (1L << (Kof - 71)) | (1L << (Ktreat - 71)) | (1L << (Kcast - 71)) | (1L << (Kcastable - 71)) | (1L << (Kversion - 71)) | (1L << (Kjsoniq - 71)) | (1L << (Kjson - 71)) | (1L << (STRING - 71)) | (1L << (NullLiteral - 71)) | (1L << (Literal - 71)) | (1L << (NCName - 71)))) != 0)) {
-				{
-				setState(727);
-				expr();
-				}
-			}
-
-			setState(730);
-			match(T__27);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ContextItemExprContext extends ParserRuleContext {
-		public ContextItemExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_contextItemExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitContextItemExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ContextItemExprContext contextItemExpr() throws RecognitionException {
-		ContextItemExprContext _localctx = new ContextItemExprContext(_ctx, getState());
-		enterRule(_localctx, 114, RULE_contextItemExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(732);
-			match(T__54);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class OrderedExprContext extends ParserRuleContext {
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public OrderedExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_orderedExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitOrderedExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final OrderedExprContext orderedExpr() throws RecognitionException {
-		OrderedExprContext _localctx = new OrderedExprContext(_ctx, getState());
-		enterRule(_localctx, 116, RULE_orderedExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(734);
-			match(T__6);
-			setState(735);
-			match(T__28);
-			setState(736);
-			expr();
-			setState(737);
-			match(T__29);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class UnorderedExprContext extends ParserRuleContext {
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public UnorderedExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_unorderedExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitUnorderedExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final UnorderedExprContext unorderedExpr() throws RecognitionException {
-		UnorderedExprContext _localctx = new UnorderedExprContext(_ctx, getState());
-		enterRule(_localctx, 118, RULE_unorderedExpr);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(739);
-			match(T__7);
-			setState(740);
-			match(T__28);
-			setState(741);
-			expr();
-			setState(742);
-			match(T__29);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class FunctionCallContext extends ParserRuleContext {
-		public Token ns;
-		public KeyWordsContext kw;
-		public NCNameOrKeyWordContext fn_name;
-		public ArgumentListContext argumentList() {
-			return getRuleContext(ArgumentListContext.class,0);
-		}
-		public NCNameOrKeyWordContext nCNameOrKeyWord() {
-			return getRuleContext(NCNameOrKeyWordContext.class,0);
-		}
-		public List<KeyWordsContext> keyWords() {
-			return getRuleContexts(KeyWordsContext.class);
-		}
-		public KeyWordsContext keyWords(int i) {
-			return getRuleContext(KeyWordsContext.class,i);
-		}
-		public TerminalNode NCName() { return getToken(JsoniqParser.NCName, 0); }
-		public FunctionCallContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_functionCall; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitFunctionCall(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final FunctionCallContext functionCall() throws RecognitionException {
-		FunctionCallContext _localctx = new FunctionCallContext(_ctx, getState());
-		enterRule(_localctx, 120, RULE_functionCall);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(750);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,72,_ctx) ) {
-			case 1:
-				{
-				setState(747);
-				_errHandler.sync(this);
-				switch (_input.LA(1)) {
-				case NCName:
-					{
-					setState(744);
-					((FunctionCallContext)_localctx).ns = match(NCName);
-					}
-					break;
-				case Kfor:
-				case Klet:
-				case Kwhere:
-				case Kgroup:
-				case Kby:
-				case Korder:
-				case Kreturn:
-				case Kif:
-				case Kin:
-				case Kas:
-				case Kat:
-				case Kallowing:
-				case Kempty:
-				case Kcount:
-				case Kstable:
-				case Kascending:
-				case Kdescending:
-				case Ksome:
-				case Kevery:
-				case Ksatisfies:
-				case Kcollation:
-				case Kgreatest:
-				case Kleast:
-				case Kswitch:
-				case Kcase:
-				case Ktry:
-				case Kcatch:
-				case Kdefault:
-				case Kthen:
-				case Kelse:
-				case Ktypeswitch:
-				case Kor:
-				case Kand:
-				case Knot:
-				case Kto:
-				case Kinstance:
-				case Kof:
-				case Ktreat:
-				case Kcast:
-				case Kcastable:
-				case Kversion:
-				case Kjsoniq:
-				case Kjson:
-					{
-					setState(745);
-					((FunctionCallContext)_localctx).kw = keyWords();
-					}
-					break;
-				case T__9:
-					{
-					}
-					break;
-				default:
-					throw new NoViableAltException(this);
-				}
-				setState(749);
-				match(T__9);
-				}
-				break;
-			}
-			setState(754);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__61:
-			case T__62:
-			case T__63:
-			case T__64:
-			case T__65:
-			case T__66:
-			case T__67:
-			case T__68:
-			case T__69:
-			case T__70:
-			case T__71:
-			case T__72:
-			case T__73:
-			case T__74:
-			case NCName:
-				{
-				setState(752);
-				((FunctionCallContext)_localctx).fn_name = nCNameOrKeyWord();
-				}
-				break;
-			case Kfor:
-			case Klet:
-			case Kwhere:
-			case Kgroup:
-			case Kby:
-			case Korder:
-			case Kreturn:
-			case Kif:
-			case Kin:
-			case Kas:
-			case Kat:
-			case Kallowing:
-			case Kempty:
-			case Kcount:
-			case Kstable:
-			case Kascending:
-			case Kdescending:
-			case Ksome:
-			case Kevery:
-			case Ksatisfies:
-			case Kcollation:
-			case Kgreatest:
-			case Kleast:
-			case Kswitch:
-			case Kcase:
-			case Ktry:
-			case Kcatch:
-			case Kdefault:
-			case Kthen:
-			case Kelse:
-			case Ktypeswitch:
-			case Kor:
-			case Kand:
-			case Knot:
-			case Kto:
-			case Kinstance:
-			case Kof:
-			case Ktreat:
-			case Kcast:
-			case Kcastable:
-			case Kversion:
-			case Kjsoniq:
-			case Kjson:
-				{
-				setState(753);
-				((FunctionCallContext)_localctx).kw = keyWords();
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-			setState(756);
-			argumentList();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ArgumentListContext extends ParserRuleContext {
-		public ArgumentContext argument;
-		public List<ArgumentContext> args = new ArrayList<ArgumentContext>();
-		public List<ArgumentContext> argument() {
-			return getRuleContexts(ArgumentContext.class);
-		}
-		public ArgumentContext argument(int i) {
-			return getRuleContext(ArgumentContext.class,i);
-		}
-		public ArgumentListContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_argumentList; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitArgumentList(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ArgumentListContext argumentList() throws RecognitionException {
-		ArgumentListContext _localctx = new ArgumentListContext(_ctx, getState());
-		enterRule(_localctx, 122, RULE_argumentList);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(758);
-			match(T__26);
-			setState(765);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			while (((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & ((1L << (T__6 - 7)) | (1L << (T__7 - 7)) | (1L << (T__9 - 7)) | (1L << (T__25 - 7)) | (1L << (T__26 - 7)) | (1L << (T__28 - 7)) | (1L << (T__30 - 7)) | (1L << (T__45 - 7)) | (1L << (T__46 - 7)) | (1L << (T__51 - 7)) | (1L << (T__54 - 7)) | (1L << (T__56 - 7)) | (1L << (T__61 - 7)) | (1L << (T__62 - 7)) | (1L << (T__63 - 7)) | (1L << (T__64 - 7)) | (1L << (T__65 - 7)) | (1L << (T__66 - 7)) | (1L << (T__67 - 7)) | (1L << (T__68 - 7)) | (1L << (T__69 - 7)))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (T__70 - 71)) | (1L << (T__71 - 71)) | (1L << (T__72 - 71)) | (1L << (T__73 - 71)) | (1L << (T__74 - 71)) | (1L << (Kfor - 71)) | (1L << (Klet - 71)) | (1L << (Kwhere - 71)) | (1L << (Kgroup - 71)) | (1L << (Kby - 71)) | (1L << (Korder - 71)) | (1L << (Kreturn - 71)) | (1L << (Kif - 71)) | (1L << (Kin - 71)) | (1L << (Kas - 71)) | (1L << (Kat - 71)) | (1L << (Kallowing - 71)) | (1L << (Kempty - 71)) | (1L << (Kcount - 71)) | (1L << (Kstable - 71)) | (1L << (Kascending - 71)) | (1L << (Kdescending - 71)) | (1L << (Ksome - 71)) | (1L << (Kevery - 71)) | (1L << (Ksatisfies - 71)) | (1L << (Kcollation - 71)) | (1L << (Kgreatest - 71)) | (1L << (Kleast - 71)) | (1L << (Kswitch - 71)) | (1L << (Kcase - 71)) | (1L << (Ktry - 71)) | (1L << (Kcatch - 71)) | (1L << (Kdefault - 71)) | (1L << (Kthen - 71)) | (1L << (Kelse - 71)) | (1L << (Ktypeswitch - 71)) | (1L << (Kor - 71)) | (1L << (Kand - 71)) | (1L << (Knot - 71)) | (1L << (Kto - 71)) | (1L << (Kinstance - 71)) | (1L << (Kof - 71)) | (1L << (Ktreat - 71)) | (1L << (Kcast - 71)) | (1L << (Kcastable - 71)) | (1L << (Kversion - 71)) | (1L << (Kjsoniq - 71)) | (1L << (Kjson - 71)) | (1L << (STRING - 71)) | (1L << (ArgumentPlaceholder - 71)) | (1L << (NullLiteral - 71)) | (1L << (Literal - 71)) | (1L << (NCName - 71)))) != 0)) {
-				{
-				{
-				setState(759);
-				((ArgumentListContext)_localctx).argument = argument();
-				((ArgumentListContext)_localctx).args.add(((ArgumentListContext)_localctx).argument);
-				setState(761);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-				if (_la==T__21) {
-					{
-					setState(760);
-					match(T__21);
-					}
-				}
-
-				}
-				}
-				setState(767);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-			}
-			setState(768);
-			match(T__27);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ArgumentContext extends ParserRuleContext {
-		public ExprSingleContext exprSingle() {
-			return getRuleContext(ExprSingleContext.class,0);
-		}
-		public TerminalNode ArgumentPlaceholder() { return getToken(JsoniqParser.ArgumentPlaceholder, 0); }
-		public ArgumentContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_argument; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitArgument(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ArgumentContext argument() throws RecognitionException {
-		ArgumentContext _localctx = new ArgumentContext(_ctx, getState());
-		enterRule(_localctx, 124, RULE_argument);
-		try {
-			setState(772);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__6:
-			case T__7:
-			case T__9:
-			case T__25:
-			case T__26:
-			case T__28:
-			case T__30:
-			case T__45:
-			case T__46:
-			case T__51:
-			case T__54:
-			case T__56:
-			case T__61:
-			case T__62:
-			case T__63:
-			case T__64:
-			case T__65:
-			case T__66:
-			case T__67:
-			case T__68:
-			case T__69:
-			case T__70:
-			case T__71:
-			case T__72:
-			case T__73:
-			case T__74:
-			case Kfor:
-			case Klet:
-			case Kwhere:
-			case Kgroup:
-			case Kby:
-			case Korder:
-			case Kreturn:
-			case Kif:
-			case Kin:
-			case Kas:
-			case Kat:
-			case Kallowing:
-			case Kempty:
-			case Kcount:
-			case Kstable:
-			case Kascending:
-			case Kdescending:
-			case Ksome:
-			case Kevery:
-			case Ksatisfies:
-			case Kcollation:
-			case Kgreatest:
-			case Kleast:
-			case Kswitch:
-			case Kcase:
-			case Ktry:
-			case Kcatch:
-			case Kdefault:
-			case Kthen:
-			case Kelse:
-			case Ktypeswitch:
-			case Kor:
-			case Kand:
-			case Knot:
-			case Kto:
-			case Kinstance:
-			case Kof:
-			case Ktreat:
-			case Kcast:
-			case Kcastable:
-			case Kversion:
-			case Kjsoniq:
-			case Kjson:
-			case STRING:
-			case NullLiteral:
-			case Literal:
-			case NCName:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(770);
-				exprSingle();
-				}
-				break;
-			case ArgumentPlaceholder:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(771);
-				match(ArgumentPlaceholder);
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class FunctionItemExprContext extends ParserRuleContext {
-		public NamedFunctionRefContext namedFunctionRef() {
-			return getRuleContext(NamedFunctionRefContext.class,0);
-		}
-		public InlineFunctionExprContext inlineFunctionExpr() {
-			return getRuleContext(InlineFunctionExprContext.class,0);
-		}
-		public FunctionItemExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_functionItemExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitFunctionItemExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final FunctionItemExprContext functionItemExpr() throws RecognitionException {
-		FunctionItemExprContext _localctx = new FunctionItemExprContext(_ctx, getState());
-		enterRule(_localctx, 126, RULE_functionItemExpr);
-		try {
-			setState(776);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case NCName:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(774);
-				namedFunctionRef();
-				}
-				break;
-			case T__25:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(775);
-				inlineFunctionExpr();
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class NamedFunctionRefContext extends ParserRuleContext {
-		public Token fn_name;
-		public Token arity;
-		public TerminalNode NCName() { return getToken(JsoniqParser.NCName, 0); }
-		public TerminalNode Literal() { return getToken(JsoniqParser.Literal, 0); }
-		public NamedFunctionRefContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_namedFunctionRef; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitNamedFunctionRef(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final NamedFunctionRefContext namedFunctionRef() throws RecognitionException {
-		NamedFunctionRefContext _localctx = new NamedFunctionRefContext(_ctx, getState());
-		enterRule(_localctx, 128, RULE_namedFunctionRef);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(778);
-			((NamedFunctionRefContext)_localctx).fn_name = match(NCName);
-			setState(779);
-			match(T__55);
-			setState(780);
-			((NamedFunctionRefContext)_localctx).arity = match(Literal);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class InlineFunctionExprContext extends ParserRuleContext {
-		public SequenceTypeContext return_type;
-		public ExprContext fn_body;
-		public ParamListContext paramList() {
-			return getRuleContext(ParamListContext.class,0);
-		}
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public SequenceTypeContext sequenceType() {
-			return getRuleContext(SequenceTypeContext.class,0);
-		}
-		public InlineFunctionExprContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_inlineFunctionExpr; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitInlineFunctionExpr(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final InlineFunctionExprContext inlineFunctionExpr() throws RecognitionException {
-		InlineFunctionExprContext _localctx = new InlineFunctionExprContext(_ctx, getState());
-		enterRule(_localctx, 130, RULE_inlineFunctionExpr);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(782);
-			match(T__25);
-			setState(783);
-			match(T__26);
-			setState(785);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==T__30) {
-				{
-				setState(784);
-				paramList();
-				}
-			}
-
-			setState(787);
-			match(T__27);
-			setState(790);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (_la==Kas) {
-				{
-				setState(788);
-				match(Kas);
-				setState(789);
-				((InlineFunctionExprContext)_localctx).return_type = sequenceType();
-				}
-			}
-
-			{
-			setState(792);
-			match(T__28);
-			setState(793);
-			((InlineFunctionExprContext)_localctx).fn_body = expr();
-			setState(794);
-			match(T__29);
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class SequenceTypeContext extends ParserRuleContext {
-		public ItemTypeContext item;
-		public Token s121;
-		public List<Token> question = new ArrayList<Token>();
-		public Token s33;
-		public List<Token> star = new ArrayList<Token>();
-		public Token s46;
-		public List<Token> plus = new ArrayList<Token>();
-		public ItemTypeContext itemType() {
-			return getRuleContext(ItemTypeContext.class,0);
-		}
-		public SequenceTypeContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_sequenceType; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitSequenceType(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final SequenceTypeContext sequenceType() throws RecognitionException {
-		SequenceTypeContext _localctx = new SequenceTypeContext(_ctx, getState());
-		enterRule(_localctx, 132, RULE_sequenceType);
-		try {
-			setState(804);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__26:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(796);
-				match(T__26);
-				setState(797);
-				match(T__27);
-				}
-				break;
-			case T__58:
-			case T__59:
-			case T__60:
-			case T__61:
-			case T__62:
-			case T__63:
-			case T__64:
-			case T__65:
-			case T__66:
-			case T__67:
-			case T__68:
-			case T__69:
-			case T__70:
-			case T__71:
-			case T__72:
-			case T__73:
-			case T__74:
-			case T__75:
-			case Kjson:
-			case NullLiteral:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(798);
-				((SequenceTypeContext)_localctx).item = itemType();
-				setState(802);
-				_errHandler.sync(this);
-				switch ( getInterpreter().adaptivePredict(_input,80,_ctx) ) {
-				case 1:
-					{
-					setState(799);
-					((SequenceTypeContext)_localctx).s121 = match(ArgumentPlaceholder);
-					((SequenceTypeContext)_localctx).question.add(((SequenceTypeContext)_localctx).s121);
-					}
-					break;
-				case 2:
-					{
-					setState(800);
-					((SequenceTypeContext)_localctx).s33 = match(T__32);
-					((SequenceTypeContext)_localctx).star.add(((SequenceTypeContext)_localctx).s33);
-					}
-					break;
-				case 3:
-					{
-					setState(801);
-					((SequenceTypeContext)_localctx).s46 = match(T__45);
-					((SequenceTypeContext)_localctx).plus.add(((SequenceTypeContext)_localctx).s46);
-					}
-					break;
-				}
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ObjectConstructorContext extends ParserRuleContext {
-		public Token s57;
-		public List<Token> merge_operator = new ArrayList<Token>();
-		public List<PairConstructorContext> pairConstructor() {
-			return getRuleContexts(PairConstructorContext.class);
-		}
-		public PairConstructorContext pairConstructor(int i) {
-			return getRuleContext(PairConstructorContext.class,i);
-		}
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public ObjectConstructorContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_objectConstructor; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitObjectConstructor(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ObjectConstructorContext objectConstructor() throws RecognitionException {
-		ObjectConstructorContext _localctx = new ObjectConstructorContext(_ctx, getState());
-		enterRule(_localctx, 134, RULE_objectConstructor);
-		int _la;
-		try {
-			setState(822);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__28:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(806);
-				match(T__28);
-				setState(815);
-				_errHandler.sync(this);
-				_la = _input.LA(1);
-				if (((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & ((1L << (T__6 - 7)) | (1L << (T__7 - 7)) | (1L << (T__9 - 7)) | (1L << (T__25 - 7)) | (1L << (T__26 - 7)) | (1L << (T__28 - 7)) | (1L << (T__30 - 7)) | (1L << (T__45 - 7)) | (1L << (T__46 - 7)) | (1L << (T__51 - 7)) | (1L << (T__54 - 7)) | (1L << (T__56 - 7)) | (1L << (T__61 - 7)) | (1L << (T__62 - 7)) | (1L << (T__63 - 7)) | (1L << (T__64 - 7)) | (1L << (T__65 - 7)) | (1L << (T__66 - 7)) | (1L << (T__67 - 7)) | (1L << (T__68 - 7)) | (1L << (T__69 - 7)))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (T__70 - 71)) | (1L << (T__71 - 71)) | (1L << (T__72 - 71)) | (1L << (T__73 - 71)) | (1L << (T__74 - 71)) | (1L << (Kfor - 71)) | (1L << (Klet - 71)) | (1L << (Kwhere - 71)) | (1L << (Kgroup - 71)) | (1L << (Kby - 71)) | (1L << (Korder - 71)) | (1L << (Kreturn - 71)) | (1L << (Kif - 71)) | (1L << (Kin - 71)) | (1L << (Kas - 71)) | (1L << (Kat - 71)) | (1L << (Kallowing - 71)) | (1L << (Kempty - 71)) | (1L << (Kcount - 71)) | (1L << (Kstable - 71)) | (1L << (Kascending - 71)) | (1L << (Kdescending - 71)) | (1L << (Ksome - 71)) | (1L << (Kevery - 71)) | (1L << (Ksatisfies - 71)) | (1L << (Kcollation - 71)) | (1L << (Kgreatest - 71)) | (1L << (Kleast - 71)) | (1L << (Kswitch - 71)) | (1L << (Kcase - 71)) | (1L << (Ktry - 71)) | (1L << (Kcatch - 71)) | (1L << (Kdefault - 71)) | (1L << (Kthen - 71)) | (1L << (Kelse - 71)) | (1L << (Ktypeswitch - 71)) | (1L << (Kor - 71)) | (1L << (Kand - 71)) | (1L << (Knot - 71)) | (1L << (Kto - 71)) | (1L << (Kinstance - 71)) | (1L << (Kof - 71)) | (1L << (Ktreat - 71)) | (1L << (Kcast - 71)) | (1L << (Kcastable - 71)) | (1L << (Kversion - 71)) | (1L << (Kjsoniq - 71)) | (1L << (Kjson - 71)) | (1L << (STRING - 71)) | (1L << (NullLiteral - 71)) | (1L << (Literal - 71)) | (1L << (NCName - 71)))) != 0)) {
-					{
-					setState(807);
-					pairConstructor();
-					setState(812);
-					_errHandler.sync(this);
-					_la = _input.LA(1);
-					while (_la==T__21) {
-						{
-						{
-						setState(808);
-						match(T__21);
-						setState(809);
-						pairConstructor();
-						}
-						}
-						setState(814);
-						_errHandler.sync(this);
-						_la = _input.LA(1);
-					}
-					}
-				}
-
-				setState(817);
-				match(T__29);
-				}
-				break;
-			case T__56:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(818);
-				((ObjectConstructorContext)_localctx).s57 = match(T__56);
-				((ObjectConstructorContext)_localctx).merge_operator.add(((ObjectConstructorContext)_localctx).s57);
-				setState(819);
-				expr();
-				setState(820);
-				match(T__57);
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ItemTypeContext extends ParserRuleContext {
-		public JSONItemTestContext jSONItemTest() {
-			return getRuleContext(JSONItemTestContext.class,0);
-		}
-		public AtomicTypeContext atomicType() {
-			return getRuleContext(AtomicTypeContext.class,0);
-		}
-		public ItemTypeContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_itemType; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitItemType(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ItemTypeContext itemType() throws RecognitionException {
-		ItemTypeContext _localctx = new ItemTypeContext(_ctx, getState());
-		enterRule(_localctx, 136, RULE_itemType);
-		try {
-			setState(827);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__58:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(824);
-				match(T__58);
-				}
-				break;
-			case T__59:
-			case T__60:
-			case Kjson:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(825);
-				jSONItemTest();
-				}
-				break;
-			case T__61:
-			case T__62:
-			case T__63:
-			case T__64:
-			case T__65:
-			case T__66:
-			case T__67:
-			case T__68:
-			case T__69:
-			case T__70:
-			case T__71:
-			case T__72:
-			case T__73:
-			case T__74:
-			case T__75:
-			case NullLiteral:
-				enterOuterAlt(_localctx, 3);
-				{
-				setState(826);
-				atomicType();
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class JSONItemTestContext extends ParserRuleContext {
-		public TerminalNode Kjson() { return getToken(JsoniqParser.Kjson, 0); }
-		public JSONItemTestContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_jSONItemTest; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitJSONItemTest(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final JSONItemTestContext jSONItemTest() throws RecognitionException {
-		JSONItemTestContext _localctx = new JSONItemTestContext(_ctx, getState());
-		enterRule(_localctx, 138, RULE_jSONItemTest);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(829);
-			_la = _input.LA(1);
-			if ( !(((((_la - 60)) & ~0x3f) == 0 && ((1L << (_la - 60)) & ((1L << (T__59 - 60)) | (1L << (T__60 - 60)) | (1L << (Kjson - 60)))) != 0)) ) {
-			_errHandler.recoverInline(this);
-			}
-			else {
-				if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-				_errHandler.reportMatch(this);
-				consume();
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordStringContext extends ParserRuleContext {
-		public KeyWordStringContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordString; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordString(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordStringContext keyWordString() throws RecognitionException {
-		KeyWordStringContext _localctx = new KeyWordStringContext(_ctx, getState());
-		enterRule(_localctx, 140, RULE_keyWordString);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(831);
-			match(T__61);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordIntegerContext extends ParserRuleContext {
-		public KeyWordIntegerContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordInteger; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordInteger(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordIntegerContext keyWordInteger() throws RecognitionException {
-		KeyWordIntegerContext _localctx = new KeyWordIntegerContext(_ctx, getState());
-		enterRule(_localctx, 142, RULE_keyWordInteger);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(833);
-			match(T__62);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordDecimalContext extends ParserRuleContext {
-		public KeyWordDecimalContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordDecimal; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordDecimal(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordDecimalContext keyWordDecimal() throws RecognitionException {
-		KeyWordDecimalContext _localctx = new KeyWordDecimalContext(_ctx, getState());
-		enterRule(_localctx, 144, RULE_keyWordDecimal);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(835);
-			match(T__63);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordDoubleContext extends ParserRuleContext {
-		public KeyWordDoubleContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordDouble; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordDouble(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordDoubleContext keyWordDouble() throws RecognitionException {
-		KeyWordDoubleContext _localctx = new KeyWordDoubleContext(_ctx, getState());
-		enterRule(_localctx, 146, RULE_keyWordDouble);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(837);
-			match(T__64);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordBooleanContext extends ParserRuleContext {
-		public KeyWordBooleanContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordBoolean; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordBoolean(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordBooleanContext keyWordBoolean() throws RecognitionException {
-		KeyWordBooleanContext _localctx = new KeyWordBooleanContext(_ctx, getState());
-		enterRule(_localctx, 148, RULE_keyWordBoolean);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(839);
-			match(T__65);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordDurationContext extends ParserRuleContext {
-		public KeyWordDurationContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordDuration; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordDuration(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordDurationContext keyWordDuration() throws RecognitionException {
-		KeyWordDurationContext _localctx = new KeyWordDurationContext(_ctx, getState());
-		enterRule(_localctx, 150, RULE_keyWordDuration);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(841);
-			match(T__66);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordYearMonthDurationContext extends ParserRuleContext {
-		public KeyWordYearMonthDurationContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordYearMonthDuration; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordYearMonthDuration(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordYearMonthDurationContext keyWordYearMonthDuration() throws RecognitionException {
-		KeyWordYearMonthDurationContext _localctx = new KeyWordYearMonthDurationContext(_ctx, getState());
-		enterRule(_localctx, 152, RULE_keyWordYearMonthDuration);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(843);
-			match(T__67);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordDayTimeDurationContext extends ParserRuleContext {
-		public KeyWordDayTimeDurationContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordDayTimeDuration; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordDayTimeDuration(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordDayTimeDurationContext keyWordDayTimeDuration() throws RecognitionException {
-		KeyWordDayTimeDurationContext _localctx = new KeyWordDayTimeDurationContext(_ctx, getState());
-		enterRule(_localctx, 154, RULE_keyWordDayTimeDuration);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(845);
-			match(T__68);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordHexBinaryContext extends ParserRuleContext {
-		public KeyWordHexBinaryContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordHexBinary; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordHexBinary(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordHexBinaryContext keyWordHexBinary() throws RecognitionException {
-		KeyWordHexBinaryContext _localctx = new KeyWordHexBinaryContext(_ctx, getState());
-		enterRule(_localctx, 156, RULE_keyWordHexBinary);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(847);
-			match(T__69);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordBase64BinaryContext extends ParserRuleContext {
-		public KeyWordBase64BinaryContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordBase64Binary; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordBase64Binary(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordBase64BinaryContext keyWordBase64Binary() throws RecognitionException {
-		KeyWordBase64BinaryContext _localctx = new KeyWordBase64BinaryContext(_ctx, getState());
-		enterRule(_localctx, 158, RULE_keyWordBase64Binary);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(849);
-			match(T__70);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordDateTimeContext extends ParserRuleContext {
-		public KeyWordDateTimeContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordDateTime; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordDateTime(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordDateTimeContext keyWordDateTime() throws RecognitionException {
-		KeyWordDateTimeContext _localctx = new KeyWordDateTimeContext(_ctx, getState());
-		enterRule(_localctx, 160, RULE_keyWordDateTime);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(851);
-			match(T__71);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordDateContext extends ParserRuleContext {
-		public KeyWordDateContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordDate; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordDate(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordDateContext keyWordDate() throws RecognitionException {
-		KeyWordDateContext _localctx = new KeyWordDateContext(_ctx, getState());
-		enterRule(_localctx, 162, RULE_keyWordDate);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(853);
-			match(T__72);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordTimeContext extends ParserRuleContext {
-		public KeyWordTimeContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordTime; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordTime(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordTimeContext keyWordTime() throws RecognitionException {
-		KeyWordTimeContext _localctx = new KeyWordTimeContext(_ctx, getState());
-		enterRule(_localctx, 164, RULE_keyWordTime);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(855);
-			match(T__73);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordAnyURIContext extends ParserRuleContext {
-		public KeyWordAnyURIContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWordAnyURI; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWordAnyURI(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordAnyURIContext keyWordAnyURI() throws RecognitionException {
-		KeyWordAnyURIContext _localctx = new KeyWordAnyURIContext(_ctx, getState());
-		enterRule(_localctx, 166, RULE_keyWordAnyURI);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(857);
-			match(T__74);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class TypesKeywordsContext extends ParserRuleContext {
-		public KeyWordStringContext keyWordString() {
-			return getRuleContext(KeyWordStringContext.class,0);
-		}
-		public KeyWordIntegerContext keyWordInteger() {
-			return getRuleContext(KeyWordIntegerContext.class,0);
-		}
-		public KeyWordDecimalContext keyWordDecimal() {
-			return getRuleContext(KeyWordDecimalContext.class,0);
-		}
-		public KeyWordDoubleContext keyWordDouble() {
-			return getRuleContext(KeyWordDoubleContext.class,0);
-		}
-		public KeyWordBooleanContext keyWordBoolean() {
-			return getRuleContext(KeyWordBooleanContext.class,0);
-		}
-		public KeyWordDurationContext keyWordDuration() {
-			return getRuleContext(KeyWordDurationContext.class,0);
-		}
-		public KeyWordYearMonthDurationContext keyWordYearMonthDuration() {
-			return getRuleContext(KeyWordYearMonthDurationContext.class,0);
-		}
-		public KeyWordDayTimeDurationContext keyWordDayTimeDuration() {
-			return getRuleContext(KeyWordDayTimeDurationContext.class,0);
-		}
-		public KeyWordDateTimeContext keyWordDateTime() {
-			return getRuleContext(KeyWordDateTimeContext.class,0);
-		}
-		public KeyWordDateContext keyWordDate() {
-			return getRuleContext(KeyWordDateContext.class,0);
-		}
-		public KeyWordTimeContext keyWordTime() {
-			return getRuleContext(KeyWordTimeContext.class,0);
-		}
-		public KeyWordHexBinaryContext keyWordHexBinary() {
-			return getRuleContext(KeyWordHexBinaryContext.class,0);
-		}
-		public KeyWordBase64BinaryContext keyWordBase64Binary() {
-			return getRuleContext(KeyWordBase64BinaryContext.class,0);
-		}
-		public KeyWordAnyURIContext keyWordAnyURI() {
-			return getRuleContext(KeyWordAnyURIContext.class,0);
-		}
-		public TypesKeywordsContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_typesKeywords; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitTypesKeywords(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final TypesKeywordsContext typesKeywords() throws RecognitionException {
-		TypesKeywordsContext _localctx = new TypesKeywordsContext(_ctx, getState());
-		enterRule(_localctx, 168, RULE_typesKeywords);
-		try {
-			setState(873);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__61:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(859);
-				keyWordString();
-				}
-				break;
-			case T__62:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(860);
-				keyWordInteger();
-				}
-				break;
-			case T__63:
-				enterOuterAlt(_localctx, 3);
-				{
-				setState(861);
-				keyWordDecimal();
-				}
-				break;
-			case T__64:
-				enterOuterAlt(_localctx, 4);
-				{
-				setState(862);
-				keyWordDouble();
-				}
-				break;
-			case T__65:
-				enterOuterAlt(_localctx, 5);
-				{
-				setState(863);
-				keyWordBoolean();
-				}
-				break;
-			case T__66:
-				enterOuterAlt(_localctx, 6);
-				{
-				setState(864);
-				keyWordDuration();
-				}
-				break;
-			case T__67:
-				enterOuterAlt(_localctx, 7);
-				{
-				setState(865);
-				keyWordYearMonthDuration();
-				}
-				break;
-			case T__68:
-				enterOuterAlt(_localctx, 8);
-				{
-				setState(866);
-				keyWordDayTimeDuration();
-				}
-				break;
-			case T__71:
-				enterOuterAlt(_localctx, 9);
-				{
-				setState(867);
-				keyWordDateTime();
-				}
-				break;
-			case T__72:
-				enterOuterAlt(_localctx, 10);
-				{
-				setState(868);
-				keyWordDate();
-				}
-				break;
-			case T__73:
-				enterOuterAlt(_localctx, 11);
-				{
-				setState(869);
-				keyWordTime();
-				}
-				break;
-			case T__69:
-				enterOuterAlt(_localctx, 12);
-				{
-				setState(870);
-				keyWordHexBinary();
-				}
-				break;
-			case T__70:
-				enterOuterAlt(_localctx, 13);
-				{
-				setState(871);
-				keyWordBase64Binary();
-				}
-				break;
-			case T__74:
-				enterOuterAlt(_localctx, 14);
-				{
-				setState(872);
-				keyWordAnyURI();
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class SingleTypeContext extends ParserRuleContext {
-		public AtomicTypeContext item;
-		public Token s121;
-		public List<Token> question = new ArrayList<Token>();
-		public AtomicTypeContext atomicType() {
-			return getRuleContext(AtomicTypeContext.class,0);
-		}
-		public SingleTypeContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_singleType; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitSingleType(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final SingleTypeContext singleType() throws RecognitionException {
-		SingleTypeContext _localctx = new SingleTypeContext(_ctx, getState());
-		enterRule(_localctx, 170, RULE_singleType);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(875);
-			((SingleTypeContext)_localctx).item = atomicType();
-			setState(877);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,87,_ctx) ) {
-			case 1:
-				{
-				setState(876);
-				((SingleTypeContext)_localctx).s121 = match(ArgumentPlaceholder);
-				((SingleTypeContext)_localctx).question.add(((SingleTypeContext)_localctx).s121);
-				}
-				break;
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class AtomicTypeContext extends ParserRuleContext {
-		public TypesKeywordsContext typesKeywords() {
-			return getRuleContext(TypesKeywordsContext.class,0);
-		}
-		public TerminalNode NullLiteral() { return getToken(JsoniqParser.NullLiteral, 0); }
-		public AtomicTypeContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_atomicType; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitAtomicType(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final AtomicTypeContext atomicType() throws RecognitionException {
-		AtomicTypeContext _localctx = new AtomicTypeContext(_ctx, getState());
-		enterRule(_localctx, 172, RULE_atomicType);
-		try {
-			setState(882);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case T__75:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(879);
-				match(T__75);
-				}
-				break;
-			case T__61:
-			case T__62:
-			case T__63:
-			case T__64:
-			case T__65:
-			case T__66:
-			case T__67:
-			case T__68:
-			case T__69:
-			case T__70:
-			case T__71:
-			case T__72:
-			case T__73:
-			case T__74:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(880);
-				typesKeywords();
-				}
-				break;
-			case NullLiteral:
-				enterOuterAlt(_localctx, 3);
-				{
-				setState(881);
-				match(NullLiteral);
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class NCNameOrKeyWordContext extends ParserRuleContext {
-		public TerminalNode NCName() { return getToken(JsoniqParser.NCName, 0); }
-		public TypesKeywordsContext typesKeywords() {
-			return getRuleContext(TypesKeywordsContext.class,0);
-		}
-		public NCNameOrKeyWordContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_nCNameOrKeyWord; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitNCNameOrKeyWord(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final NCNameOrKeyWordContext nCNameOrKeyWord() throws RecognitionException {
-		NCNameOrKeyWordContext _localctx = new NCNameOrKeyWordContext(_ctx, getState());
-		enterRule(_localctx, 174, RULE_nCNameOrKeyWord);
-		try {
-			setState(886);
-			_errHandler.sync(this);
-			switch (_input.LA(1)) {
-			case NCName:
-				enterOuterAlt(_localctx, 1);
-				{
-				setState(884);
-				match(NCName);
-				}
-				break;
-			case T__61:
-			case T__62:
-			case T__63:
-			case T__64:
-			case T__65:
-			case T__66:
-			case T__67:
-			case T__68:
-			case T__69:
-			case T__70:
-			case T__71:
-			case T__72:
-			case T__73:
-			case T__74:
-				enterOuterAlt(_localctx, 2);
-				{
-				setState(885);
-				typesKeywords();
-				}
-				break;
-			default:
-				throw new NoViableAltException(this);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class PairConstructorContext extends ParserRuleContext {
-		public ExprSingleContext lhs;
-		public Token name;
-		public ExprSingleContext rhs;
-		public List<ExprSingleContext> exprSingle() {
-			return getRuleContexts(ExprSingleContext.class);
-		}
-		public ExprSingleContext exprSingle(int i) {
-			return getRuleContext(ExprSingleContext.class,i);
-		}
-		public TerminalNode NCName() { return getToken(JsoniqParser.NCName, 0); }
-		public PairConstructorContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_pairConstructor; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitPairConstructor(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final PairConstructorContext pairConstructor() throws RecognitionException {
-		PairConstructorContext _localctx = new PairConstructorContext(_ctx, getState());
-		enterRule(_localctx, 176, RULE_pairConstructor);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(890);
-			_errHandler.sync(this);
-			switch ( getInterpreter().adaptivePredict(_input,90,_ctx) ) {
-			case 1:
-				{
-				setState(888);
-				((PairConstructorContext)_localctx).lhs = exprSingle();
-				}
-				break;
-			case 2:
-				{
-				setState(889);
-				((PairConstructorContext)_localctx).name = match(NCName);
-				}
-				break;
-			}
-			setState(892);
-			_la = _input.LA(1);
-			if ( !(_la==T__9 || _la==ArgumentPlaceholder) ) {
-			_errHandler.recoverInline(this);
-			}
-			else {
-				if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-				_errHandler.reportMatch(this);
-				consume();
-			}
-			setState(893);
-			((PairConstructorContext)_localctx).rhs = exprSingle();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class ArrayConstructorContext extends ParserRuleContext {
-		public ExprContext expr() {
-			return getRuleContext(ExprContext.class,0);
-		}
-		public ArrayConstructorContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_arrayConstructor; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitArrayConstructor(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final ArrayConstructorContext arrayConstructor() throws RecognitionException {
-		ArrayConstructorContext _localctx = new ArrayConstructorContext(_ctx, getState());
-		enterRule(_localctx, 178, RULE_arrayConstructor);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(895);
-			match(T__51);
-			setState(897);
-			_errHandler.sync(this);
-			_la = _input.LA(1);
-			if (((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & ((1L << (T__6 - 7)) | (1L << (T__7 - 7)) | (1L << (T__9 - 7)) | (1L << (T__25 - 7)) | (1L << (T__26 - 7)) | (1L << (T__28 - 7)) | (1L << (T__30 - 7)) | (1L << (T__45 - 7)) | (1L << (T__46 - 7)) | (1L << (T__51 - 7)) | (1L << (T__54 - 7)) | (1L << (T__56 - 7)) | (1L << (T__61 - 7)) | (1L << (T__62 - 7)) | (1L << (T__63 - 7)) | (1L << (T__64 - 7)) | (1L << (T__65 - 7)) | (1L << (T__66 - 7)) | (1L << (T__67 - 7)) | (1L << (T__68 - 7)) | (1L << (T__69 - 7)))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (T__70 - 71)) | (1L << (T__71 - 71)) | (1L << (T__72 - 71)) | (1L << (T__73 - 71)) | (1L << (T__74 - 71)) | (1L << (Kfor - 71)) | (1L << (Klet - 71)) | (1L << (Kwhere - 71)) | (1L << (Kgroup - 71)) | (1L << (Kby - 71)) | (1L << (Korder - 71)) | (1L << (Kreturn - 71)) | (1L << (Kif - 71)) | (1L << (Kin - 71)) | (1L << (Kas - 71)) | (1L << (Kat - 71)) | (1L << (Kallowing - 71)) | (1L << (Kempty - 71)) | (1L << (Kcount - 71)) | (1L << (Kstable - 71)) | (1L << (Kascending - 71)) | (1L << (Kdescending - 71)) | (1L << (Ksome - 71)) | (1L << (Kevery - 71)) | (1L << (Ksatisfies - 71)) | (1L << (Kcollation - 71)) | (1L << (Kgreatest - 71)) | (1L << (Kleast - 71)) | (1L << (Kswitch - 71)) | (1L << (Kcase - 71)) | (1L << (Ktry - 71)) | (1L << (Kcatch - 71)) | (1L << (Kdefault - 71)) | (1L << (Kthen - 71)) | (1L << (Kelse - 71)) | (1L << (Ktypeswitch - 71)) | (1L << (Kor - 71)) | (1L << (Kand - 71)) | (1L << (Knot - 71)) | (1L << (Kto - 71)) | (1L << (Kinstance - 71)) | (1L << (Kof - 71)) | (1L << (Ktreat - 71)) | (1L << (Kcast - 71)) | (1L << (Kcastable - 71)) | (1L << (Kversion - 71)) | (1L << (Kjsoniq - 71)) | (1L << (Kjson - 71)) | (1L << (STRING - 71)) | (1L << (NullLiteral - 71)) | (1L << (Literal - 71)) | (1L << (NCName - 71)))) != 0)) {
-				{
-				setState(896);
-				expr();
-				}
-			}
-
-			setState(899);
-			match(T__52);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class UriLiteralContext extends ParserRuleContext {
-		public StringLiteralContext stringLiteral() {
-			return getRuleContext(StringLiteralContext.class,0);
-		}
-		public UriLiteralContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_uriLiteral; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitUriLiteral(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final UriLiteralContext uriLiteral() throws RecognitionException {
-		UriLiteralContext _localctx = new UriLiteralContext(_ctx, getState());
-		enterRule(_localctx, 180, RULE_uriLiteral);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(901);
-			stringLiteral();
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class StringLiteralContext extends ParserRuleContext {
-		public TerminalNode STRING() { return getToken(JsoniqParser.STRING, 0); }
-		public StringLiteralContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_stringLiteral; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitStringLiteral(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final StringLiteralContext stringLiteral() throws RecognitionException {
-		StringLiteralContext _localctx = new StringLiteralContext(_ctx, getState());
-		enterRule(_localctx, 182, RULE_stringLiteral);
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(903);
-			match(STRING);
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static class KeyWordsContext extends ParserRuleContext {
-		public TerminalNode Kjsoniq() { return getToken(JsoniqParser.Kjsoniq, 0); }
-		public TerminalNode Kjson() { return getToken(JsoniqParser.Kjson, 0); }
-		public TerminalNode Kversion() { return getToken(JsoniqParser.Kversion, 0); }
-		public TerminalNode Ktypeswitch() { return getToken(JsoniqParser.Ktypeswitch, 0); }
-		public TerminalNode Kor() { return getToken(JsoniqParser.Kor, 0); }
-		public TerminalNode Kand() { return getToken(JsoniqParser.Kand, 0); }
-		public TerminalNode Knot() { return getToken(JsoniqParser.Knot, 0); }
-		public TerminalNode Kto() { return getToken(JsoniqParser.Kto, 0); }
-		public TerminalNode Kinstance() { return getToken(JsoniqParser.Kinstance, 0); }
-		public TerminalNode Kof() { return getToken(JsoniqParser.Kof, 0); }
-		public TerminalNode Ktreat() { return getToken(JsoniqParser.Ktreat, 0); }
-		public TerminalNode Kcast() { return getToken(JsoniqParser.Kcast, 0); }
-		public TerminalNode Kcastable() { return getToken(JsoniqParser.Kcastable, 0); }
-		public TerminalNode Kdefault() { return getToken(JsoniqParser.Kdefault, 0); }
-		public TerminalNode Kthen() { return getToken(JsoniqParser.Kthen, 0); }
-		public TerminalNode Kelse() { return getToken(JsoniqParser.Kelse, 0); }
-		public TerminalNode Kcollation() { return getToken(JsoniqParser.Kcollation, 0); }
-		public TerminalNode Kgreatest() { return getToken(JsoniqParser.Kgreatest, 0); }
-		public TerminalNode Kleast() { return getToken(JsoniqParser.Kleast, 0); }
-		public TerminalNode Kswitch() { return getToken(JsoniqParser.Kswitch, 0); }
-		public TerminalNode Kcase() { return getToken(JsoniqParser.Kcase, 0); }
-		public TerminalNode Ktry() { return getToken(JsoniqParser.Ktry, 0); }
-		public TerminalNode Kcatch() { return getToken(JsoniqParser.Kcatch, 0); }
-		public TerminalNode Ksome() { return getToken(JsoniqParser.Ksome, 0); }
-		public TerminalNode Kevery() { return getToken(JsoniqParser.Kevery, 0); }
-		public TerminalNode Ksatisfies() { return getToken(JsoniqParser.Ksatisfies, 0); }
-		public TerminalNode Kstable() { return getToken(JsoniqParser.Kstable, 0); }
-		public TerminalNode Kascending() { return getToken(JsoniqParser.Kascending, 0); }
-		public TerminalNode Kdescending() { return getToken(JsoniqParser.Kdescending, 0); }
-		public TerminalNode Kempty() { return getToken(JsoniqParser.Kempty, 0); }
-		public TerminalNode Kallowing() { return getToken(JsoniqParser.Kallowing, 0); }
-		public TerminalNode Kas() { return getToken(JsoniqParser.Kas, 0); }
-		public TerminalNode Kat() { return getToken(JsoniqParser.Kat, 0); }
-		public TerminalNode Kin() { return getToken(JsoniqParser.Kin, 0); }
-		public TerminalNode Kif() { return getToken(JsoniqParser.Kif, 0); }
-		public TerminalNode Kfor() { return getToken(JsoniqParser.Kfor, 0); }
-		public TerminalNode Klet() { return getToken(JsoniqParser.Klet, 0); }
-		public TerminalNode Kwhere() { return getToken(JsoniqParser.Kwhere, 0); }
-		public TerminalNode Kgroup() { return getToken(JsoniqParser.Kgroup, 0); }
-		public TerminalNode Kby() { return getToken(JsoniqParser.Kby, 0); }
-		public TerminalNode Korder() { return getToken(JsoniqParser.Korder, 0); }
-		public TerminalNode Kcount() { return getToken(JsoniqParser.Kcount, 0); }
-		public TerminalNode Kreturn() { return getToken(JsoniqParser.Kreturn, 0); }
-		public KeyWordsContext(ParserRuleContext parent, int invokingState) {
-			super(parent, invokingState);
-		}
-		@Override public int getRuleIndex() { return RULE_keyWords; }
-		@Override
-		public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-			if ( visitor instanceof JsoniqVisitor ) return ((JsoniqVisitor<? extends T>)visitor).visitKeyWords(this);
-			else return visitor.visitChildren(this);
-		}
-	}
-
-	public final KeyWordsContext keyWords() throws RecognitionException {
-		KeyWordsContext _localctx = new KeyWordsContext(_ctx, getState());
-		enterRule(_localctx, 184, RULE_keyWords);
-		int _la;
-		try {
-			enterOuterAlt(_localctx, 1);
-			{
-			setState(905);
-			_la = _input.LA(1);
-			if ( !(((((_la - 77)) & ~0x3f) == 0 && ((1L << (_la - 77)) & ((1L << (Kfor - 77)) | (1L << (Klet - 77)) | (1L << (Kwhere - 77)) | (1L << (Kgroup - 77)) | (1L << (Kby - 77)) | (1L << (Korder - 77)) | (1L << (Kreturn - 77)) | (1L << (Kif - 77)) | (1L << (Kin - 77)) | (1L << (Kas - 77)) | (1L << (Kat - 77)) | (1L << (Kallowing - 77)) | (1L << (Kempty - 77)) | (1L << (Kcount - 77)) | (1L << (Kstable - 77)) | (1L << (Kascending - 77)) | (1L << (Kdescending - 77)) | (1L << (Ksome - 77)) | (1L << (Kevery - 77)) | (1L << (Ksatisfies - 77)) | (1L << (Kcollation - 77)) | (1L << (Kgreatest - 77)) | (1L << (Kleast - 77)) | (1L << (Kswitch - 77)) | (1L << (Kcase - 77)) | (1L << (Ktry - 77)) | (1L << (Kcatch - 77)) | (1L << (Kdefault - 77)) | (1L << (Kthen - 77)) | (1L << (Kelse - 77)) | (1L << (Ktypeswitch - 77)) | (1L << (Kor - 77)) | (1L << (Kand - 77)) | (1L << (Knot - 77)) | (1L << (Kto - 77)) | (1L << (Kinstance - 77)) | (1L << (Kof - 77)) | (1L << (Ktreat - 77)) | (1L << (Kcast - 77)) | (1L << (Kcastable - 77)) | (1L << (Kversion - 77)) | (1L << (Kjsoniq - 77)) | (1L << (Kjson - 77)))) != 0)) ) {
-			_errHandler.recoverInline(this);
-			}
-			else {
-				if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-				_errHandler.reportMatch(this);
-				consume();
-			}
-			}
-		}
-		catch (RecognitionException re) {
-			_localctx.exception = re;
-			_errHandler.reportError(this, re);
-			_errHandler.recover(this, re);
-		}
-		finally {
-			exitRule();
-		}
-		return _localctx;
-	}
-
-	public static final String _serializedATN =
-		"\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3\u0086\u038e\4\2\t"+
-		"\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13"+
-		"\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
-		"\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
-		"\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \4!"+
-		"\t!\4\"\t\"\4#\t#\4$\t$\4%\t%\4&\t&\4\'\t\'\4(\t(\4)\t)\4*\t*\4+\t+\4"+
-		",\t,\4-\t-\4.\t.\4/\t/\4\60\t\60\4\61\t\61\4\62\t\62\4\63\t\63\4\64\t"+
-		"\64\4\65\t\65\4\66\t\66\4\67\t\67\48\t8\49\t9\4:\t:\4;\t;\4<\t<\4=\t="+
-		"\4>\t>\4?\t?\4@\t@\4A\tA\4B\tB\4C\tC\4D\tD\4E\tE\4F\tF\4G\tG\4H\tH\4I"+
-		"\tI\4J\tJ\4K\tK\4L\tL\4M\tM\4N\tN\4O\tO\4P\tP\4Q\tQ\4R\tR\4S\tS\4T\tT"+
-		"\4U\tU\4V\tV\4W\tW\4X\tX\4Y\tY\4Z\tZ\4[\t[\4\\\t\\\4]\t]\4^\t^\3\2\3\2"+
-		"\3\2\3\2\3\2\5\2\u00c2\n\2\3\2\3\2\5\2\u00c6\n\2\3\3\3\3\3\3\3\4\3\4\3"+
-		"\4\3\4\3\4\3\4\3\4\3\4\3\5\3\5\3\5\3\5\3\5\5\5\u00d8\n\5\3\5\3\5\7\5\u00dc"+
-		"\n\5\f\5\16\5\u00df\13\5\3\5\3\5\5\5\u00e3\n\5\3\5\3\5\7\5\u00e7\n\5\f"+
-		"\5\16\5\u00ea\13\5\3\6\3\6\3\6\3\6\3\6\3\7\3\7\3\7\3\7\3\b\3\b\3\b\3\b"+
-		"\3\b\3\b\3\t\3\t\3\t\3\t\5\t\u00ff\n\t\3\t\3\t\3\t\5\t\u0104\n\t\3\t\3"+
-		"\t\3\t\3\t\7\t\u010a\n\t\f\t\16\t\u010d\13\t\3\n\3\n\3\13\3\13\3\13\3"+
-		"\13\3\13\5\13\u0116\n\13\3\13\3\13\3\13\3\13\3\13\7\13\u011d\n\13\f\13"+
-		"\16\13\u0120\13\13\5\13\u0122\n\13\3\f\3\f\3\f\3\f\3\f\5\f\u0129\n\f\3"+
-		"\f\3\f\3\f\3\f\3\f\5\f\u0130\n\f\5\f\u0132\n\f\3\r\3\r\3\r\3\r\5\r\u0138"+
-		"\n\r\3\r\3\r\3\r\5\r\u013d\n\r\3\r\3\r\3\r\5\r\u0142\n\r\3\r\3\r\3\r\3"+
-		"\r\3\r\5\r\u0149\n\r\3\16\3\16\3\16\7\16\u014e\n\16\f\16\16\16\u0151\13"+
-		"\16\3\17\3\17\3\17\3\17\5\17\u0157\n\17\3\20\3\20\3\20\7\20\u015c\n\20"+
-		"\f\20\16\20\u015f\13\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21\5\21\u0168"+
-		"\n\21\3\22\3\22\5\22\u016c\n\22\3\22\3\22\3\22\3\22\3\22\3\22\7\22\u0174"+
-		"\n\22\f\22\16\22\u0177\13\22\3\22\3\22\3\22\3\23\3\23\3\23\3\23\7\23\u0180"+
-		"\n\23\f\23\16\23\u0183\13\23\3\24\3\24\3\24\5\24\u0188\n\24\3\24\3\24"+
-		"\5\24\u018c\n\24\3\24\3\24\5\24\u0190\n\24\3\24\3\24\3\24\3\25\3\25\3"+
-		"\25\3\25\7\25\u0199\n\25\f\25\16\25\u019c\13\25\3\26\3\26\3\26\5\26\u01a1"+
-		"\n\26\3\26\3\26\3\26\3\27\3\27\3\27\3\30\3\30\3\30\3\30\3\30\7\30\u01ae"+
-		"\n\30\f\30\16\30\u01b1\13\30\3\31\3\31\3\31\5\31\u01b6\n\31\3\31\3\31"+
-		"\5\31\u01ba\n\31\3\31\3\31\5\31\u01be\n\31\3\32\3\32\3\32\3\32\3\32\5"+
-		"\32\u01c5\n\32\3\32\3\32\3\32\7\32\u01ca\n\32\f\32\16\32\u01cd\13\32\3"+
-		"\33\3\33\3\33\5\33\u01d2\n\33\3\33\3\33\3\33\5\33\u01d7\n\33\5\33\u01d9"+
-		"\n\33\3\33\3\33\5\33\u01dd\n\33\3\34\3\34\3\34\3\35\3\35\5\35\u01e4\n"+
-		"\35\3\35\3\35\3\35\7\35\u01e9\n\35\f\35\16\35\u01ec\13\35\3\35\3\35\3"+
-		"\35\3\36\3\36\3\36\5\36\u01f4\n\36\3\36\3\36\3\36\3\37\3\37\3\37\3\37"+
-		"\3\37\6\37\u01fe\n\37\r\37\16\37\u01ff\3\37\3\37\3\37\3\37\3 \3 \6 \u0208"+
-		"\n \r \16 \u0209\3 \3 \3 \3!\3!\3!\3!\3!\6!\u0214\n!\r!\16!\u0215\3!\3"+
-		"!\5!\u021a\n!\3!\3!\3!\3\"\3\"\3\"\3\"\5\"\u0223\n\"\3\"\3\"\3\"\7\"\u0228"+
-		"\n\"\f\"\16\"\u022b\13\"\3\"\3\"\3\"\3#\3#\3#\3#\3#\3#\3#\3#\3#\3$\3$"+
-		"\3$\3$\3$\3$\3$\3$\3$\3$\3%\3%\3%\7%\u0246\n%\f%\16%\u0249\13%\3&\3&\3"+
-		"&\7&\u024e\n&\f&\16&\u0251\13&\3\'\5\'\u0254\n\'\3\'\3\'\3(\3(\3(\5(\u025b"+
-		"\n(\3)\3)\3)\7)\u0260\n)\f)\16)\u0263\13)\3*\3*\3*\5*\u0268\n*\3+\3+\3"+
-		"+\7+\u026d\n+\f+\16+\u0270\13+\3,\3,\3,\7,\u0275\n,\f,\16,\u0278\13,\3"+
-		"-\3-\3-\3-\5-\u027e\n-\3.\3.\3.\3.\5.\u0284\n.\3/\3/\3/\3/\5/\u028a\n"+
-		"/\3\60\3\60\3\60\3\60\5\60\u0290\n\60\3\61\7\61\u0293\n\61\f\61\16\61"+
-		"\u0296\13\61\3\61\3\61\3\62\3\62\3\62\7\62\u029d\n\62\f\62\16\62\u02a0"+
-		"\13\62\3\63\3\63\3\63\3\63\3\63\3\63\7\63\u02a8\n\63\f\63\16\63\u02ab"+
-		"\13\63\3\64\3\64\3\64\3\64\3\64\3\64\3\65\3\65\3\65\3\66\3\66\3\66\3\66"+
-		"\3\67\3\67\3\67\3\67\3\67\3\67\3\67\3\67\5\67\u02c2\n\67\38\38\38\38\3"+
-		"8\38\38\38\38\38\38\38\58\u02d0\n8\39\39\39\59\u02d5\n9\39\39\3:\3:\5"+
-		":\u02db\n:\3:\3:\3;\3;\3<\3<\3<\3<\3<\3=\3=\3=\3=\3=\3>\3>\3>\5>\u02ee"+
-		"\n>\3>\5>\u02f1\n>\3>\3>\5>\u02f5\n>\3>\3>\3?\3?\3?\5?\u02fc\n?\7?\u02fe"+
-		"\n?\f?\16?\u0301\13?\3?\3?\3@\3@\5@\u0307\n@\3A\3A\5A\u030b\nA\3B\3B\3"+
-		"B\3B\3C\3C\3C\5C\u0314\nC\3C\3C\3C\5C\u0319\nC\3C\3C\3C\3C\3D\3D\3D\3"+
-		"D\3D\3D\5D\u0325\nD\5D\u0327\nD\3E\3E\3E\3E\7E\u032d\nE\fE\16E\u0330\13"+
-		"E\5E\u0332\nE\3E\3E\3E\3E\3E\5E\u0339\nE\3F\3F\3F\5F\u033e\nF\3G\3G\3"+
-		"H\3H\3I\3I\3J\3J\3K\3K\3L\3L\3M\3M\3N\3N\3O\3O\3P\3P\3Q\3Q\3R\3R\3S\3"+
-		"S\3T\3T\3U\3U\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\5V\u036c\nV\3"+
-		"W\3W\5W\u0370\nW\3X\3X\3X\5X\u0375\nX\3Y\3Y\5Y\u0379\nY\3Z\3Z\5Z\u037d"+
-		"\nZ\3Z\3Z\3Z\3[\3[\5[\u0384\n[\3[\3[\3\\\3\\\3]\3]\3^\3^\3^\2\2_\2\4\6"+
-		"\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRT"+
-		"VXZ\\^`bdfhjlnprtvxz|~\u0080\u0082\u0084\u0086\u0088\u008a\u008c\u008e"+
-		"\u0090\u0092\u0094\u0096\u0098\u009a\u009c\u009e\u00a0\u00a2\u00a4\u00a6"+
-		"\u00a8\u00aa\u00ac\u00ae\u00b0\u00b2\u00b4\u00b6\u00b8\u00ba\2\13\3\2"+
-		"\t\n\3\2de\3\2\r\26\4\2\6\6$.\3\2\60\61\4\2##\62\64\4\2>?yy\4\2\f\f{{"+
-		"\3\2Oy\2\u03bc\2\u00c1\3\2\2\2\4\u00c7\3\2\2\2\6\u00ca\3\2\2\2\b\u00dd"+
-		"\3\2\2\2\n\u00eb\3\2\2\2\f\u00f0\3\2\2\2\16\u00f4\3\2\2\2\20\u00fa\3\2"+
-		"\2\2\22\u010e\3\2\2\2\24\u0110\3\2\2\2\26\u0123\3\2\2\2\30\u0133\3\2\2"+
-		"\2\32\u014a\3\2\2\2\34\u0152\3\2\2\2\36\u0158\3\2\2\2 \u0167\3\2\2\2\""+
-		"\u016b\3\2\2\2$\u017b\3\2\2\2&\u0184\3\2\2\2(\u0194\3\2\2\2*\u019d\3\2"+
-		"\2\2,\u01a5\3\2\2\2.\u01a8\3\2\2\2\60\u01b2\3\2\2\2\62\u01c4\3\2\2\2\64"+
-		"\u01ce\3\2\2\2\66\u01de\3\2\2\28\u01e3\3\2\2\2:\u01f0\3\2\2\2<\u01f8\3"+
-		"\2\2\2>\u0207\3\2\2\2@\u020e\3\2\2\2B\u021e\3\2\2\2D\u022f\3\2\2\2F\u0238"+
-		"\3\2\2\2H\u0242\3\2\2\2J\u024a\3\2\2\2L\u0253\3\2\2\2N\u0257\3\2\2\2P"+
-		"\u025c\3\2\2\2R\u0264\3\2\2\2T\u0269\3\2\2\2V\u0271\3\2\2\2X\u0279\3\2"+
-		"\2\2Z\u027f\3\2\2\2\\\u0285\3\2\2\2^\u028b\3\2\2\2`\u0294\3\2\2\2b\u0299"+
-		"\3\2\2\2d\u02a1\3\2\2\2f\u02ac\3\2\2\2h\u02b2\3\2\2\2j\u02b5\3\2\2\2l"+
-		"\u02b9\3\2\2\2n\u02cf\3\2\2\2p\u02d1\3\2\2\2r\u02d8\3\2\2\2t\u02de\3\2"+
-		"\2\2v\u02e0\3\2\2\2x\u02e5\3\2\2\2z\u02f0\3\2\2\2|\u02f8\3\2\2\2~\u0306"+
-		"\3\2\2\2\u0080\u030a\3\2\2\2\u0082\u030c\3\2\2\2\u0084\u0310\3\2\2\2\u0086"+
-		"\u0326\3\2\2\2\u0088\u0338\3\2\2\2\u008a\u033d\3\2\2\2\u008c\u033f\3\2"+
-		"\2\2\u008e\u0341\3\2\2\2\u0090\u0343\3\2\2\2\u0092\u0345\3\2\2\2\u0094"+
-		"\u0347\3\2\2\2\u0096\u0349\3\2\2\2\u0098\u034b\3\2\2\2\u009a\u034d\3\2"+
-		"\2\2\u009c\u034f\3\2\2\2\u009e\u0351\3\2\2\2\u00a0\u0353\3\2\2\2\u00a2"+
-		"\u0355\3\2\2\2\u00a4\u0357\3\2\2\2\u00a6\u0359\3\2\2\2\u00a8\u035b\3\2"+
-		"\2\2\u00aa\u036b\3\2\2\2\u00ac\u036d\3\2\2\2\u00ae\u0374\3\2\2\2\u00b0"+
-		"\u0378\3\2\2\2\u00b2\u037c\3\2\2\2\u00b4\u0381\3\2\2\2\u00b6\u0387\3\2"+
-		"\2\2\u00b8\u0389\3\2\2\2\u00ba\u038b\3\2\2\2\u00bc\u00bd\7x\2\2\u00bd"+
-		"\u00be\7w\2\2\u00be\u00bf\5\u00b8]\2\u00bf\u00c0\7\3\2\2\u00c0\u00c2\3"+
-		"\2\2\2\u00c1\u00bc\3\2\2\2\u00c1\u00c2\3\2\2\2\u00c2\u00c5\3\2\2\2\u00c3"+
-		"\u00c6\5\6\4\2\u00c4\u00c6\5\4\3\2\u00c5\u00c3\3\2\2\2\u00c5\u00c4\3\2"+
-		"\2\2\u00c6\3\3\2\2\2\u00c7\u00c8\5\b\5\2\u00c8\u00c9\5\36\20\2\u00c9\5"+
-		"\3\2\2\2\u00ca\u00cb\7\4\2\2\u00cb\u00cc\7\5\2\2\u00cc\u00cd\7\u0084\2"+
-		"\2\u00cd\u00ce\7\6\2\2\u00ce\u00cf\5\u00b6\\\2\u00cf\u00d0\7\3\2\2\u00d0"+
-		"\u00d1\5\b\5\2\u00d1\7\3\2\2\2\u00d2\u00d8\5\n\6\2\u00d3\u00d8\5\f\7\2"+
-		"\u00d4\u00d8\5\16\b\2\u00d5\u00d8\5\20\t\2\u00d6\u00d8\5\24\13\2\u00d7"+
-		"\u00d2\3\2\2\2\u00d7\u00d3\3\2\2\2\u00d7\u00d4\3\2\2\2\u00d7\u00d5\3\2"+
-		"\2\2\u00d7\u00d6\3\2\2\2\u00d8\u00d9\3\2\2\2\u00d9\u00da\7\3\2\2\u00da"+
-		"\u00dc\3\2\2\2\u00db\u00d7\3\2\2\2\u00dc\u00df\3\2\2\2\u00dd\u00db\3\2"+
-		"\2\2\u00dd\u00de\3\2\2\2\u00de\u00e8\3\2\2\2\u00df\u00dd\3\2\2\2\u00e0"+
-		"\u00e3\5\30\r\2\u00e1\u00e3\5\26\f\2\u00e2\u00e0\3\2\2\2\u00e2\u00e1\3"+
-		"\2\2\2\u00e3\u00e4\3\2\2\2\u00e4\u00e5\7\3\2\2\u00e5\u00e7\3\2\2\2\u00e6"+
-		"\u00e2\3\2\2\2\u00e7\u00ea\3\2\2\2\u00e8\u00e6\3\2\2\2\u00e8\u00e9\3\2"+
-		"\2\2\u00e9\t\3\2\2\2\u00ea\u00e8\3\2\2\2\u00eb\u00ec\7\7\2\2\u00ec\u00ed"+
-		"\7j\2\2\u00ed\u00ee\7c\2\2\u00ee\u00ef\5\u00b6\\\2\u00ef\13\3\2\2\2\u00f0"+
-		"\u00f1\7\7\2\2\u00f1\u00f2\7\b\2\2\u00f2\u00f3\t\2\2\2\u00f3\r\3\2\2\2"+
-		"\u00f4\u00f5\7\7\2\2\u00f5\u00f6\7j\2\2\u00f6\u00f7\7T\2\2\u00f7\u00f8"+
-		"\7[\2\2\u00f8\u00f9\t\3\2\2\u00f9\17\3\2\2\2\u00fa\u0103\7\7\2\2\u00fb"+
-		"\u00fe\7\13\2\2\u00fc\u00fd\7\u0084\2\2\u00fd\u00ff\7\f\2\2\u00fe\u00fc"+
-		"\3\2\2\2\u00fe\u00ff\3\2\2\2\u00ff\u0100\3\2\2\2\u0100\u0104\7\u0084\2"+
-		"\2\u0101\u0102\7j\2\2\u0102\u0104\7\13\2\2\u0103\u00fb\3\2\2\2\u0103\u0101"+
-		"\3\2\2\2\u0104\u010b\3\2\2\2\u0105\u0106\5\22\n\2\u0106\u0107\7\6\2\2"+
-		"\u0107\u0108\5\u00b8]\2\u0108\u010a\3\2\2\2\u0109\u0105\3\2\2\2\u010a"+
-		"\u010d\3\2\2\2\u010b\u0109\3\2\2\2\u010b\u010c\3\2\2\2\u010c\21\3\2\2"+
-		"\2\u010d\u010b\3\2\2\2\u010e\u010f\t\4\2\2\u010f\23\3\2\2\2\u0110\u0111"+
-		"\7\27\2\2\u0111\u0115\7\4\2\2\u0112\u0113\7\5\2\2\u0113\u0114\7\u0084"+
-		"\2\2\u0114\u0116\7\6\2\2\u0115\u0112\3\2\2\2\u0115\u0116\3\2\2\2\u0116"+
-		"\u0117\3\2\2\2\u0117\u0121\5\u00b6\\\2\u0118\u0119\7Y\2\2\u0119\u011e"+
-		"\5\u00b6\\\2\u011a\u011b\7\30\2\2\u011b\u011d\5\u00b6\\\2\u011c\u011a"+
-		"\3\2\2\2\u011d\u0120\3\2\2\2\u011e\u011c\3\2\2\2\u011e\u011f\3\2\2\2\u011f"+
-		"\u0122\3\2\2\2\u0120\u011e\3\2\2\2\u0121\u0118\3\2\2\2\u0121\u0122\3\2"+
-		"\2\2\u0122\25\3\2\2\2\u0123\u0124\7\7\2\2\u0124\u0125\7\31\2\2\u0125\u0128"+
-		"\5p9\2\u0126\u0127\7X\2\2\u0127\u0129\5\u0086D\2\u0128\u0126\3\2\2\2\u0128"+
-		"\u0129\3\2\2\2\u0129\u0131\3\2\2\2\u012a\u012b\7\32\2\2\u012b\u0132\5"+
-		" \21\2\u012c\u012f\7\33\2\2\u012d\u012e\7\32\2\2\u012e\u0130\5 \21\2\u012f"+
-		"\u012d\3\2\2\2\u012f\u0130\3\2\2\2\u0130\u0132\3\2\2\2\u0131\u012a\3\2"+
-		"\2\2\u0131\u012c\3\2\2\2\u0132\27\3\2\2\2\u0133\u0134\7\7\2\2\u0134\u0137"+
-		"\7\34\2\2\u0135\u0136\7\u0084\2\2\u0136\u0138\7\f\2\2\u0137\u0135\3\2"+
-		"\2\2\u0137\u0138\3\2\2\2\u0138\u0139\3\2\2\2\u0139\u013a\7\u0084\2\2\u013a"+
-		"\u013c\7\35\2\2\u013b\u013d\5\32\16\2\u013c\u013b\3\2\2\2\u013c\u013d"+
-		"\3\2\2\2\u013d\u013e\3\2\2\2\u013e\u0141\7\36\2\2\u013f\u0140\7X\2\2\u0140"+
-		"\u0142\5\u0086D\2\u0141\u013f\3\2\2\2\u0141\u0142\3\2\2\2\u0142\u0148"+
-		"\3\2\2\2\u0143\u0144\7\37\2\2\u0144\u0145\5\36\20\2\u0145\u0146\7 \2\2"+
-		"\u0146\u0149\3\2\2\2\u0147\u0149\7\33\2\2\u0148\u0143\3\2\2\2\u0148\u0147"+
-		"\3\2\2\2\u0149\31\3\2\2\2\u014a\u014f\5\34\17\2\u014b\u014c\7\30\2\2\u014c"+
-		"\u014e\5\34\17\2\u014d\u014b\3\2\2\2\u014e\u0151\3\2\2\2\u014f\u014d\3"+
-		"\2\2\2\u014f\u0150\3\2\2\2\u0150\33\3\2\2\2\u0151\u014f\3\2\2\2\u0152"+
-		"\u0153\7!\2\2\u0153\u0156\7\u0084\2\2\u0154\u0155\7X\2\2\u0155\u0157\5"+
-		"\u0086D\2\u0156\u0154\3\2\2\2\u0156\u0157\3\2\2\2\u0157\35\3\2\2\2\u0158"+
-		"\u015d\5 \21\2\u0159\u015a\7\30\2\2\u015a\u015c\5 \21\2\u015b\u0159\3"+
-		"\2\2\2\u015c\u015f\3\2\2\2\u015d\u015b\3\2\2\2\u015d\u015e\3\2\2\2\u015e"+
-		"\37\3\2\2\2\u015f\u015d\3\2\2\2\u0160\u0168\5\"\22\2\u0161\u0168\58\35"+
-		"\2\u0162\u0168\5<\37\2\u0163\u0168\5@!\2\u0164\u0168\5D#\2\u0165\u0168"+
-		"\5F$\2\u0166\u0168\5H%\2\u0167\u0160\3\2\2\2\u0167\u0161\3\2\2\2\u0167"+
-		"\u0162\3\2\2\2\u0167\u0163\3\2\2\2\u0167\u0164\3\2\2\2\u0167\u0165\3\2"+
-		"\2\2\u0167\u0166\3\2\2\2\u0168!\3\2\2\2\u0169\u016c\5$\23\2\u016a\u016c"+
-		"\5(\25\2\u016b\u0169\3\2\2\2\u016b\u016a\3\2\2\2\u016c\u0175\3\2\2\2\u016d"+
-		"\u0174\5$\23\2\u016e\u0174\5,\27\2\u016f\u0174\5(\25\2\u0170\u0174\5."+
-		"\30\2\u0171\u0174\5\62\32\2\u0172\u0174\5\66\34\2\u0173\u016d\3\2\2\2"+
-		"\u0173\u016e\3\2\2\2\u0173\u016f\3\2\2\2\u0173\u0170\3\2\2\2\u0173\u0171"+
-		"\3\2\2\2\u0173\u0172\3\2\2\2\u0174\u0177\3\2\2\2\u0175\u0173\3\2\2\2\u0175"+
-		"\u0176\3\2\2\2\u0176\u0178\3\2\2\2\u0177\u0175\3\2\2\2\u0178\u0179\7U"+
-		"\2\2\u0179\u017a\5 \21\2\u017a#\3\2\2\2\u017b\u017c\7O\2\2\u017c\u0181"+
-		"\5&\24\2\u017d\u017e\7\30\2\2\u017e\u0180\5&\24\2\u017f\u017d\3\2\2\2"+
-		"\u0180\u0183\3\2\2\2\u0181\u017f\3\2\2\2\u0181\u0182\3\2\2\2\u0182%\3"+
-		"\2\2\2\u0183\u0181\3\2\2\2\u0184\u0187\5p9\2\u0185\u0186\7X\2\2\u0186"+
-		"\u0188\5\u0086D\2\u0187\u0185\3\2\2\2\u0187\u0188\3\2\2\2\u0188\u018b"+
-		"\3\2\2\2\u0189\u018a\7Z\2\2\u018a\u018c\7[\2\2\u018b\u0189\3\2\2\2\u018b"+
-		"\u018c\3\2\2\2\u018c\u018f\3\2\2\2\u018d\u018e\7Y\2\2\u018e\u0190\5p9"+
-		"\2\u018f\u018d\3\2\2\2\u018f\u0190\3\2\2\2\u0190\u0191\3\2\2\2\u0191\u0192"+
-		"\7W\2\2\u0192\u0193\5 \21\2\u0193\'\3\2\2\2\u0194\u0195\7P\2\2\u0195\u019a"+
-		"\5*\26\2\u0196\u0197\7\30\2\2\u0197\u0199\5*\26\2\u0198\u0196\3\2\2\2"+
-		"\u0199\u019c\3\2\2\2\u019a\u0198\3\2\2\2\u019a\u019b\3\2\2\2\u019b)\3"+
-		"\2\2\2\u019c\u019a\3\2\2\2\u019d\u01a0\5p9\2\u019e\u019f\7X\2\2\u019f"+
-		"\u01a1\5\u0086D\2\u01a0\u019e\3\2\2\2\u01a0\u01a1\3\2\2\2\u01a1\u01a2"+
-		"\3\2\2\2\u01a2\u01a3\7\32\2\2\u01a3\u01a4\5 \21\2\u01a4+\3\2\2\2\u01a5"+
-		"\u01a6\7Q\2\2\u01a6\u01a7\5 \21\2\u01a7-\3\2\2\2\u01a8\u01a9\7R\2\2\u01a9"+
-		"\u01aa\7S\2\2\u01aa\u01af\5\60\31\2\u01ab\u01ac\7\30\2\2\u01ac\u01ae\5"+
-		"\60\31\2\u01ad\u01ab\3\2\2\2\u01ae\u01b1\3\2\2\2\u01af\u01ad\3\2\2\2\u01af"+
-		"\u01b0\3\2\2\2\u01b0/\3\2\2\2\u01b1\u01af\3\2\2\2\u01b2\u01b9\5p9\2\u01b3"+
-		"\u01b4\7X\2\2\u01b4\u01b6\5\u0086D\2\u01b5\u01b3\3\2\2\2\u01b5\u01b6\3"+
-		"\2\2\2\u01b6\u01b7\3\2\2\2\u01b7\u01b8\7\32\2\2\u01b8\u01ba\5 \21\2\u01b9"+
-		"\u01b5\3\2\2\2\u01b9\u01ba\3\2\2\2\u01ba\u01bd\3\2\2\2\u01bb\u01bc\7c"+
-		"\2\2\u01bc\u01be\5\u00b6\\\2\u01bd\u01bb\3\2\2\2\u01bd\u01be\3\2\2\2\u01be"+
-		"\61\3\2\2\2\u01bf\u01c0\7T\2\2\u01c0\u01c5\7S\2\2\u01c1\u01c2\7]\2\2\u01c2"+
-		"\u01c3\7T\2\2\u01c3\u01c5\7S\2\2\u01c4\u01bf\3\2\2\2\u01c4\u01c1\3\2\2"+
-		"\2\u01c5\u01c6\3\2\2\2\u01c6\u01cb\5\64\33\2\u01c7\u01c8\7\30\2\2\u01c8"+
-		"\u01ca\5\64\33\2\u01c9\u01c7\3\2\2\2\u01ca\u01cd\3\2\2\2\u01cb\u01c9\3"+
-		"\2\2\2\u01cb\u01cc\3\2\2\2\u01cc\63\3\2\2\2\u01cd\u01cb\3\2\2\2\u01ce"+
-		"\u01d1\5 \21\2\u01cf\u01d2\7^\2\2\u01d0\u01d2\7_\2\2\u01d1\u01cf\3\2\2"+
-		"\2\u01d1\u01d0\3\2\2\2\u01d1\u01d2\3\2\2\2\u01d2\u01d8\3\2\2\2\u01d3\u01d6"+
-		"\7[\2\2\u01d4\u01d7\7d\2\2\u01d5\u01d7\7e\2\2\u01d6\u01d4\3\2\2\2\u01d6"+
-		"\u01d5\3\2\2\2\u01d7\u01d9\3\2\2\2\u01d8\u01d3\3\2\2\2\u01d8\u01d9\3\2"+
-		"\2\2\u01d9\u01dc\3\2\2\2\u01da\u01db\7c\2\2\u01db\u01dd\5\u00b6\\\2\u01dc"+
-		"\u01da\3\2\2\2\u01dc\u01dd\3\2\2\2\u01dd\65\3\2\2\2\u01de\u01df\7\\\2"+
-		"\2\u01df\u01e0\5p9\2\u01e0\67\3\2\2\2\u01e1\u01e4\7`\2\2\u01e2\u01e4\7"+
-		"a\2\2\u01e3\u01e1\3\2\2\2\u01e3\u01e2\3\2\2\2\u01e4\u01e5\3\2\2\2\u01e5"+
-		"\u01ea\5:\36\2\u01e6\u01e7\7\30\2\2\u01e7\u01e9\5:\36\2\u01e8\u01e6\3"+
-		"\2\2\2\u01e9\u01ec\3\2\2\2\u01ea\u01e8\3\2\2\2\u01ea\u01eb\3\2\2\2\u01eb"+
-		"\u01ed\3\2\2\2\u01ec\u01ea\3\2\2\2\u01ed\u01ee\7b\2\2\u01ee\u01ef\5 \21"+
-		"\2\u01ef9\3\2\2\2\u01f0\u01f3\5p9\2\u01f1\u01f2\7X\2\2\u01f2\u01f4\5\u0086"+
-		"D\2\u01f3\u01f1\3\2\2\2\u01f3\u01f4\3\2\2\2\u01f4\u01f5\3\2\2\2\u01f5"+
-		"\u01f6\7W\2\2\u01f6\u01f7\5 \21\2\u01f7;\3\2\2\2\u01f8\u01f9\7f\2\2\u01f9"+
-		"\u01fa\7\35\2\2\u01fa\u01fb\5\36\20\2\u01fb\u01fd\7\36\2\2\u01fc\u01fe"+
-		"\5> \2\u01fd\u01fc\3\2\2\2\u01fe\u01ff\3\2\2\2\u01ff\u01fd\3\2\2\2\u01ff"+
-		"\u0200\3\2\2\2\u0200\u0201\3\2\2\2\u0201\u0202\7j\2\2\u0202\u0203\7U\2"+
-		"\2\u0203\u0204\5 \21\2\u0204=\3\2\2\2\u0205\u0206\7g\2\2\u0206\u0208\5"+
-		" \21\2\u0207\u0205\3\2\2\2\u0208\u0209\3\2\2\2\u0209\u0207\3\2\2\2\u0209"+
-		"\u020a\3\2\2\2\u020a\u020b\3\2\2\2\u020b\u020c\7U\2\2\u020c\u020d\5 \21"+
-		"\2\u020d?\3\2\2\2\u020e\u020f\7m\2\2\u020f\u0210\7\35\2\2\u0210\u0211"+
-		"\5\36\20\2\u0211\u0213\7\36\2\2\u0212\u0214\5B\"\2\u0213\u0212\3\2\2\2"+
-		"\u0214\u0215\3\2\2\2\u0215\u0213\3\2\2\2\u0215\u0216\3\2\2\2\u0216\u0217"+
-		"\3\2\2\2\u0217\u0219\7j\2\2\u0218\u021a\5p9\2\u0219\u0218\3\2\2\2\u0219"+
-		"\u021a\3\2\2\2\u021a\u021b\3\2\2\2\u021b\u021c\7U\2\2\u021c\u021d\5 \21"+
-		"\2\u021dA\3\2\2\2\u021e\u0222\7g\2\2\u021f\u0220\5p9\2\u0220\u0221\7X"+
-		"\2\2\u0221\u0223\3\2\2\2\u0222\u021f\3\2\2\2\u0222\u0223\3\2\2\2\u0223"+
-		"\u0224\3\2\2\2\u0224\u0229\5\u0086D\2\u0225\u0226\7\"\2\2\u0226\u0228"+
-		"\5\u0086D\2\u0227\u0225\3\2\2\2\u0228\u022b\3\2\2\2\u0229\u0227\3\2\2"+
-		"\2\u0229\u022a\3\2\2\2\u022a\u022c\3\2\2\2\u022b\u0229\3\2\2\2\u022c\u022d"+
-		"\7U\2\2\u022d\u022e\5 \21\2\u022eC\3\2\2\2\u022f\u0230\7V\2\2\u0230\u0231"+
-		"\7\35\2\2\u0231\u0232\5\36\20\2\u0232\u0233\7\36\2\2\u0233\u0234\7k\2"+
-		"\2\u0234\u0235\5 \21\2\u0235\u0236\7l\2\2\u0236\u0237\5 \21\2\u0237E\3"+
-		"\2\2\2\u0238\u0239\7h\2\2\u0239\u023a\7\37\2\2\u023a\u023b\5\36\20\2\u023b"+
-		"\u023c\7 \2\2\u023c\u023d\7i\2\2\u023d\u023e\7#\2\2\u023e\u023f\7\37\2"+
-		"\2\u023f\u0240\5\36\20\2\u0240\u0241\7 \2\2\u0241G\3\2\2\2\u0242\u0247"+
-		"\5J&\2\u0243\u0244\7n\2\2\u0244\u0246\5J&\2\u0245\u0243\3\2\2\2\u0246"+
-		"\u0249\3\2\2\2\u0247\u0245\3\2\2\2\u0247\u0248\3\2\2\2\u0248I\3\2\2\2"+
-		"\u0249\u0247\3\2\2\2\u024a\u024f\5L\'\2\u024b\u024c\7o\2\2\u024c\u024e"+
-		"\5L\'\2\u024d\u024b\3\2\2\2\u024e\u0251\3\2\2\2\u024f\u024d\3\2\2\2\u024f"+
-		"\u0250\3\2\2\2\u0250K\3\2\2\2\u0251\u024f\3\2\2\2\u0252\u0254\7p\2\2\u0253"+
-		"\u0252\3\2\2\2\u0253\u0254\3\2\2\2\u0254\u0255\3\2\2\2\u0255\u0256\5N"+
-		"(\2\u0256M\3\2\2\2\u0257\u025a\5P)\2\u0258\u0259\t\5\2\2\u0259\u025b\5"+
-		"P)\2\u025a\u0258\3\2\2\2\u025a\u025b\3\2\2\2\u025bO\3\2\2\2\u025c\u0261"+
-		"\5R*\2\u025d\u025e\7/\2\2\u025e\u0260\5R*\2\u025f\u025d\3\2\2\2\u0260"+
-		"\u0263\3\2\2\2\u0261\u025f\3\2\2\2\u0261\u0262\3\2\2\2\u0262Q\3\2\2\2"+
-		"\u0263\u0261\3\2\2\2\u0264\u0267\5T+\2\u0265\u0266\7q\2\2\u0266\u0268"+
-		"\5T+\2\u0267\u0265\3\2\2\2\u0267\u0268\3\2\2\2\u0268S\3\2\2\2\u0269\u026e"+
-		"\5V,\2\u026a\u026b\t\6\2\2\u026b\u026d\5V,\2\u026c\u026a\3\2\2\2\u026d"+
-		"\u0270\3\2\2\2\u026e\u026c\3\2\2\2\u026e\u026f\3\2\2\2\u026fU\3\2\2\2"+
-		"\u0270\u026e\3\2\2\2\u0271\u0276\5X-\2\u0272\u0273\t\7\2\2\u0273\u0275"+
-		"\5X-\2\u0274\u0272\3\2\2\2\u0275\u0278\3\2\2\2\u0276\u0274\3\2\2\2\u0276"+
-		"\u0277\3\2\2\2\u0277W\3\2\2\2\u0278\u0276\3\2\2\2\u0279\u027d\5Z.\2\u027a"+
-		"\u027b\7r\2\2\u027b\u027c\7s\2\2\u027c\u027e\5\u0086D\2\u027d\u027a\3"+
-		"\2\2\2\u027d\u027e\3\2\2\2\u027eY\3\2\2\2\u027f\u0283\5\\/\2\u0280\u0281"+
-		"\7t\2\2\u0281\u0282\7X\2\2\u0282\u0284\5\u0086D\2\u0283\u0280\3\2\2\2"+
-		"\u0283\u0284\3\2\2\2\u0284[\3\2\2\2\u0285\u0289\5^\60\2\u0286\u0287\7"+
-		"v\2\2\u0287\u0288\7X\2\2\u0288\u028a\5\u00acW\2\u0289\u0286\3\2\2\2\u0289"+
-		"\u028a\3\2\2\2\u028a]\3\2\2\2\u028b\u028f\5`\61\2\u028c\u028d\7u\2\2\u028d"+
-		"\u028e\7X\2\2\u028e\u0290\5\u00acW\2\u028f\u028c\3\2\2\2\u028f\u0290\3"+
-		"\2\2\2\u0290_\3\2\2\2\u0291\u0293\t\6\2\2\u0292\u0291\3\2\2\2\u0293\u0296"+
-		"\3\2\2\2\u0294\u0292\3\2\2\2\u0294\u0295\3\2\2\2\u0295\u0297\3\2\2\2\u0296"+
-		"\u0294\3\2\2\2\u0297\u0298\5b\62\2\u0298a\3\2\2\2\u0299\u029e\5d\63\2"+
-		"\u029a\u029b\7\65\2\2\u029b\u029d\5d\63\2\u029c\u029a\3\2\2\2\u029d\u02a0"+
-		"\3\2\2\2\u029e\u029c\3\2\2\2\u029e\u029f\3\2\2\2\u029fc\3\2\2\2\u02a0"+
-		"\u029e\3\2\2\2\u02a1\u02a9\5n8\2\u02a2\u02a8\5f\64\2\u02a3\u02a8\5j\66"+
-		"\2\u02a4\u02a8\5l\67\2\u02a5\u02a8\5h\65\2\u02a6\u02a8\5|?\2\u02a7\u02a2"+
-		"\3\2\2\2\u02a7\u02a3\3\2\2\2\u02a7\u02a4\3\2\2\2\u02a7\u02a5\3\2\2\2\u02a7"+
-		"\u02a6\3\2\2\2\u02a8\u02ab\3\2\2\2\u02a9\u02a7\3\2\2\2\u02a9\u02aa\3\2"+
-		"\2\2\u02aae\3\2\2\2\u02ab\u02a9\3\2\2\2\u02ac\u02ad\7\66\2\2\u02ad\u02ae"+
-		"\7\66\2\2\u02ae\u02af\5\36\20\2\u02af\u02b0\7\67\2\2\u02b0\u02b1\7\67"+
-		"\2\2\u02b1g\3\2\2\2\u02b2\u02b3\7\66\2\2\u02b3\u02b4\7\67\2\2\u02b4i\3"+
-		"\2\2\2\u02b5\u02b6\7\66\2\2\u02b6\u02b7\5\36\20\2\u02b7\u02b8\7\67\2\2"+
-		"\u02b8k\3\2\2\2\u02b9\u02c1\78\2\2\u02ba\u02c2\5\u00ba^\2\u02bb\u02c2"+
-		"\5\u00b8]\2\u02bc\u02c2\7\u0084\2\2\u02bd\u02c2\5r:\2\u02be\u02c2\5p9"+
-		"\2\u02bf\u02c2\5t;\2\u02c0\u02c2\5\u00aaV\2\u02c1\u02ba\3\2\2\2\u02c1"+
-		"\u02bb\3\2\2\2\u02c1\u02bc\3\2\2\2\u02c1\u02bd\3\2\2\2\u02c1\u02be\3\2"+
-		"\2\2\u02c1\u02bf\3\2\2\2\u02c1\u02c0\3\2\2\2\u02c2m\3\2\2\2\u02c3\u02d0"+
-		"\7|\2\2\u02c4\u02d0\7}\2\2\u02c5\u02d0\5\u00b8]\2\u02c6\u02d0\5p9\2\u02c7"+
-		"\u02d0\5r:\2\u02c8\u02d0\5t;\2\u02c9\u02d0\5\u0088E\2\u02ca\u02d0\5z>"+
-		"\2\u02cb\u02d0\5v<\2\u02cc\u02d0\5x=\2\u02cd\u02d0\5\u00b4[\2\u02ce\u02d0"+
-		"\5\u0080A\2\u02cf\u02c3\3\2\2\2\u02cf\u02c4\3\2\2\2\u02cf\u02c5\3\2\2"+
-		"\2\u02cf\u02c6\3\2\2\2\u02cf\u02c7\3\2\2\2\u02cf\u02c8\3\2\2\2\u02cf\u02c9"+
-		"\3\2\2\2\u02cf\u02ca\3\2\2\2\u02cf\u02cb\3\2\2\2\u02cf\u02cc\3\2\2\2\u02cf"+
-		"\u02cd\3\2\2\2\u02cf\u02ce\3\2\2\2\u02d0o\3\2\2\2\u02d1\u02d4\7!\2\2\u02d2"+
-		"\u02d3\7\u0084\2\2\u02d3\u02d5\7\f\2\2\u02d4\u02d2\3\2\2\2\u02d4\u02d5"+
-		"\3\2\2\2\u02d5\u02d6\3\2\2\2\u02d6\u02d7\7\u0084\2\2\u02d7q\3\2\2\2\u02d8"+
-		"\u02da\7\35\2\2\u02d9\u02db\5\36\20\2\u02da\u02d9\3\2\2\2\u02da\u02db"+
-		"\3\2\2\2\u02db\u02dc\3\2\2\2\u02dc\u02dd\7\36\2\2\u02dds\3\2\2\2\u02de"+
-		"\u02df\79\2\2\u02dfu\3\2\2\2\u02e0\u02e1\7\t\2\2\u02e1\u02e2\7\37\2\2"+
-		"\u02e2\u02e3\5\36\20\2\u02e3\u02e4\7 \2\2\u02e4w\3\2\2\2\u02e5\u02e6\7"+
-		"\n\2\2\u02e6\u02e7\7\37\2\2\u02e7\u02e8\5\36\20\2\u02e8\u02e9\7 \2\2\u02e9"+
-		"y\3\2\2\2\u02ea\u02ee\7\u0084\2\2\u02eb\u02ee\5\u00ba^\2\u02ec\u02ee\3"+
-		"\2\2\2\u02ed\u02ea\3\2\2\2\u02ed\u02eb\3\2\2\2\u02ed\u02ec\3\2\2\2\u02ee"+
-		"\u02ef\3\2\2\2\u02ef\u02f1\7\f\2\2\u02f0\u02ed\3\2\2\2\u02f0\u02f1\3\2"+
-		"\2\2\u02f1\u02f4\3\2\2\2\u02f2\u02f5\5\u00b0Y\2\u02f3\u02f5\5\u00ba^\2"+
-		"\u02f4\u02f2\3\2\2\2\u02f4\u02f3\3\2\2\2\u02f5\u02f6\3\2\2\2\u02f6\u02f7"+
-		"\5|?\2\u02f7{\3\2\2\2\u02f8\u02ff\7\35\2\2\u02f9\u02fb\5~@\2\u02fa\u02fc"+
-		"\7\30\2\2\u02fb\u02fa\3\2\2\2\u02fb\u02fc\3\2\2\2\u02fc\u02fe\3\2\2\2"+
-		"\u02fd\u02f9\3\2\2\2\u02fe\u0301\3\2\2\2\u02ff\u02fd\3\2\2\2\u02ff\u0300"+
-		"\3\2\2\2\u0300\u0302\3\2\2\2\u0301\u02ff\3\2\2\2\u0302\u0303\7\36\2\2"+
-		"\u0303}\3\2\2\2\u0304\u0307\5 \21\2\u0305\u0307\7{\2\2\u0306\u0304\3\2"+
-		"\2\2\u0306\u0305\3\2\2\2\u0307\177\3\2\2\2\u0308\u030b\5\u0082B\2\u0309"+
-		"\u030b\5\u0084C\2\u030a\u0308\3\2\2\2\u030a\u0309\3\2\2\2\u030b\u0081"+
-		"\3\2\2\2\u030c\u030d\7\u0084\2\2\u030d\u030e\7:\2\2\u030e\u030f\7}\2\2"+
-		"\u030f\u0083\3\2\2\2\u0310\u0311\7\34\2\2\u0311\u0313\7\35\2\2\u0312\u0314"+
-		"\5\32\16\2\u0313\u0312\3\2\2\2\u0313\u0314\3\2\2\2\u0314\u0315\3\2\2\2"+
-		"\u0315\u0318\7\36\2\2\u0316\u0317\7X\2\2\u0317\u0319\5\u0086D\2\u0318"+
-		"\u0316\3\2\2\2\u0318\u0319\3\2\2\2\u0319\u031a\3\2\2\2\u031a\u031b\7\37"+
-		"\2\2\u031b\u031c\5\36\20\2\u031c\u031d\7 \2\2\u031d\u0085\3\2\2\2\u031e"+
-		"\u031f\7\35\2\2\u031f\u0327\7\36\2\2\u0320\u0324\5\u008aF\2\u0321\u0325"+
-		"\7{\2\2\u0322\u0325\7#\2\2\u0323\u0325\7\60\2\2\u0324\u0321\3\2\2\2\u0324"+
-		"\u0322\3\2\2\2\u0324\u0323\3\2\2\2\u0324\u0325\3\2\2\2\u0325\u0327\3\2"+
-		"\2\2\u0326\u031e\3\2\2\2\u0326\u0320\3\2\2\2\u0327\u0087\3\2\2\2\u0328"+
-		"\u0331\7\37\2\2\u0329\u032e\5\u00b2Z\2\u032a\u032b\7\30\2\2\u032b\u032d"+
-		"\5\u00b2Z\2\u032c\u032a\3\2\2\2\u032d\u0330\3\2\2\2\u032e\u032c\3\2\2"+
-		"\2\u032e\u032f\3\2\2\2\u032f\u0332\3\2\2\2\u0330\u032e\3\2\2\2\u0331\u0329"+
-		"\3\2\2\2\u0331\u0332\3\2\2\2\u0332\u0333\3\2\2\2\u0333\u0339\7 \2\2\u0334"+
-		"\u0335\7;\2\2\u0335\u0336\5\36\20\2\u0336\u0337\7<\2\2\u0337\u0339\3\2"+
-		"\2\2\u0338\u0328\3\2\2\2\u0338\u0334\3\2\2\2\u0339\u0089\3\2\2\2\u033a"+
-		"\u033e\7=\2\2\u033b\u033e\5\u008cG\2\u033c\u033e\5\u00aeX\2\u033d\u033a"+
-		"\3\2\2\2\u033d\u033b\3\2\2\2\u033d\u033c\3\2\2\2\u033e\u008b\3\2\2\2\u033f"+
-		"\u0340\t\b\2\2\u0340\u008d\3\2\2\2\u0341\u0342\7@\2\2\u0342\u008f\3\2"+
-		"\2\2\u0343\u0344\7A\2\2\u0344\u0091\3\2\2\2\u0345\u0346\7B\2\2\u0346\u0093"+
-		"\3\2\2\2\u0347\u0348\7C\2\2\u0348\u0095\3\2\2\2\u0349\u034a\7D\2\2\u034a"+
-		"\u0097\3\2\2\2\u034b\u034c\7E\2\2\u034c\u0099\3\2\2\2\u034d\u034e\7F\2"+
-		"\2\u034e\u009b\3\2\2\2\u034f\u0350\7G\2\2\u0350\u009d\3\2\2\2\u0351\u0352"+
-		"\7H\2\2\u0352\u009f\3\2\2\2\u0353\u0354\7I\2\2\u0354\u00a1\3\2\2\2\u0355"+
-		"\u0356\7J\2\2\u0356\u00a3\3\2\2\2\u0357\u0358\7K\2\2\u0358\u00a5\3\2\2"+
-		"\2\u0359\u035a\7L\2\2\u035a\u00a7\3\2\2\2\u035b\u035c\7M\2\2\u035c\u00a9"+
-		"\3\2\2\2\u035d\u036c\5\u008eH\2\u035e\u036c\5\u0090I\2\u035f\u036c\5\u0092"+
-		"J\2\u0360\u036c\5\u0094K\2\u0361\u036c\5\u0096L\2\u0362\u036c\5\u0098"+
-		"M\2\u0363\u036c\5\u009aN\2\u0364\u036c\5\u009cO\2\u0365\u036c\5\u00a2"+
-		"R\2\u0366\u036c\5\u00a4S\2\u0367\u036c\5\u00a6T\2\u0368\u036c\5\u009e"+
-		"P\2\u0369\u036c\5\u00a0Q\2\u036a\u036c\5\u00a8U\2\u036b\u035d\3\2\2\2"+
-		"\u036b\u035e\3\2\2\2\u036b\u035f\3\2\2\2\u036b\u0360\3\2\2\2\u036b\u0361"+
-		"\3\2\2\2\u036b\u0362\3\2\2\2\u036b\u0363\3\2\2\2\u036b\u0364\3\2\2\2\u036b"+
-		"\u0365\3\2\2\2\u036b\u0366\3\2\2\2\u036b\u0367\3\2\2\2\u036b\u0368\3\2"+
-		"\2\2\u036b\u0369\3\2\2\2\u036b\u036a\3\2\2\2\u036c\u00ab\3\2\2\2\u036d"+
-		"\u036f\5\u00aeX\2\u036e\u0370\7{\2\2\u036f\u036e\3\2\2\2\u036f\u0370\3"+
-		"\2\2\2\u0370\u00ad\3\2\2\2\u0371\u0375\7N\2\2\u0372\u0375\5\u00aaV\2\u0373"+
-		"\u0375\7|\2\2\u0374\u0371\3\2\2\2\u0374\u0372\3\2\2\2\u0374\u0373\3\2"+
-		"\2\2\u0375\u00af\3\2\2\2\u0376\u0379\7\u0084\2\2\u0377\u0379\5\u00aaV"+
-		"\2\u0378\u0376\3\2\2\2\u0378\u0377\3\2\2\2\u0379\u00b1\3\2\2\2\u037a\u037d"+
-		"\5 \21\2\u037b\u037d\7\u0084\2\2\u037c\u037a\3\2\2\2\u037c\u037b\3\2\2"+
-		"\2\u037d\u037e\3\2\2\2\u037e\u037f\t\t\2\2\u037f\u0380\5 \21\2\u0380\u00b3"+
-		"\3\2\2\2\u0381\u0383\7\66\2\2\u0382\u0384\5\36\20\2\u0383\u0382\3\2\2"+
-		"\2\u0383\u0384\3\2\2\2\u0384\u0385\3\2\2\2\u0385\u0386\7\67\2\2\u0386"+
-		"\u00b5\3\2\2\2\u0387\u0388\5\u00b8]\2\u0388\u00b7\3\2\2\2\u0389\u038a"+
-		"\7z\2\2\u038a\u00b9\3\2\2\2\u038b\u038c\t\n\2\2\u038c\u00bb\3\2\2\2^\u00c1"+
-		"\u00c5\u00d7\u00dd\u00e2\u00e8\u00fe\u0103\u010b\u0115\u011e\u0121\u0128"+
-		"\u012f\u0131\u0137\u013c\u0141\u0148\u014f\u0156\u015d\u0167\u016b\u0173"+
-		"\u0175\u0181\u0187\u018b\u018f\u019a\u01a0\u01af\u01b5\u01b9\u01bd\u01c4"+
-		"\u01cb\u01d1\u01d6\u01d8\u01dc\u01e3\u01ea\u01f3\u01ff\u0209\u0215\u0219"+
-		"\u0222\u0229\u0247\u024f\u0253\u025a\u0261\u0267\u026e\u0276\u027d\u0283"+
-		"\u0289\u028f\u0294\u029e\u02a7\u02a9\u02c1\u02cf\u02d4\u02da\u02ed\u02f0"+
-		"\u02f4\u02fb\u02ff\u0306\u030a\u0313\u0318\u0324\u0326\u032e\u0331\u0338"+
-		"\u033d\u036b\u036f\u0374\u0378\u037c\u0383";
-	public static final ATN _ATN =
-		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
-	static {
-		_decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
-		for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {
-			_decisionToDFA[i] = new DFA(_ATN.getDecisionState(i), i);
-		}
-	}
+    static {
+        RuntimeMetaData.checkVersion("4.7", RuntimeMetaData.VERSION);
+    }
+
+    protected static final DFA[] _decisionToDFA;
+    protected static final PredictionContextCache _sharedContextCache =
+            new PredictionContextCache();
+    public static final int
+            T__0 = 1, T__1 = 2, T__2 = 3, T__3 = 4, T__4 = 5, T__5 = 6, T__6 = 7, T__7 = 8, T__8 = 9,
+            T__9 = 10, T__10 = 11, T__11 = 12, T__12 = 13, T__13 = 14, T__14 = 15, T__15 = 16, T__16 = 17,
+            T__17 = 18, T__18 = 19, T__19 = 20, T__20 = 21, T__21 = 22, T__22 = 23, T__23 = 24,
+            T__24 = 25, T__25 = 26, T__26 = 27, T__27 = 28, T__28 = 29, T__29 = 30, T__30 = 31,
+            T__31 = 32, T__32 = 33, T__33 = 34, T__34 = 35, T__35 = 36, T__36 = 37, T__37 = 38,
+            T__38 = 39, T__39 = 40, T__40 = 41, T__41 = 42, T__42 = 43, T__43 = 44, T__44 = 45,
+            T__45 = 46, T__46 = 47, T__47 = 48, T__48 = 49, T__49 = 50, T__50 = 51, T__51 = 52,
+            T__52 = 53, T__53 = 54, T__54 = 55, T__55 = 56, T__56 = 57, T__57 = 58, T__58 = 59,
+            T__59 = 60, T__60 = 61, T__61 = 62, T__62 = 63, T__63 = 64, T__64 = 65, T__65 = 66,
+            T__66 = 67, T__67 = 68, T__68 = 69, T__69 = 70, T__70 = 71, T__71 = 72, T__72 = 73,
+            T__73 = 74, T__74 = 75, T__75 = 76, Kfor = 77, Klet = 78, Kwhere = 79, Kgroup = 80,
+            Kby = 81, Korder = 82, Kreturn = 83, Kif = 84, Kin = 85, Kas = 86, Kat = 87, Kallowing = 88,
+            Kempty = 89, Kcount = 90, Kstable = 91, Kascending = 92, Kdescending = 93, Ksome = 94,
+            Kevery = 95, Ksatisfies = 96, Kcollation = 97, Kgreatest = 98, Kleast = 99, Kswitch = 100,
+            Kcase = 101, Ktry = 102, Kcatch = 103, Kdefault = 104, Kthen = 105, Kelse = 106, Ktypeswitch = 107,
+            Kor = 108, Kand = 109, Knot = 110, Kto = 111, Kinstance = 112, Kof = 113, Ktreat = 114,
+            Kcast = 115, Kcastable = 116, Kversion = 117, Kjsoniq = 118, Kjson = 119, STRING = 120,
+            ArgumentPlaceholder = 121, NullLiteral = 122, Literal = 123, NumericLiteral = 124,
+            BooleanLiteral = 125, IntegerLiteral = 126, DecimalLiteral = 127, DoubleLiteral = 128,
+            WS = 129, NCName = 130, XQComment = 131, ContentChar = 132;
+    public static final int
+            RULE_module = 0, RULE_mainModule = 1, RULE_libraryModule = 2, RULE_prolog = 3,
+            RULE_defaultCollationDecl = 4, RULE_orderingModeDecl = 5, RULE_emptyOrderDecl = 6,
+            RULE_decimalFormatDecl = 7, RULE_dfPropertyName = 8, RULE_moduleImport = 9,
+            RULE_varDecl = 10, RULE_functionDecl = 11, RULE_paramList = 12, RULE_param = 13,
+            RULE_expr = 14, RULE_exprSingle = 15, RULE_flowrExpr = 16, RULE_forClause = 17,
+            RULE_forVar = 18, RULE_letClause = 19, RULE_letVar = 20, RULE_whereClause = 21,
+            RULE_groupByClause = 22, RULE_groupByVar = 23, RULE_orderByClause = 24,
+            RULE_orderByExpr = 25, RULE_countClause = 26, RULE_quantifiedExpr = 27,
+            RULE_quantifiedExprVar = 28, RULE_switchExpr = 29, RULE_switchCaseClause = 30,
+            RULE_typeSwitchExpr = 31, RULE_caseClause = 32, RULE_ifExpr = 33, RULE_tryCatchExpr = 34,
+            RULE_orExpr = 35, RULE_andExpr = 36, RULE_notExpr = 37, RULE_comparisonExpr = 38,
+            RULE_stringConcatExpr = 39, RULE_rangeExpr = 40, RULE_additiveExpr = 41,
+            RULE_multiplicativeExpr = 42, RULE_instanceOfExpr = 43, RULE_treatExpr = 44,
+            RULE_castableExpr = 45, RULE_castExpr = 46, RULE_unaryExpr = 47, RULE_simpleMapExpr = 48,
+            RULE_postFixExpr = 49, RULE_arrayLookup = 50, RULE_arrayUnboxing = 51,
+            RULE_predicate = 52, RULE_objectLookup = 53, RULE_primaryExpr = 54, RULE_varRef = 55,
+            RULE_parenthesizedExpr = 56, RULE_contextItemExpr = 57, RULE_orderedExpr = 58,
+            RULE_unorderedExpr = 59, RULE_functionCall = 60, RULE_argumentList = 61,
+            RULE_argument = 62, RULE_functionItemExpr = 63, RULE_namedFunctionRef = 64,
+            RULE_inlineFunctionExpr = 65, RULE_sequenceType = 66, RULE_objectConstructor = 67,
+            RULE_itemType = 68, RULE_jSONItemTest = 69, RULE_keyWordString = 70, RULE_keyWordInteger = 71,
+            RULE_keyWordDecimal = 72, RULE_keyWordDouble = 73, RULE_keyWordBoolean = 74,
+            RULE_keyWordDuration = 75, RULE_keyWordYearMonthDuration = 76, RULE_keyWordDayTimeDuration = 77,
+            RULE_keyWordHexBinary = 78, RULE_keyWordBase64Binary = 79, RULE_keyWordDateTime = 80,
+            RULE_keyWordDate = 81, RULE_keyWordTime = 82, RULE_keyWordAnyURI = 83,
+            RULE_typesKeywords = 84, RULE_singleType = 85, RULE_atomicType = 86, RULE_nCNameOrKeyWord = 87,
+            RULE_pairConstructor = 88, RULE_arrayConstructor = 89, RULE_uriLiteral = 90,
+            RULE_stringLiteral = 91, RULE_keyWords = 92;
+    public static final String[] ruleNames = {
+            "module", "mainModule", "libraryModule", "prolog", "defaultCollationDecl",
+            "orderingModeDecl", "emptyOrderDecl", "decimalFormatDecl", "dfPropertyName",
+            "moduleImport", "varDecl", "functionDecl", "paramList", "param", "expr",
+            "exprSingle", "flowrExpr", "forClause", "forVar", "letClause", "letVar",
+            "whereClause", "groupByClause", "groupByVar", "orderByClause", "orderByExpr",
+            "countClause", "quantifiedExpr", "quantifiedExprVar", "switchExpr", "switchCaseClause",
+            "typeSwitchExpr", "caseClause", "ifExpr", "tryCatchExpr", "orExpr", "andExpr",
+            "notExpr", "comparisonExpr", "stringConcatExpr", "rangeExpr", "additiveExpr",
+            "multiplicativeExpr", "instanceOfExpr", "treatExpr", "castableExpr", "castExpr",
+            "unaryExpr", "simpleMapExpr", "postFixExpr", "arrayLookup", "arrayUnboxing",
+            "predicate", "objectLookup", "primaryExpr", "varRef", "parenthesizedExpr",
+            "contextItemExpr", "orderedExpr", "unorderedExpr", "functionCall", "argumentList",
+            "argument", "functionItemExpr", "namedFunctionRef", "inlineFunctionExpr",
+            "sequenceType", "objectConstructor", "itemType", "jSONItemTest", "keyWordString",
+            "keyWordInteger", "keyWordDecimal", "keyWordDouble", "keyWordBoolean",
+            "keyWordDuration", "keyWordYearMonthDuration", "keyWordDayTimeDuration",
+            "keyWordHexBinary", "keyWordBase64Binary", "keyWordDateTime", "keyWordDate",
+            "keyWordTime", "keyWordAnyURI", "typesKeywords", "singleType", "atomicType",
+            "nCNameOrKeyWord", "pairConstructor", "arrayConstructor", "uriLiteral",
+            "stringLiteral", "keyWords"
+    };
+
+    private static final String[] _LITERAL_NAMES = {
+            null, "';'", "'module'", "'namespace'", "'='", "'declare'", "'ordering'",
+            "'ordered'", "'unordered'", "'decimal-format'", "':'", "'decimal-separator'",
+            "'grouping-separator'", "'infinity'", "'minus-sign'", "'NaN'", "'percent'",
+            "'per-mille'", "'zero-digit'", "'digit'", "'pattern-separator'", "'import'",
+            "','", "'variable'", "':='", "'external'", "'function'", "'('", "')'",
+            "'{'", "'}'", "'$'", "'|'", "'*'", "'eq'", "'ne'", "'lt'", "'le'", "'gt'",
+            "'ge'", "'!='", "'<'", "'<='", "'>'", "'>='", "'||'", "'+'", "'-'", "'div'",
+            "'idiv'", "'mod'", "'!'", "'['", "']'", "'.'", "'$$'", "'#'", "'{|'",
+            "'|}'", "'item'", "'object'", "'array'", "'string'", "'integer'", "'decimal'",
+            "'double'", "'boolean'", "'duration'", "'yearMonthDuration'", "'dayTimeDuration'",
+            "'hexBinary'", "'base64Binary'", "'dateTime'", "'date'", "'time'", "'anyURI'",
+            "'atomic'", "'for'", "'let'", "'where'", "'group'", "'by'", "'order'",
+            "'return'", "'if'", "'in'", "'as'", "'at'", "'allowing'", "'empty'", "'count'",
+            "'stable'", "'ascending'", "'descending'", "'some'", "'every'", "'satisfies'",
+            "'collation'", "'greatest'", "'least'", "'switch'", "'case'", "'try'",
+            "'catch'", "'default'", "'then'", "'else'", "'typeswitch'", "'or'", "'and'",
+            "'not'", "'to'", "'instance'", "'of'", "'treat'", "'cast'", "'castable'",
+            "'version'", "'jsoniq'", "'json-item'", null, "'?'", "'null'"
+    };
+    private static final String[] _SYMBOLIC_NAMES = {
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null, null,
+            null, null, null, null, null, "Kfor", "Klet", "Kwhere", "Kgroup", "Kby",
+            "Korder", "Kreturn", "Kif", "Kin", "Kas", "Kat", "Kallowing", "Kempty",
+            "Kcount", "Kstable", "Kascending", "Kdescending", "Ksome", "Kevery", "Ksatisfies",
+            "Kcollation", "Kgreatest", "Kleast", "Kswitch", "Kcase", "Ktry", "Kcatch",
+            "Kdefault", "Kthen", "Kelse", "Ktypeswitch", "Kor", "Kand", "Knot", "Kto",
+            "Kinstance", "Kof", "Ktreat", "Kcast", "Kcastable", "Kversion", "Kjsoniq",
+            "Kjson", "STRING", "ArgumentPlaceholder", "NullLiteral", "Literal", "NumericLiteral",
+            "BooleanLiteral", "IntegerLiteral", "DecimalLiteral", "DoubleLiteral",
+            "WS", "NCName", "XQComment", "ContentChar"
+    };
+    public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
+
+    /**
+     * @deprecated Use {@link #VOCABULARY} instead.
+     */
+    @Deprecated
+    public static final String[] tokenNames;
+
+    static {
+        tokenNames = new String[_SYMBOLIC_NAMES.length];
+        for (int i = 0; i < tokenNames.length; i++) {
+            tokenNames[i] = VOCABULARY.getLiteralName(i);
+            if (tokenNames[i] == null) {
+                tokenNames[i] = VOCABULARY.getSymbolicName(i);
+            }
+
+            if (tokenNames[i] == null) {
+                tokenNames[i] = "<INVALID>";
+            }
+        }
+    }
+
+    @Override
+    @Deprecated
+    public String[] getTokenNames() {
+        return tokenNames;
+    }
+
+    @Override
+
+    public Vocabulary getVocabulary() {
+        return VOCABULARY;
+    }
+
+    @Override
+    public String getGrammarFileName() {
+        return "Jsoniq.g4";
+    }
+
+    @Override
+    public String[] getRuleNames() {
+        return ruleNames;
+    }
+
+    @Override
+    public String getSerializedATN() {
+        return _serializedATN;
+    }
+
+    @Override
+    public ATN getATN() {
+        return _ATN;
+    }
+
+    public JsoniqParser(TokenStream input) {
+        super(input);
+        _interp = new ParserATNSimulator(this, _ATN, _decisionToDFA, _sharedContextCache);
+    }
+
+    public static class ModuleContext extends ParserRuleContext {
+        public StringLiteralContext vers;
+        public MainModuleContext main;
+
+        public LibraryModuleContext libraryModule() {
+            return getRuleContext(LibraryModuleContext.class, 0);
+        }
+
+        public TerminalNode Kjsoniq() {
+            return getToken(JsoniqParser.Kjsoniq, 0);
+        }
+
+        public TerminalNode Kversion() {
+            return getToken(JsoniqParser.Kversion, 0);
+        }
+
+        public MainModuleContext mainModule() {
+            return getRuleContext(MainModuleContext.class, 0);
+        }
+
+        public StringLiteralContext stringLiteral() {
+            return getRuleContext(StringLiteralContext.class, 0);
+        }
+
+        public ModuleContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_module;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitModule(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ModuleContext module() throws RecognitionException {
+        ModuleContext _localctx = new ModuleContext(_ctx, getState());
+        enterRule(_localctx, 0, RULE_module);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(191);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 0, _ctx)) {
+                    case 1: {
+                        setState(186);
+                        match(Kjsoniq);
+                        setState(187);
+                        match(Kversion);
+                        setState(188);
+                        ((ModuleContext) _localctx).vers = stringLiteral();
+                        setState(189);
+                        match(T__0);
+                    }
+                    break;
+                }
+                setState(195);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case T__1: {
+                        setState(193);
+                        libraryModule();
+                    }
+                    break;
+                    case T__4:
+                    case T__6:
+                    case T__7:
+                    case T__9:
+                    case T__20:
+                    case T__25:
+                    case T__26:
+                    case T__28:
+                    case T__30:
+                    case T__45:
+                    case T__46:
+                    case T__51:
+                    case T__54:
+                    case T__56:
+                    case T__61:
+                    case T__62:
+                    case T__63:
+                    case T__64:
+                    case T__65:
+                    case T__66:
+                    case T__67:
+                    case T__68:
+                    case T__69:
+                    case T__70:
+                    case T__71:
+                    case T__72:
+                    case T__73:
+                    case T__74:
+                    case Kfor:
+                    case Klet:
+                    case Kwhere:
+                    case Kgroup:
+                    case Kby:
+                    case Korder:
+                    case Kreturn:
+                    case Kif:
+                    case Kin:
+                    case Kas:
+                    case Kat:
+                    case Kallowing:
+                    case Kempty:
+                    case Kcount:
+                    case Kstable:
+                    case Kascending:
+                    case Kdescending:
+                    case Ksome:
+                    case Kevery:
+                    case Ksatisfies:
+                    case Kcollation:
+                    case Kgreatest:
+                    case Kleast:
+                    case Kswitch:
+                    case Kcase:
+                    case Ktry:
+                    case Kcatch:
+                    case Kdefault:
+                    case Kthen:
+                    case Kelse:
+                    case Ktypeswitch:
+                    case Kor:
+                    case Kand:
+                    case Knot:
+                    case Kto:
+                    case Kinstance:
+                    case Kof:
+                    case Ktreat:
+                    case Kcast:
+                    case Kcastable:
+                    case Kversion:
+                    case Kjsoniq:
+                    case Kjson:
+                    case STRING:
+                    case NullLiteral:
+                    case Literal:
+                    case NCName: {
+                        setState(194);
+                        ((ModuleContext) _localctx).main = mainModule();
+                    }
+                    break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class MainModuleContext extends ParserRuleContext {
+        public PrologContext prolog() {
+            return getRuleContext(PrologContext.class, 0);
+        }
+
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public MainModuleContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_mainModule;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitMainModule(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final MainModuleContext mainModule() throws RecognitionException {
+        MainModuleContext _localctx = new MainModuleContext(_ctx, getState());
+        enterRule(_localctx, 2, RULE_mainModule);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(197);
+                prolog();
+                setState(198);
+                expr();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class LibraryModuleContext extends ParserRuleContext {
+        public TerminalNode NCName() {
+            return getToken(JsoniqParser.NCName, 0);
+        }
+
+        public UriLiteralContext uriLiteral() {
+            return getRuleContext(UriLiteralContext.class, 0);
+        }
+
+        public PrologContext prolog() {
+            return getRuleContext(PrologContext.class, 0);
+        }
+
+        public LibraryModuleContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_libraryModule;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitLibraryModule(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final LibraryModuleContext libraryModule() throws RecognitionException {
+        LibraryModuleContext _localctx = new LibraryModuleContext(_ctx, getState());
+        enterRule(_localctx, 4, RULE_libraryModule);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(200);
+                match(T__1);
+                setState(201);
+                match(T__2);
+                setState(202);
+                match(NCName);
+                setState(203);
+                match(T__3);
+                setState(204);
+                uriLiteral();
+                setState(205);
+                match(T__0);
+                setState(206);
+                prolog();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class PrologContext extends ParserRuleContext {
+        public List<DefaultCollationDeclContext> defaultCollationDecl() {
+            return getRuleContexts(DefaultCollationDeclContext.class);
+        }
+
+        public DefaultCollationDeclContext defaultCollationDecl(int i) {
+            return getRuleContext(DefaultCollationDeclContext.class, i);
+        }
+
+        public List<OrderingModeDeclContext> orderingModeDecl() {
+            return getRuleContexts(OrderingModeDeclContext.class);
+        }
+
+        public OrderingModeDeclContext orderingModeDecl(int i) {
+            return getRuleContext(OrderingModeDeclContext.class, i);
+        }
+
+        public List<EmptyOrderDeclContext> emptyOrderDecl() {
+            return getRuleContexts(EmptyOrderDeclContext.class);
+        }
+
+        public EmptyOrderDeclContext emptyOrderDecl(int i) {
+            return getRuleContext(EmptyOrderDeclContext.class, i);
+        }
+
+        public List<DecimalFormatDeclContext> decimalFormatDecl() {
+            return getRuleContexts(DecimalFormatDeclContext.class);
+        }
+
+        public DecimalFormatDeclContext decimalFormatDecl(int i) {
+            return getRuleContext(DecimalFormatDeclContext.class, i);
+        }
+
+        public List<ModuleImportContext> moduleImport() {
+            return getRuleContexts(ModuleImportContext.class);
+        }
+
+        public ModuleImportContext moduleImport(int i) {
+            return getRuleContext(ModuleImportContext.class, i);
+        }
+
+        public List<FunctionDeclContext> functionDecl() {
+            return getRuleContexts(FunctionDeclContext.class);
+        }
+
+        public FunctionDeclContext functionDecl(int i) {
+            return getRuleContext(FunctionDeclContext.class, i);
+        }
+
+        public List<VarDeclContext> varDecl() {
+            return getRuleContexts(VarDeclContext.class);
+        }
+
+        public VarDeclContext varDecl(int i) {
+            return getRuleContext(VarDeclContext.class, i);
+        }
+
+        public PrologContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_prolog;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitProlog(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final PrologContext prolog() throws RecognitionException {
+        PrologContext _localctx = new PrologContext(_ctx, getState());
+        enterRule(_localctx, 6, RULE_prolog);
+        int _la;
+        try {
+            int _alt;
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(219);
+                _errHandler.sync(this);
+                _alt = getInterpreter().adaptivePredict(_input, 3, _ctx);
+                while (_alt != 2 && _alt != org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER) {
+                    if (_alt == 1) {
+                        {
+                            {
+                                setState(213);
+                                _errHandler.sync(this);
+                                switch (getInterpreter().adaptivePredict(_input, 2, _ctx)) {
+                                    case 1: {
+                                        setState(208);
+                                        defaultCollationDecl();
+                                    }
+                                    break;
+                                    case 2: {
+                                        setState(209);
+                                        orderingModeDecl();
+                                    }
+                                    break;
+                                    case 3: {
+                                        setState(210);
+                                        emptyOrderDecl();
+                                    }
+                                    break;
+                                    case 4: {
+                                        setState(211);
+                                        decimalFormatDecl();
+                                    }
+                                    break;
+                                    case 5: {
+                                        setState(212);
+                                        moduleImport();
+                                    }
+                                    break;
+                                }
+                                setState(215);
+                                match(T__0);
+                            }
+                        }
+                    }
+                    setState(221);
+                    _errHandler.sync(this);
+                    _alt = getInterpreter().adaptivePredict(_input, 3, _ctx);
+                }
+                setState(230);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__4) {
+                    {
+                        {
+                            setState(224);
+                            _errHandler.sync(this);
+                            switch (getInterpreter().adaptivePredict(_input, 4, _ctx)) {
+                                case 1: {
+                                    setState(222);
+                                    functionDecl();
+                                }
+                                break;
+                                case 2: {
+                                    setState(223);
+                                    varDecl();
+                                }
+                                break;
+                            }
+                            setState(226);
+                            match(T__0);
+                        }
+                    }
+                    setState(232);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class DefaultCollationDeclContext extends ParserRuleContext {
+        public TerminalNode Kdefault() {
+            return getToken(JsoniqParser.Kdefault, 0);
+        }
+
+        public TerminalNode Kcollation() {
+            return getToken(JsoniqParser.Kcollation, 0);
+        }
+
+        public UriLiteralContext uriLiteral() {
+            return getRuleContext(UriLiteralContext.class, 0);
+        }
+
+        public DefaultCollationDeclContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_defaultCollationDecl;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitDefaultCollationDecl(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final DefaultCollationDeclContext defaultCollationDecl() throws RecognitionException {
+        DefaultCollationDeclContext _localctx = new DefaultCollationDeclContext(_ctx, getState());
+        enterRule(_localctx, 8, RULE_defaultCollationDecl);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(233);
+                match(T__4);
+                setState(234);
+                match(Kdefault);
+                setState(235);
+                match(Kcollation);
+                setState(236);
+                uriLiteral();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class OrderingModeDeclContext extends ParserRuleContext {
+        public OrderingModeDeclContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_orderingModeDecl;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitOrderingModeDecl(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final OrderingModeDeclContext orderingModeDecl() throws RecognitionException {
+        OrderingModeDeclContext _localctx = new OrderingModeDeclContext(_ctx, getState());
+        enterRule(_localctx, 10, RULE_orderingModeDecl);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(238);
+                match(T__4);
+                setState(239);
+                match(T__5);
+                setState(240);
+                _la = _input.LA(1);
+                if (!(_la == T__6 || _la == T__7)) {
+                    _errHandler.recoverInline(this);
+                } else {
+                    if (_input.LA(1) == Token.EOF) {
+                        matchedEOF = true;
+                    }
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class EmptyOrderDeclContext extends ParserRuleContext {
+        public TerminalNode Kdefault() {
+            return getToken(JsoniqParser.Kdefault, 0);
+        }
+
+        public TerminalNode Kempty() {
+            return getToken(JsoniqParser.Kempty, 0);
+        }
+
+        public TerminalNode Kgreatest() {
+            return getToken(JsoniqParser.Kgreatest, 0);
+        }
+
+        public TerminalNode Kleast() {
+            return getToken(JsoniqParser.Kleast, 0);
+        }
+
+        public EmptyOrderDeclContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_emptyOrderDecl;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitEmptyOrderDecl(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final EmptyOrderDeclContext emptyOrderDecl() throws RecognitionException {
+        EmptyOrderDeclContext _localctx = new EmptyOrderDeclContext(_ctx, getState());
+        enterRule(_localctx, 12, RULE_emptyOrderDecl);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(242);
+                match(T__4);
+                setState(243);
+                match(Kdefault);
+                setState(244);
+                match(Korder);
+                setState(245);
+                match(Kempty);
+                setState(246);
+                _la = _input.LA(1);
+                if (!(_la == Kgreatest || _la == Kleast)) {
+                    _errHandler.recoverInline(this);
+                } else {
+                    if (_input.LA(1) == Token.EOF) {
+                        matchedEOF = true;
+                    }
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class DecimalFormatDeclContext extends ParserRuleContext {
+        public List<DfPropertyNameContext> dfPropertyName() {
+            return getRuleContexts(DfPropertyNameContext.class);
+        }
+
+        public DfPropertyNameContext dfPropertyName(int i) {
+            return getRuleContext(DfPropertyNameContext.class, i);
+        }
+
+        public List<StringLiteralContext> stringLiteral() {
+            return getRuleContexts(StringLiteralContext.class);
+        }
+
+        public StringLiteralContext stringLiteral(int i) {
+            return getRuleContext(StringLiteralContext.class, i);
+        }
+
+        public List<TerminalNode> NCName() {
+            return getTokens(JsoniqParser.NCName);
+        }
+
+        public TerminalNode NCName(int i) {
+            return getToken(JsoniqParser.NCName, i);
+        }
+
+        public TerminalNode Kdefault() {
+            return getToken(JsoniqParser.Kdefault, 0);
+        }
+
+        public DecimalFormatDeclContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_decimalFormatDecl;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitDecimalFormatDecl(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final DecimalFormatDeclContext decimalFormatDecl() throws RecognitionException {
+        DecimalFormatDeclContext _localctx = new DecimalFormatDeclContext(_ctx, getState());
+        enterRule(_localctx, 14, RULE_decimalFormatDecl);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(248);
+                match(T__4);
+                setState(257);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case T__8: {
+                        {
+                            setState(249);
+                            match(T__8);
+                            setState(252);
+                            _errHandler.sync(this);
+                            switch (getInterpreter().adaptivePredict(_input, 6, _ctx)) {
+                                case 1: {
+                                    setState(250);
+                                    match(NCName);
+                                    setState(251);
+                                    match(T__9);
+                                }
+                                break;
+                            }
+                            setState(254);
+                            match(NCName);
+                        }
+                    }
+                    break;
+                    case Kdefault: {
+                        {
+                            setState(255);
+                            match(Kdefault);
+                            setState(256);
+                            match(T__8);
+                        }
+                    }
+                    break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+                setState(265);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__10) | (1L << T__11) | (1L << T__12) | (1L << T__13) | (1L << T__14) | (1L << T__15) | (1L << T__16) | (1L << T__17) | (1L << T__18) | (1L << T__19))) != 0)) {
+                    {
+                        {
+                            setState(259);
+                            dfPropertyName();
+                            setState(260);
+                            match(T__3);
+                            setState(261);
+                            stringLiteral();
+                        }
+                    }
+                    setState(267);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class DfPropertyNameContext extends ParserRuleContext {
+        public DfPropertyNameContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_dfPropertyName;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitDfPropertyName(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final DfPropertyNameContext dfPropertyName() throws RecognitionException {
+        DfPropertyNameContext _localctx = new DfPropertyNameContext(_ctx, getState());
+        enterRule(_localctx, 16, RULE_dfPropertyName);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(268);
+                _la = _input.LA(1);
+                if (!((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__10) | (1L << T__11) | (1L << T__12) | (1L << T__13) | (1L << T__14) | (1L << T__15) | (1L << T__16) | (1L << T__17) | (1L << T__18) | (1L << T__19))) != 0))) {
+                    _errHandler.recoverInline(this);
+                } else {
+                    if (_input.LA(1) == Token.EOF) {
+                        matchedEOF = true;
+                    }
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ModuleImportContext extends ParserRuleContext {
+        public List<UriLiteralContext> uriLiteral() {
+            return getRuleContexts(UriLiteralContext.class);
+        }
+
+        public UriLiteralContext uriLiteral(int i) {
+            return getRuleContext(UriLiteralContext.class, i);
+        }
+
+        public TerminalNode NCName() {
+            return getToken(JsoniqParser.NCName, 0);
+        }
+
+        public TerminalNode Kat() {
+            return getToken(JsoniqParser.Kat, 0);
+        }
+
+        public ModuleImportContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_moduleImport;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitModuleImport(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ModuleImportContext moduleImport() throws RecognitionException {
+        ModuleImportContext _localctx = new ModuleImportContext(_ctx, getState());
+        enterRule(_localctx, 18, RULE_moduleImport);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(270);
+                match(T__20);
+                setState(271);
+                match(T__1);
+                setState(275);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == T__2) {
+                    {
+                        setState(272);
+                        match(T__2);
+                        setState(273);
+                        match(NCName);
+                        setState(274);
+                        match(T__3);
+                    }
+                }
+
+                setState(277);
+                uriLiteral();
+                setState(287);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kat) {
+                    {
+                        setState(278);
+                        match(Kat);
+                        setState(279);
+                        uriLiteral();
+                        setState(284);
+                        _errHandler.sync(this);
+                        _la = _input.LA(1);
+                        while (_la == T__21) {
+                            {
+                                {
+                                    setState(280);
+                                    match(T__21);
+                                    setState(281);
+                                    uriLiteral();
+                                }
+                            }
+                            setState(286);
+                            _errHandler.sync(this);
+                            _la = _input.LA(1);
+                        }
+                    }
+                }
+
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class VarDeclContext extends ParserRuleContext {
+        public Token external;
+
+        public VarRefContext varRef() {
+            return getRuleContext(VarRefContext.class, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public VarDeclContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_varDecl;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitVarDecl(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final VarDeclContext varDecl() throws RecognitionException {
+        VarDeclContext _localctx = new VarDeclContext(_ctx, getState());
+        enterRule(_localctx, 20, RULE_varDecl);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(289);
+                match(T__4);
+                setState(290);
+                match(T__22);
+                setState(291);
+                varRef();
+                setState(294);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kas) {
+                    {
+                        setState(292);
+                        match(Kas);
+                        setState(293);
+                        sequenceType();
+                    }
+                }
+
+                setState(303);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case T__23: {
+                        {
+                            setState(296);
+                            match(T__23);
+                            setState(297);
+                            exprSingle();
+                        }
+                    }
+                    break;
+                    case T__24: {
+                        {
+                            setState(298);
+                            ((VarDeclContext) _localctx).external = match(T__24);
+                            setState(301);
+                            _errHandler.sync(this);
+                            _la = _input.LA(1);
+                            if (_la == T__23) {
+                                {
+                                    setState(299);
+                                    match(T__23);
+                                    setState(300);
+                                    exprSingle();
+                                }
+                            }
+
+                        }
+                    }
+                    break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class FunctionDeclContext extends ParserRuleContext {
+        public Token namespace;
+        public Token fn_name;
+        public SequenceTypeContext return_type;
+        public ExprContext fn_body;
+
+        public List<TerminalNode> NCName() {
+            return getTokens(JsoniqParser.NCName);
+        }
+
+        public TerminalNode NCName(int i) {
+            return getToken(JsoniqParser.NCName, i);
+        }
+
+        public ParamListContext paramList() {
+            return getRuleContext(ParamListContext.class, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public FunctionDeclContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_functionDecl;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitFunctionDecl(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final FunctionDeclContext functionDecl() throws RecognitionException {
+        FunctionDeclContext _localctx = new FunctionDeclContext(_ctx, getState());
+        enterRule(_localctx, 22, RULE_functionDecl);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(305);
+                match(T__4);
+                setState(306);
+                match(T__25);
+                setState(309);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 15, _ctx)) {
+                    case 1: {
+                        setState(307);
+                        ((FunctionDeclContext) _localctx).namespace = match(NCName);
+                        setState(308);
+                        match(T__9);
+                    }
+                    break;
+                }
+                setState(311);
+                ((FunctionDeclContext) _localctx).fn_name = match(NCName);
+                setState(312);
+                match(T__26);
+                setState(314);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == T__30) {
+                    {
+                        setState(313);
+                        paramList();
+                    }
+                }
+
+                setState(316);
+                match(T__27);
+                setState(319);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kas) {
+                    {
+                        setState(317);
+                        match(Kas);
+                        setState(318);
+                        ((FunctionDeclContext) _localctx).return_type = sequenceType();
+                    }
+                }
+
+                setState(326);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case T__28: {
+                        setState(321);
+                        match(T__28);
+                        setState(322);
+                        ((FunctionDeclContext) _localctx).fn_body = expr();
+                        setState(323);
+                        match(T__29);
+                    }
+                    break;
+                    case T__24: {
+                        setState(325);
+                        match(T__24);
+                    }
+                    break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ParamListContext extends ParserRuleContext {
+        public List<ParamContext> param() {
+            return getRuleContexts(ParamContext.class);
+        }
+
+        public ParamContext param(int i) {
+            return getRuleContext(ParamContext.class, i);
+        }
+
+        public ParamListContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_paramList;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitParamList(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ParamListContext paramList() throws RecognitionException {
+        ParamListContext _localctx = new ParamListContext(_ctx, getState());
+        enterRule(_localctx, 24, RULE_paramList);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(328);
+                param();
+                setState(333);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__21) {
+                    {
+                        {
+                            setState(329);
+                            match(T__21);
+                            setState(330);
+                            param();
+                        }
+                    }
+                    setState(335);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ParamContext extends ParserRuleContext {
+        public TerminalNode NCName() {
+            return getToken(JsoniqParser.NCName, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public ParamContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_param;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitParam(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ParamContext param() throws RecognitionException {
+        ParamContext _localctx = new ParamContext(_ctx, getState());
+        enterRule(_localctx, 26, RULE_param);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(336);
+                match(T__30);
+                setState(337);
+                match(NCName);
+                setState(340);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kas) {
+                    {
+                        setState(338);
+                        match(Kas);
+                        setState(339);
+                        sequenceType();
+                    }
+                }
+
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ExprContext extends ParserRuleContext {
+        public List<ExprSingleContext> exprSingle() {
+            return getRuleContexts(ExprSingleContext.class);
+        }
+
+        public ExprSingleContext exprSingle(int i) {
+            return getRuleContext(ExprSingleContext.class, i);
+        }
+
+        public ExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_expr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ExprContext expr() throws RecognitionException {
+        ExprContext _localctx = new ExprContext(_ctx, getState());
+        enterRule(_localctx, 28, RULE_expr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(342);
+                exprSingle();
+                setState(347);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__21) {
+                    {
+                        {
+                            setState(343);
+                            match(T__21);
+                            setState(344);
+                            exprSingle();
+                        }
+                    }
+                    setState(349);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ExprSingleContext extends ParserRuleContext {
+        public FlowrExprContext flowrExpr() {
+            return getRuleContext(FlowrExprContext.class, 0);
+        }
+
+        public QuantifiedExprContext quantifiedExpr() {
+            return getRuleContext(QuantifiedExprContext.class, 0);
+        }
+
+        public SwitchExprContext switchExpr() {
+            return getRuleContext(SwitchExprContext.class, 0);
+        }
+
+        public TypeSwitchExprContext typeSwitchExpr() {
+            return getRuleContext(TypeSwitchExprContext.class, 0);
+        }
+
+        public IfExprContext ifExpr() {
+            return getRuleContext(IfExprContext.class, 0);
+        }
+
+        public TryCatchExprContext tryCatchExpr() {
+            return getRuleContext(TryCatchExprContext.class, 0);
+        }
+
+        public OrExprContext orExpr() {
+            return getRuleContext(OrExprContext.class, 0);
+        }
+
+        public ExprSingleContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_exprSingle;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitExprSingle(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ExprSingleContext exprSingle() throws RecognitionException {
+        ExprSingleContext _localctx = new ExprSingleContext(_ctx, getState());
+        enterRule(_localctx, 30, RULE_exprSingle);
+        try {
+            setState(357);
+            _errHandler.sync(this);
+            switch (getInterpreter().adaptivePredict(_input, 22, _ctx)) {
+                case 1:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(350);
+                    flowrExpr();
+                }
+                break;
+                case 2:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(351);
+                    quantifiedExpr();
+                }
+                break;
+                case 3:
+                    enterOuterAlt(_localctx, 3);
+                {
+                    setState(352);
+                    switchExpr();
+                }
+                break;
+                case 4:
+                    enterOuterAlt(_localctx, 4);
+                {
+                    setState(353);
+                    typeSwitchExpr();
+                }
+                break;
+                case 5:
+                    enterOuterAlt(_localctx, 5);
+                {
+                    setState(354);
+                    ifExpr();
+                }
+                break;
+                case 6:
+                    enterOuterAlt(_localctx, 6);
+                {
+                    setState(355);
+                    tryCatchExpr();
+                }
+                break;
+                case 7:
+                    enterOuterAlt(_localctx, 7);
+                {
+                    setState(356);
+                    orExpr();
+                }
+                break;
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class FlowrExprContext extends ParserRuleContext {
+        public ForClauseContext start_for;
+        public LetClauseContext start_let;
+        public ExprSingleContext return_expr;
+
+        public TerminalNode Kreturn() {
+            return getToken(JsoniqParser.Kreturn, 0);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public List<ForClauseContext> forClause() {
+            return getRuleContexts(ForClauseContext.class);
+        }
+
+        public ForClauseContext forClause(int i) {
+            return getRuleContext(ForClauseContext.class, i);
+        }
+
+        public List<LetClauseContext> letClause() {
+            return getRuleContexts(LetClauseContext.class);
+        }
+
+        public LetClauseContext letClause(int i) {
+            return getRuleContext(LetClauseContext.class, i);
+        }
+
+        public List<WhereClauseContext> whereClause() {
+            return getRuleContexts(WhereClauseContext.class);
+        }
+
+        public WhereClauseContext whereClause(int i) {
+            return getRuleContext(WhereClauseContext.class, i);
+        }
+
+        public List<GroupByClauseContext> groupByClause() {
+            return getRuleContexts(GroupByClauseContext.class);
+        }
+
+        public GroupByClauseContext groupByClause(int i) {
+            return getRuleContext(GroupByClauseContext.class, i);
+        }
+
+        public List<OrderByClauseContext> orderByClause() {
+            return getRuleContexts(OrderByClauseContext.class);
+        }
+
+        public OrderByClauseContext orderByClause(int i) {
+            return getRuleContext(OrderByClauseContext.class, i);
+        }
+
+        public List<CountClauseContext> countClause() {
+            return getRuleContexts(CountClauseContext.class);
+        }
+
+        public CountClauseContext countClause(int i) {
+            return getRuleContext(CountClauseContext.class, i);
+        }
+
+        public FlowrExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_flowrExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitFlowrExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final FlowrExprContext flowrExpr() throws RecognitionException {
+        FlowrExprContext _localctx = new FlowrExprContext(_ctx, getState());
+        enterRule(_localctx, 32, RULE_flowrExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(361);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case Kfor: {
+                        setState(359);
+                        ((FlowrExprContext) _localctx).start_for = forClause();
+                    }
+                    break;
+                    case Klet: {
+                        setState(360);
+                        ((FlowrExprContext) _localctx).start_let = letClause();
+                    }
+                    break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+                setState(371);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (((((_la - 77)) & ~0x3f) == 0 && ((1L << (_la - 77)) & ((1L << (Kfor - 77)) | (1L << (Klet - 77)) | (1L << (Kwhere - 77)) | (1L << (Kgroup - 77)) | (1L << (Korder - 77)) | (1L << (Kcount - 77)) | (1L << (Kstable - 77)))) != 0)) {
+                    {
+                        setState(369);
+                        _errHandler.sync(this);
+                        switch (_input.LA(1)) {
+                            case Kfor: {
+                                setState(363);
+                                forClause();
+                            }
+                            break;
+                            case Kwhere: {
+                                setState(364);
+                                whereClause();
+                            }
+                            break;
+                            case Klet: {
+                                setState(365);
+                                letClause();
+                            }
+                            break;
+                            case Kgroup: {
+                                setState(366);
+                                groupByClause();
+                            }
+                            break;
+                            case Korder:
+                            case Kstable: {
+                                setState(367);
+                                orderByClause();
+                            }
+                            break;
+                            case Kcount: {
+                                setState(368);
+                                countClause();
+                            }
+                            break;
+                            default:
+                                throw new NoViableAltException(this);
+                        }
+                    }
+                    setState(373);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+                setState(374);
+                match(Kreturn);
+                setState(375);
+                ((FlowrExprContext) _localctx).return_expr = exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ForClauseContext extends ParserRuleContext {
+        public ForVarContext forVar;
+        public List<ForVarContext> vars = new ArrayList<ForVarContext>();
+
+        public TerminalNode Kfor() {
+            return getToken(JsoniqParser.Kfor, 0);
+        }
+
+        public List<ForVarContext> forVar() {
+            return getRuleContexts(ForVarContext.class);
+        }
+
+        public ForVarContext forVar(int i) {
+            return getRuleContext(ForVarContext.class, i);
+        }
+
+        public ForClauseContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_forClause;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitForClause(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ForClauseContext forClause() throws RecognitionException {
+        ForClauseContext _localctx = new ForClauseContext(_ctx, getState());
+        enterRule(_localctx, 34, RULE_forClause);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(377);
+                match(Kfor);
+                setState(378);
+                ((ForClauseContext) _localctx).forVar = forVar();
+                ((ForClauseContext) _localctx).vars.add(((ForClauseContext) _localctx).forVar);
+                setState(383);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__21) {
+                    {
+                        {
+                            setState(379);
+                            match(T__21);
+                            setState(380);
+                            ((ForClauseContext) _localctx).forVar = forVar();
+                            ((ForClauseContext) _localctx).vars.add(((ForClauseContext) _localctx).forVar);
+                        }
+                    }
+                    setState(385);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ForVarContext extends ParserRuleContext {
+        public VarRefContext var_ref;
+        public SequenceTypeContext seq;
+        public Token flag;
+        public VarRefContext at;
+        public ExprSingleContext ex;
+
+        public TerminalNode Kin() {
+            return getToken(JsoniqParser.Kin, 0);
+        }
+
+        public List<VarRefContext> varRef() {
+            return getRuleContexts(VarRefContext.class);
+        }
+
+        public VarRefContext varRef(int i) {
+            return getRuleContext(VarRefContext.class, i);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public TerminalNode Kempty() {
+            return getToken(JsoniqParser.Kempty, 0);
+        }
+
+        public TerminalNode Kat() {
+            return getToken(JsoniqParser.Kat, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public TerminalNode Kallowing() {
+            return getToken(JsoniqParser.Kallowing, 0);
+        }
+
+        public ForVarContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_forVar;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitForVar(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ForVarContext forVar() throws RecognitionException {
+        ForVarContext _localctx = new ForVarContext(_ctx, getState());
+        enterRule(_localctx, 36, RULE_forVar);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(386);
+                ((ForVarContext) _localctx).var_ref = varRef();
+                setState(389);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kas) {
+                    {
+                        setState(387);
+                        match(Kas);
+                        setState(388);
+                        ((ForVarContext) _localctx).seq = sequenceType();
+                    }
+                }
+
+                setState(393);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kallowing) {
+                    {
+                        setState(391);
+                        ((ForVarContext) _localctx).flag = match(Kallowing);
+                        setState(392);
+                        match(Kempty);
+                    }
+                }
+
+                setState(397);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kat) {
+                    {
+                        setState(395);
+                        match(Kat);
+                        setState(396);
+                        ((ForVarContext) _localctx).at = varRef();
+                    }
+                }
+
+                setState(399);
+                match(Kin);
+                setState(400);
+                ((ForVarContext) _localctx).ex = exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class LetClauseContext extends ParserRuleContext {
+        public LetVarContext letVar;
+        public List<LetVarContext> vars = new ArrayList<LetVarContext>();
+
+        public TerminalNode Klet() {
+            return getToken(JsoniqParser.Klet, 0);
+        }
+
+        public List<LetVarContext> letVar() {
+            return getRuleContexts(LetVarContext.class);
+        }
+
+        public LetVarContext letVar(int i) {
+            return getRuleContext(LetVarContext.class, i);
+        }
+
+        public LetClauseContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_letClause;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitLetClause(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final LetClauseContext letClause() throws RecognitionException {
+        LetClauseContext _localctx = new LetClauseContext(_ctx, getState());
+        enterRule(_localctx, 38, RULE_letClause);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(402);
+                match(Klet);
+                setState(403);
+                ((LetClauseContext) _localctx).letVar = letVar();
+                ((LetClauseContext) _localctx).vars.add(((LetClauseContext) _localctx).letVar);
+                setState(408);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__21) {
+                    {
+                        {
+                            setState(404);
+                            match(T__21);
+                            setState(405);
+                            ((LetClauseContext) _localctx).letVar = letVar();
+                            ((LetClauseContext) _localctx).vars.add(((LetClauseContext) _localctx).letVar);
+                        }
+                    }
+                    setState(410);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class LetVarContext extends ParserRuleContext {
+        public VarRefContext var_ref;
+        public SequenceTypeContext seq;
+        public ExprSingleContext ex;
+
+        public VarRefContext varRef() {
+            return getRuleContext(VarRefContext.class, 0);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public LetVarContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_letVar;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitLetVar(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final LetVarContext letVar() throws RecognitionException {
+        LetVarContext _localctx = new LetVarContext(_ctx, getState());
+        enterRule(_localctx, 40, RULE_letVar);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(411);
+                ((LetVarContext) _localctx).var_ref = varRef();
+                setState(414);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kas) {
+                    {
+                        setState(412);
+                        match(Kas);
+                        setState(413);
+                        ((LetVarContext) _localctx).seq = sequenceType();
+                    }
+                }
+
+                setState(416);
+                match(T__23);
+                setState(417);
+                ((LetVarContext) _localctx).ex = exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class WhereClauseContext extends ParserRuleContext {
+        public TerminalNode Kwhere() {
+            return getToken(JsoniqParser.Kwhere, 0);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public WhereClauseContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_whereClause;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitWhereClause(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final WhereClauseContext whereClause() throws RecognitionException {
+        WhereClauseContext _localctx = new WhereClauseContext(_ctx, getState());
+        enterRule(_localctx, 42, RULE_whereClause);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(419);
+                match(Kwhere);
+                setState(420);
+                exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class GroupByClauseContext extends ParserRuleContext {
+        public GroupByVarContext groupByVar;
+        public List<GroupByVarContext> vars = new ArrayList<GroupByVarContext>();
+
+        public TerminalNode Kgroup() {
+            return getToken(JsoniqParser.Kgroup, 0);
+        }
+
+        public TerminalNode Kby() {
+            return getToken(JsoniqParser.Kby, 0);
+        }
+
+        public List<GroupByVarContext> groupByVar() {
+            return getRuleContexts(GroupByVarContext.class);
+        }
+
+        public GroupByVarContext groupByVar(int i) {
+            return getRuleContext(GroupByVarContext.class, i);
+        }
+
+        public GroupByClauseContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_groupByClause;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitGroupByClause(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final GroupByClauseContext groupByClause() throws RecognitionException {
+        GroupByClauseContext _localctx = new GroupByClauseContext(_ctx, getState());
+        enterRule(_localctx, 44, RULE_groupByClause);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(422);
+                match(Kgroup);
+                setState(423);
+                match(Kby);
+                setState(424);
+                ((GroupByClauseContext) _localctx).groupByVar = groupByVar();
+                ((GroupByClauseContext) _localctx).vars.add(((GroupByClauseContext) _localctx).groupByVar);
+                setState(429);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__21) {
+                    {
+                        {
+                            setState(425);
+                            match(T__21);
+                            setState(426);
+                            ((GroupByClauseContext) _localctx).groupByVar = groupByVar();
+                            ((GroupByClauseContext) _localctx).vars.add(((GroupByClauseContext) _localctx).groupByVar);
+                        }
+                    }
+                    setState(431);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class GroupByVarContext extends ParserRuleContext {
+        public VarRefContext var_ref;
+        public SequenceTypeContext seq;
+        public Token decl;
+        public ExprSingleContext ex;
+        public UriLiteralContext uri;
+
+        public VarRefContext varRef() {
+            return getRuleContext(VarRefContext.class, 0);
+        }
+
+        public TerminalNode Kcollation() {
+            return getToken(JsoniqParser.Kcollation, 0);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public UriLiteralContext uriLiteral() {
+            return getRuleContext(UriLiteralContext.class, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public GroupByVarContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_groupByVar;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitGroupByVar(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final GroupByVarContext groupByVar() throws RecognitionException {
+        GroupByVarContext _localctx = new GroupByVarContext(_ctx, getState());
+        enterRule(_localctx, 46, RULE_groupByVar);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(432);
+                ((GroupByVarContext) _localctx).var_ref = varRef();
+                setState(439);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == T__23 || _la == Kas) {
+                    {
+                        setState(435);
+                        _errHandler.sync(this);
+                        _la = _input.LA(1);
+                        if (_la == Kas) {
+                            {
+                                setState(433);
+                                match(Kas);
+                                setState(434);
+                                ((GroupByVarContext) _localctx).seq = sequenceType();
+                            }
+                        }
+
+                        setState(437);
+                        ((GroupByVarContext) _localctx).decl = match(T__23);
+                        setState(438);
+                        ((GroupByVarContext) _localctx).ex = exprSingle();
+                    }
+                }
+
+                setState(443);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kcollation) {
+                    {
+                        setState(441);
+                        match(Kcollation);
+                        setState(442);
+                        ((GroupByVarContext) _localctx).uri = uriLiteral();
+                    }
+                }
+
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class OrderByClauseContext extends ParserRuleContext {
+        public Token stb;
+
+        public List<OrderByExprContext> orderByExpr() {
+            return getRuleContexts(OrderByExprContext.class);
+        }
+
+        public OrderByExprContext orderByExpr(int i) {
+            return getRuleContext(OrderByExprContext.class, i);
+        }
+
+        public TerminalNode Korder() {
+            return getToken(JsoniqParser.Korder, 0);
+        }
+
+        public TerminalNode Kby() {
+            return getToken(JsoniqParser.Kby, 0);
+        }
+
+        public TerminalNode Kstable() {
+            return getToken(JsoniqParser.Kstable, 0);
+        }
+
+        public OrderByClauseContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_orderByClause;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitOrderByClause(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final OrderByClauseContext orderByClause() throws RecognitionException {
+        OrderByClauseContext _localctx = new OrderByClauseContext(_ctx, getState());
+        enterRule(_localctx, 48, RULE_orderByClause);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(450);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case Korder: {
+                        {
+                            setState(445);
+                            match(Korder);
+                            setState(446);
+                            match(Kby);
+                        }
+                    }
+                    break;
+                    case Kstable: {
+                        {
+                            setState(447);
+                            ((OrderByClauseContext) _localctx).stb = match(Kstable);
+                            setState(448);
+                            match(Korder);
+                            setState(449);
+                            match(Kby);
+                        }
+                    }
+                    break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+                setState(452);
+                orderByExpr();
+                setState(457);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__21) {
+                    {
+                        {
+                            setState(453);
+                            match(T__21);
+                            setState(454);
+                            orderByExpr();
+                        }
+                    }
+                    setState(459);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class OrderByExprContext extends ParserRuleContext {
+        public ExprSingleContext ex;
+        public Token desc;
+        public Token gr;
+        public Token ls;
+        public UriLiteralContext uril;
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public TerminalNode Kascending() {
+            return getToken(JsoniqParser.Kascending, 0);
+        }
+
+        public TerminalNode Kempty() {
+            return getToken(JsoniqParser.Kempty, 0);
+        }
+
+        public TerminalNode Kcollation() {
+            return getToken(JsoniqParser.Kcollation, 0);
+        }
+
+        public TerminalNode Kdescending() {
+            return getToken(JsoniqParser.Kdescending, 0);
+        }
+
+        public UriLiteralContext uriLiteral() {
+            return getRuleContext(UriLiteralContext.class, 0);
+        }
+
+        public TerminalNode Kgreatest() {
+            return getToken(JsoniqParser.Kgreatest, 0);
+        }
+
+        public TerminalNode Kleast() {
+            return getToken(JsoniqParser.Kleast, 0);
+        }
+
+        public OrderByExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_orderByExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitOrderByExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final OrderByExprContext orderByExpr() throws RecognitionException {
+        OrderByExprContext _localctx = new OrderByExprContext(_ctx, getState());
+        enterRule(_localctx, 50, RULE_orderByExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(460);
+                ((OrderByExprContext) _localctx).ex = exprSingle();
+                setState(463);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case Kascending: {
+                        setState(461);
+                        match(Kascending);
+                    }
+                    break;
+                    case Kdescending: {
+                        setState(462);
+                        ((OrderByExprContext) _localctx).desc = match(Kdescending);
+                    }
+                    break;
+                    case T__21:
+                    case Kfor:
+                    case Klet:
+                    case Kwhere:
+                    case Kgroup:
+                    case Korder:
+                    case Kreturn:
+                    case Kempty:
+                    case Kcount:
+                    case Kstable:
+                    case Kcollation:
+                        break;
+                    default:
+                        break;
+                }
+                setState(470);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kempty) {
+                    {
+                        setState(465);
+                        match(Kempty);
+                        setState(468);
+                        _errHandler.sync(this);
+                        switch (_input.LA(1)) {
+                            case Kgreatest: {
+                                setState(466);
+                                ((OrderByExprContext) _localctx).gr = match(Kgreatest);
+                            }
+                            break;
+                            case Kleast: {
+                                setState(467);
+                                ((OrderByExprContext) _localctx).ls = match(Kleast);
+                            }
+                            break;
+                            default:
+                                throw new NoViableAltException(this);
+                        }
+                    }
+                }
+
+                setState(474);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kcollation) {
+                    {
+                        setState(472);
+                        match(Kcollation);
+                        setState(473);
+                        ((OrderByExprContext) _localctx).uril = uriLiteral();
+                    }
+                }
+
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class CountClauseContext extends ParserRuleContext {
+        public TerminalNode Kcount() {
+            return getToken(JsoniqParser.Kcount, 0);
+        }
+
+        public VarRefContext varRef() {
+            return getRuleContext(VarRefContext.class, 0);
+        }
+
+        public CountClauseContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_countClause;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitCountClause(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final CountClauseContext countClause() throws RecognitionException {
+        CountClauseContext _localctx = new CountClauseContext(_ctx, getState());
+        enterRule(_localctx, 52, RULE_countClause);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(476);
+                match(Kcount);
+                setState(477);
+                varRef();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class QuantifiedExprContext extends ParserRuleContext {
+        public Token so;
+        public Token ev;
+        public QuantifiedExprVarContext quantifiedExprVar;
+        public List<QuantifiedExprVarContext> vars = new ArrayList<QuantifiedExprVarContext>();
+
+        public TerminalNode Ksatisfies() {
+            return getToken(JsoniqParser.Ksatisfies, 0);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public List<QuantifiedExprVarContext> quantifiedExprVar() {
+            return getRuleContexts(QuantifiedExprVarContext.class);
+        }
+
+        public QuantifiedExprVarContext quantifiedExprVar(int i) {
+            return getRuleContext(QuantifiedExprVarContext.class, i);
+        }
+
+        public TerminalNode Ksome() {
+            return getToken(JsoniqParser.Ksome, 0);
+        }
+
+        public TerminalNode Kevery() {
+            return getToken(JsoniqParser.Kevery, 0);
+        }
+
+        public QuantifiedExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_quantifiedExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitQuantifiedExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final QuantifiedExprContext quantifiedExpr() throws RecognitionException {
+        QuantifiedExprContext _localctx = new QuantifiedExprContext(_ctx, getState());
+        enterRule(_localctx, 54, RULE_quantifiedExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(481);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case Ksome: {
+                        setState(479);
+                        ((QuantifiedExprContext) _localctx).so = match(Ksome);
+                    }
+                    break;
+                    case Kevery: {
+                        setState(480);
+                        ((QuantifiedExprContext) _localctx).ev = match(Kevery);
+                    }
+                    break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+                setState(483);
+                ((QuantifiedExprContext) _localctx).quantifiedExprVar = quantifiedExprVar();
+                ((QuantifiedExprContext) _localctx).vars.add(((QuantifiedExprContext) _localctx).quantifiedExprVar);
+                setState(488);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__21) {
+                    {
+                        {
+                            setState(484);
+                            match(T__21);
+                            setState(485);
+                            ((QuantifiedExprContext) _localctx).quantifiedExprVar = quantifiedExprVar();
+                            ((QuantifiedExprContext) _localctx).vars.add(((QuantifiedExprContext) _localctx).quantifiedExprVar);
+                        }
+                    }
+                    setState(490);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+                setState(491);
+                match(Ksatisfies);
+                setState(492);
+                exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class QuantifiedExprVarContext extends ParserRuleContext {
+        public VarRefContext varRef() {
+            return getRuleContext(VarRefContext.class, 0);
+        }
+
+        public TerminalNode Kin() {
+            return getToken(JsoniqParser.Kin, 0);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public QuantifiedExprVarContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_quantifiedExprVar;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitQuantifiedExprVar(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final QuantifiedExprVarContext quantifiedExprVar() throws RecognitionException {
+        QuantifiedExprVarContext _localctx = new QuantifiedExprVarContext(_ctx, getState());
+        enterRule(_localctx, 56, RULE_quantifiedExprVar);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(494);
+                varRef();
+                setState(497);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kas) {
+                    {
+                        setState(495);
+                        match(Kas);
+                        setState(496);
+                        sequenceType();
+                    }
+                }
+
+                setState(499);
+                match(Kin);
+                setState(500);
+                exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class SwitchExprContext extends ParserRuleContext {
+        public ExprContext cond;
+        public SwitchCaseClauseContext switchCaseClause;
+        public List<SwitchCaseClauseContext> cases = new ArrayList<SwitchCaseClauseContext>();
+        public ExprSingleContext def;
+
+        public TerminalNode Kswitch() {
+            return getToken(JsoniqParser.Kswitch, 0);
+        }
+
+        public TerminalNode Kdefault() {
+            return getToken(JsoniqParser.Kdefault, 0);
+        }
+
+        public TerminalNode Kreturn() {
+            return getToken(JsoniqParser.Kreturn, 0);
+        }
+
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public List<SwitchCaseClauseContext> switchCaseClause() {
+            return getRuleContexts(SwitchCaseClauseContext.class);
+        }
+
+        public SwitchCaseClauseContext switchCaseClause(int i) {
+            return getRuleContext(SwitchCaseClauseContext.class, i);
+        }
+
+        public SwitchExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_switchExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitSwitchExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final SwitchExprContext switchExpr() throws RecognitionException {
+        SwitchExprContext _localctx = new SwitchExprContext(_ctx, getState());
+        enterRule(_localctx, 58, RULE_switchExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(502);
+                match(Kswitch);
+                setState(503);
+                match(T__26);
+                setState(504);
+                ((SwitchExprContext) _localctx).cond = expr();
+                setState(505);
+                match(T__27);
+                setState(507);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                do {
+                    {
+                        {
+                            setState(506);
+                            ((SwitchExprContext) _localctx).switchCaseClause = switchCaseClause();
+                            ((SwitchExprContext) _localctx).cases.add(((SwitchExprContext) _localctx).switchCaseClause);
+                        }
+                    }
+                    setState(509);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                } while (_la == Kcase);
+                setState(511);
+                match(Kdefault);
+                setState(512);
+                match(Kreturn);
+                setState(513);
+                ((SwitchExprContext) _localctx).def = exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class SwitchCaseClauseContext extends ParserRuleContext {
+        public ExprSingleContext exprSingle;
+        public List<ExprSingleContext> cond = new ArrayList<ExprSingleContext>();
+        public ExprSingleContext ret;
+
+        public TerminalNode Kreturn() {
+            return getToken(JsoniqParser.Kreturn, 0);
+        }
+
+        public List<ExprSingleContext> exprSingle() {
+            return getRuleContexts(ExprSingleContext.class);
+        }
+
+        public ExprSingleContext exprSingle(int i) {
+            return getRuleContext(ExprSingleContext.class, i);
+        }
+
+        public List<TerminalNode> Kcase() {
+            return getTokens(JsoniqParser.Kcase);
+        }
+
+        public TerminalNode Kcase(int i) {
+            return getToken(JsoniqParser.Kcase, i);
+        }
+
+        public SwitchCaseClauseContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_switchCaseClause;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitSwitchCaseClause(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final SwitchCaseClauseContext switchCaseClause() throws RecognitionException {
+        SwitchCaseClauseContext _localctx = new SwitchCaseClauseContext(_ctx, getState());
+        enterRule(_localctx, 60, RULE_switchCaseClause);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(517);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                do {
+                    {
+                        {
+                            setState(515);
+                            match(Kcase);
+                            setState(516);
+                            ((SwitchCaseClauseContext) _localctx).exprSingle = exprSingle();
+                            ((SwitchCaseClauseContext) _localctx).cond.add(((SwitchCaseClauseContext) _localctx).exprSingle);
+                        }
+                    }
+                    setState(519);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                } while (_la == Kcase);
+                setState(521);
+                match(Kreturn);
+                setState(522);
+                ((SwitchCaseClauseContext) _localctx).ret = exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class TypeSwitchExprContext extends ParserRuleContext {
+        public ExprContext cond;
+        public CaseClauseContext caseClause;
+        public List<CaseClauseContext> cses = new ArrayList<CaseClauseContext>();
+        public VarRefContext var_ref;
+        public ExprSingleContext def;
+
+        public TerminalNode Ktypeswitch() {
+            return getToken(JsoniqParser.Ktypeswitch, 0);
+        }
+
+        public TerminalNode Kdefault() {
+            return getToken(JsoniqParser.Kdefault, 0);
+        }
+
+        public TerminalNode Kreturn() {
+            return getToken(JsoniqParser.Kreturn, 0);
+        }
+
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public List<CaseClauseContext> caseClause() {
+            return getRuleContexts(CaseClauseContext.class);
+        }
+
+        public CaseClauseContext caseClause(int i) {
+            return getRuleContext(CaseClauseContext.class, i);
+        }
+
+        public VarRefContext varRef() {
+            return getRuleContext(VarRefContext.class, 0);
+        }
+
+        public TypeSwitchExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_typeSwitchExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitTypeSwitchExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final TypeSwitchExprContext typeSwitchExpr() throws RecognitionException {
+        TypeSwitchExprContext _localctx = new TypeSwitchExprContext(_ctx, getState());
+        enterRule(_localctx, 62, RULE_typeSwitchExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(524);
+                match(Ktypeswitch);
+                setState(525);
+                match(T__26);
+                setState(526);
+                ((TypeSwitchExprContext) _localctx).cond = expr();
+                setState(527);
+                match(T__27);
+                setState(529);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                do {
+                    {
+                        {
+                            setState(528);
+                            ((TypeSwitchExprContext) _localctx).caseClause = caseClause();
+                            ((TypeSwitchExprContext) _localctx).cses.add(((TypeSwitchExprContext) _localctx).caseClause);
+                        }
+                    }
+                    setState(531);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                } while (_la == Kcase);
+                setState(533);
+                match(Kdefault);
+                setState(535);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == T__30) {
+                    {
+                        setState(534);
+                        ((TypeSwitchExprContext) _localctx).var_ref = varRef();
+                    }
+                }
+
+                setState(537);
+                match(Kreturn);
+                setState(538);
+                ((TypeSwitchExprContext) _localctx).def = exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class CaseClauseContext extends ParserRuleContext {
+        public VarRefContext var_ref;
+        public SequenceTypeContext sequenceType;
+        public List<SequenceTypeContext> union = new ArrayList<SequenceTypeContext>();
+        public ExprSingleContext ret;
+
+        public TerminalNode Kcase() {
+            return getToken(JsoniqParser.Kcase, 0);
+        }
+
+        public TerminalNode Kreturn() {
+            return getToken(JsoniqParser.Kreturn, 0);
+        }
+
+        public List<SequenceTypeContext> sequenceType() {
+            return getRuleContexts(SequenceTypeContext.class);
+        }
+
+        public SequenceTypeContext sequenceType(int i) {
+            return getRuleContext(SequenceTypeContext.class, i);
+        }
+
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public VarRefContext varRef() {
+            return getRuleContext(VarRefContext.class, 0);
+        }
+
+        public CaseClauseContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_caseClause;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitCaseClause(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final CaseClauseContext caseClause() throws RecognitionException {
+        CaseClauseContext _localctx = new CaseClauseContext(_ctx, getState());
+        enterRule(_localctx, 64, RULE_caseClause);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(540);
+                match(Kcase);
+                setState(544);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == T__30) {
+                    {
+                        setState(541);
+                        ((CaseClauseContext) _localctx).var_ref = varRef();
+                        setState(542);
+                        match(Kas);
+                    }
+                }
+
+                setState(546);
+                ((CaseClauseContext) _localctx).sequenceType = sequenceType();
+                ((CaseClauseContext) _localctx).union.add(((CaseClauseContext) _localctx).sequenceType);
+                setState(551);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__31) {
+                    {
+                        {
+                            setState(547);
+                            match(T__31);
+                            setState(548);
+                            ((CaseClauseContext) _localctx).sequenceType = sequenceType();
+                            ((CaseClauseContext) _localctx).union.add(((CaseClauseContext) _localctx).sequenceType);
+                        }
+                    }
+                    setState(553);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+                setState(554);
+                match(Kreturn);
+                setState(555);
+                ((CaseClauseContext) _localctx).ret = exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class IfExprContext extends ParserRuleContext {
+        public ExprContext test_condition;
+        public ExprSingleContext branch;
+        public ExprSingleContext else_branch;
+
+        public TerminalNode Kif() {
+            return getToken(JsoniqParser.Kif, 0);
+        }
+
+        public TerminalNode Kthen() {
+            return getToken(JsoniqParser.Kthen, 0);
+        }
+
+        public TerminalNode Kelse() {
+            return getToken(JsoniqParser.Kelse, 0);
+        }
+
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public List<ExprSingleContext> exprSingle() {
+            return getRuleContexts(ExprSingleContext.class);
+        }
+
+        public ExprSingleContext exprSingle(int i) {
+            return getRuleContext(ExprSingleContext.class, i);
+        }
+
+        public IfExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_ifExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitIfExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final IfExprContext ifExpr() throws RecognitionException {
+        IfExprContext _localctx = new IfExprContext(_ctx, getState());
+        enterRule(_localctx, 66, RULE_ifExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(557);
+                match(Kif);
+                setState(558);
+                match(T__26);
+                setState(559);
+                ((IfExprContext) _localctx).test_condition = expr();
+                setState(560);
+                match(T__27);
+                setState(561);
+                match(Kthen);
+                setState(562);
+                ((IfExprContext) _localctx).branch = exprSingle();
+                setState(563);
+                match(Kelse);
+                setState(564);
+                ((IfExprContext) _localctx).else_branch = exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class TryCatchExprContext extends ParserRuleContext {
+        public TerminalNode Ktry() {
+            return getToken(JsoniqParser.Ktry, 0);
+        }
+
+        public List<ExprContext> expr() {
+            return getRuleContexts(ExprContext.class);
+        }
+
+        public ExprContext expr(int i) {
+            return getRuleContext(ExprContext.class, i);
+        }
+
+        public TerminalNode Kcatch() {
+            return getToken(JsoniqParser.Kcatch, 0);
+        }
+
+        public TryCatchExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_tryCatchExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitTryCatchExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final TryCatchExprContext tryCatchExpr() throws RecognitionException {
+        TryCatchExprContext _localctx = new TryCatchExprContext(_ctx, getState());
+        enterRule(_localctx, 68, RULE_tryCatchExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(566);
+                match(Ktry);
+                setState(567);
+                match(T__28);
+                setState(568);
+                expr();
+                setState(569);
+                match(T__29);
+                setState(570);
+                match(Kcatch);
+                setState(571);
+                match(T__32);
+                setState(572);
+                match(T__28);
+                setState(573);
+                expr();
+                setState(574);
+                match(T__29);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class OrExprContext extends ParserRuleContext {
+        public AndExprContext main_expr;
+        public AndExprContext andExpr;
+        public List<AndExprContext> rhs = new ArrayList<AndExprContext>();
+
+        public List<AndExprContext> andExpr() {
+            return getRuleContexts(AndExprContext.class);
+        }
+
+        public AndExprContext andExpr(int i) {
+            return getRuleContext(AndExprContext.class, i);
+        }
+
+        public List<TerminalNode> Kor() {
+            return getTokens(JsoniqParser.Kor);
+        }
+
+        public TerminalNode Kor(int i) {
+            return getToken(JsoniqParser.Kor, i);
+        }
+
+        public OrExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_orExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitOrExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final OrExprContext orExpr() throws RecognitionException {
+        OrExprContext _localctx = new OrExprContext(_ctx, getState());
+        enterRule(_localctx, 70, RULE_orExpr);
+        try {
+            int _alt;
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(576);
+                ((OrExprContext) _localctx).main_expr = andExpr();
+                setState(581);
+                _errHandler.sync(this);
+                _alt = getInterpreter().adaptivePredict(_input, 51, _ctx);
+                while (_alt != 2 && _alt != org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER) {
+                    if (_alt == 1) {
+                        {
+                            {
+                                setState(577);
+                                match(Kor);
+                                setState(578);
+                                ((OrExprContext) _localctx).andExpr = andExpr();
+                                ((OrExprContext) _localctx).rhs.add(((OrExprContext) _localctx).andExpr);
+                            }
+                        }
+                    }
+                    setState(583);
+                    _errHandler.sync(this);
+                    _alt = getInterpreter().adaptivePredict(_input, 51, _ctx);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class AndExprContext extends ParserRuleContext {
+        public NotExprContext main_expr;
+        public NotExprContext notExpr;
+        public List<NotExprContext> rhs = new ArrayList<NotExprContext>();
+
+        public List<NotExprContext> notExpr() {
+            return getRuleContexts(NotExprContext.class);
+        }
+
+        public NotExprContext notExpr(int i) {
+            return getRuleContext(NotExprContext.class, i);
+        }
+
+        public List<TerminalNode> Kand() {
+            return getTokens(JsoniqParser.Kand);
+        }
+
+        public TerminalNode Kand(int i) {
+            return getToken(JsoniqParser.Kand, i);
+        }
+
+        public AndExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_andExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitAndExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final AndExprContext andExpr() throws RecognitionException {
+        AndExprContext _localctx = new AndExprContext(_ctx, getState());
+        enterRule(_localctx, 72, RULE_andExpr);
+        try {
+            int _alt;
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(584);
+                ((AndExprContext) _localctx).main_expr = notExpr();
+                setState(589);
+                _errHandler.sync(this);
+                _alt = getInterpreter().adaptivePredict(_input, 52, _ctx);
+                while (_alt != 2 && _alt != org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER) {
+                    if (_alt == 1) {
+                        {
+                            {
+                                setState(585);
+                                match(Kand);
+                                setState(586);
+                                ((AndExprContext) _localctx).notExpr = notExpr();
+                                ((AndExprContext) _localctx).rhs.add(((AndExprContext) _localctx).notExpr);
+                            }
+                        }
+                    }
+                    setState(591);
+                    _errHandler.sync(this);
+                    _alt = getInterpreter().adaptivePredict(_input, 52, _ctx);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class NotExprContext extends ParserRuleContext {
+        public Token Knot;
+        public List<Token> op = new ArrayList<Token>();
+        public ComparisonExprContext main_expr;
+
+        public ComparisonExprContext comparisonExpr() {
+            return getRuleContext(ComparisonExprContext.class, 0);
+        }
+
+        public TerminalNode Knot() {
+            return getToken(JsoniqParser.Knot, 0);
+        }
+
+        public NotExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_notExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitNotExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final NotExprContext notExpr() throws RecognitionException {
+        NotExprContext _localctx = new NotExprContext(_ctx, getState());
+        enterRule(_localctx, 74, RULE_notExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(593);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 53, _ctx)) {
+                    case 1: {
+                        setState(592);
+                        ((NotExprContext) _localctx).Knot = match(Knot);
+                        ((NotExprContext) _localctx).op.add(((NotExprContext) _localctx).Knot);
+                    }
+                    break;
+                }
+                setState(595);
+                ((NotExprContext) _localctx).main_expr = comparisonExpr();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ComparisonExprContext extends ParserRuleContext {
+        public StringConcatExprContext main_expr;
+        public Token s34;
+        public List<Token> op = new ArrayList<Token>();
+        public Token s35;
+        public Token s36;
+        public Token s37;
+        public Token s38;
+        public Token s39;
+        public Token s4;
+        public Token s40;
+        public Token s41;
+        public Token s42;
+        public Token s43;
+        public Token s44;
+        public Token _tset1051;
+        public StringConcatExprContext stringConcatExpr;
+        public List<StringConcatExprContext> rhs = new ArrayList<StringConcatExprContext>();
+
+        public List<StringConcatExprContext> stringConcatExpr() {
+            return getRuleContexts(StringConcatExprContext.class);
+        }
+
+        public StringConcatExprContext stringConcatExpr(int i) {
+            return getRuleContext(StringConcatExprContext.class, i);
+        }
+
+        public ComparisonExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_comparisonExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitComparisonExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ComparisonExprContext comparisonExpr() throws RecognitionException {
+        ComparisonExprContext _localctx = new ComparisonExprContext(_ctx, getState());
+        enterRule(_localctx, 76, RULE_comparisonExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(597);
+                ((ComparisonExprContext) _localctx).main_expr = stringConcatExpr();
+                setState(600);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__3) | (1L << T__33) | (1L << T__34) | (1L << T__35) | (1L << T__36) | (1L << T__37) | (1L << T__38) | (1L << T__39) | (1L << T__40) | (1L << T__41) | (1L << T__42) | (1L << T__43))) != 0)) {
+                    {
+                        setState(598);
+                        ((ComparisonExprContext) _localctx)._tset1051 = _input.LT(1);
+                        _la = _input.LA(1);
+                        if (!((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__3) | (1L << T__33) | (1L << T__34) | (1L << T__35) | (1L << T__36) | (1L << T__37) | (1L << T__38) | (1L << T__39) | (1L << T__40) | (1L << T__41) | (1L << T__42) | (1L << T__43))) != 0))) {
+                            ((ComparisonExprContext) _localctx)._tset1051 = (Token) _errHandler.recoverInline(this);
+                        } else {
+                            if (_input.LA(1) == Token.EOF) {
+                                matchedEOF = true;
+                            }
+                            _errHandler.reportMatch(this);
+                            consume();
+                        }
+                        ((ComparisonExprContext) _localctx).op.add(((ComparisonExprContext) _localctx)._tset1051);
+                        setState(599);
+                        ((ComparisonExprContext) _localctx).stringConcatExpr = stringConcatExpr();
+                        ((ComparisonExprContext) _localctx).rhs.add(((ComparisonExprContext) _localctx).stringConcatExpr);
+                    }
+                }
+
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class StringConcatExprContext extends ParserRuleContext {
+        public RangeExprContext main_expr;
+        public RangeExprContext rangeExpr;
+        public List<RangeExprContext> rhs = new ArrayList<RangeExprContext>();
+
+        public List<RangeExprContext> rangeExpr() {
+            return getRuleContexts(RangeExprContext.class);
+        }
+
+        public RangeExprContext rangeExpr(int i) {
+            return getRuleContext(RangeExprContext.class, i);
+        }
+
+        public StringConcatExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_stringConcatExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitStringConcatExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final StringConcatExprContext stringConcatExpr() throws RecognitionException {
+        StringConcatExprContext _localctx = new StringConcatExprContext(_ctx, getState());
+        enterRule(_localctx, 78, RULE_stringConcatExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(602);
+                ((StringConcatExprContext) _localctx).main_expr = rangeExpr();
+                setState(607);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__44) {
+                    {
+                        {
+                            setState(603);
+                            match(T__44);
+                            setState(604);
+                            ((StringConcatExprContext) _localctx).rangeExpr = rangeExpr();
+                            ((StringConcatExprContext) _localctx).rhs.add(((StringConcatExprContext) _localctx).rangeExpr);
+                        }
+                    }
+                    setState(609);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class RangeExprContext extends ParserRuleContext {
+        public AdditiveExprContext main_expr;
+        public AdditiveExprContext additiveExpr;
+        public List<AdditiveExprContext> rhs = new ArrayList<AdditiveExprContext>();
+
+        public List<AdditiveExprContext> additiveExpr() {
+            return getRuleContexts(AdditiveExprContext.class);
+        }
+
+        public AdditiveExprContext additiveExpr(int i) {
+            return getRuleContext(AdditiveExprContext.class, i);
+        }
+
+        public TerminalNode Kto() {
+            return getToken(JsoniqParser.Kto, 0);
+        }
+
+        public RangeExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_rangeExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitRangeExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final RangeExprContext rangeExpr() throws RecognitionException {
+        RangeExprContext _localctx = new RangeExprContext(_ctx, getState());
+        enterRule(_localctx, 80, RULE_rangeExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(610);
+                ((RangeExprContext) _localctx).main_expr = additiveExpr();
+                setState(613);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 56, _ctx)) {
+                    case 1: {
+                        setState(611);
+                        match(Kto);
+                        setState(612);
+                        ((RangeExprContext) _localctx).additiveExpr = additiveExpr();
+                        ((RangeExprContext) _localctx).rhs.add(((RangeExprContext) _localctx).additiveExpr);
+                    }
+                    break;
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class AdditiveExprContext extends ParserRuleContext {
+        public MultiplicativeExprContext main_expr;
+        public Token s46;
+        public List<Token> op = new ArrayList<Token>();
+        public Token s47;
+        public Token _tset1160;
+        public MultiplicativeExprContext multiplicativeExpr;
+        public List<MultiplicativeExprContext> rhs = new ArrayList<MultiplicativeExprContext>();
+
+        public List<MultiplicativeExprContext> multiplicativeExpr() {
+            return getRuleContexts(MultiplicativeExprContext.class);
+        }
+
+        public MultiplicativeExprContext multiplicativeExpr(int i) {
+            return getRuleContext(MultiplicativeExprContext.class, i);
+        }
+
+        public AdditiveExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_additiveExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitAdditiveExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final AdditiveExprContext additiveExpr() throws RecognitionException {
+        AdditiveExprContext _localctx = new AdditiveExprContext(_ctx, getState());
+        enterRule(_localctx, 82, RULE_additiveExpr);
+        int _la;
+        try {
+            int _alt;
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(615);
+                ((AdditiveExprContext) _localctx).main_expr = multiplicativeExpr();
+                setState(620);
+                _errHandler.sync(this);
+                _alt = getInterpreter().adaptivePredict(_input, 57, _ctx);
+                while (_alt != 2 && _alt != org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER) {
+                    if (_alt == 1) {
+                        {
+                            {
+                                setState(616);
+                                ((AdditiveExprContext) _localctx)._tset1160 = _input.LT(1);
+                                _la = _input.LA(1);
+                                if (!(_la == T__45 || _la == T__46)) {
+                                    ((AdditiveExprContext) _localctx)._tset1160 = (Token) _errHandler.recoverInline(this);
+                                } else {
+                                    if (_input.LA(1) == Token.EOF) {
+                                        matchedEOF = true;
+                                    }
+                                    _errHandler.reportMatch(this);
+                                    consume();
+                                }
+                                ((AdditiveExprContext) _localctx).op.add(((AdditiveExprContext) _localctx)._tset1160);
+                                setState(617);
+                                ((AdditiveExprContext) _localctx).multiplicativeExpr = multiplicativeExpr();
+                                ((AdditiveExprContext) _localctx).rhs.add(((AdditiveExprContext) _localctx).multiplicativeExpr);
+                            }
+                        }
+                    }
+                    setState(622);
+                    _errHandler.sync(this);
+                    _alt = getInterpreter().adaptivePredict(_input, 57, _ctx);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class MultiplicativeExprContext extends ParserRuleContext {
+        public InstanceOfExprContext main_expr;
+        public Token s33;
+        public List<Token> op = new ArrayList<Token>();
+        public Token s48;
+        public Token s49;
+        public Token s50;
+        public Token _tset1188;
+        public InstanceOfExprContext instanceOfExpr;
+        public List<InstanceOfExprContext> rhs = new ArrayList<InstanceOfExprContext>();
+
+        public List<InstanceOfExprContext> instanceOfExpr() {
+            return getRuleContexts(InstanceOfExprContext.class);
+        }
+
+        public InstanceOfExprContext instanceOfExpr(int i) {
+            return getRuleContext(InstanceOfExprContext.class, i);
+        }
+
+        public MultiplicativeExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_multiplicativeExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitMultiplicativeExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final MultiplicativeExprContext multiplicativeExpr() throws RecognitionException {
+        MultiplicativeExprContext _localctx = new MultiplicativeExprContext(_ctx, getState());
+        enterRule(_localctx, 84, RULE_multiplicativeExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(623);
+                ((MultiplicativeExprContext) _localctx).main_expr = instanceOfExpr();
+                setState(628);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while ((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__32) | (1L << T__47) | (1L << T__48) | (1L << T__49))) != 0)) {
+                    {
+                        {
+                            setState(624);
+                            ((MultiplicativeExprContext) _localctx)._tset1188 = _input.LT(1);
+                            _la = _input.LA(1);
+                            if (!((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << T__32) | (1L << T__47) | (1L << T__48) | (1L << T__49))) != 0))) {
+                                ((MultiplicativeExprContext) _localctx)._tset1188 = (Token) _errHandler.recoverInline(this);
+                            } else {
+                                if (_input.LA(1) == Token.EOF) {
+                                    matchedEOF = true;
+                                }
+                                _errHandler.reportMatch(this);
+                                consume();
+                            }
+                            ((MultiplicativeExprContext) _localctx).op.add(((MultiplicativeExprContext) _localctx)._tset1188);
+                            setState(625);
+                            ((MultiplicativeExprContext) _localctx).instanceOfExpr = instanceOfExpr();
+                            ((MultiplicativeExprContext) _localctx).rhs.add(((MultiplicativeExprContext) _localctx).instanceOfExpr);
+                        }
+                    }
+                    setState(630);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class InstanceOfExprContext extends ParserRuleContext {
+        public TreatExprContext main_expr;
+        public SequenceTypeContext seq;
+
+        public TreatExprContext treatExpr() {
+            return getRuleContext(TreatExprContext.class, 0);
+        }
+
+        public TerminalNode Kinstance() {
+            return getToken(JsoniqParser.Kinstance, 0);
+        }
+
+        public TerminalNode Kof() {
+            return getToken(JsoniqParser.Kof, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public InstanceOfExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_instanceOfExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitInstanceOfExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final InstanceOfExprContext instanceOfExpr() throws RecognitionException {
+        InstanceOfExprContext _localctx = new InstanceOfExprContext(_ctx, getState());
+        enterRule(_localctx, 86, RULE_instanceOfExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(631);
+                ((InstanceOfExprContext) _localctx).main_expr = treatExpr();
+                setState(635);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 59, _ctx)) {
+                    case 1: {
+                        setState(632);
+                        match(Kinstance);
+                        setState(633);
+                        match(Kof);
+                        setState(634);
+                        ((InstanceOfExprContext) _localctx).seq = sequenceType();
+                    }
+                    break;
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class TreatExprContext extends ParserRuleContext {
+        public CastableExprContext main_expr;
+        public SequenceTypeContext seq;
+
+        public CastableExprContext castableExpr() {
+            return getRuleContext(CastableExprContext.class, 0);
+        }
+
+        public TerminalNode Ktreat() {
+            return getToken(JsoniqParser.Ktreat, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public TreatExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_treatExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitTreatExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final TreatExprContext treatExpr() throws RecognitionException {
+        TreatExprContext _localctx = new TreatExprContext(_ctx, getState());
+        enterRule(_localctx, 88, RULE_treatExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(637);
+                ((TreatExprContext) _localctx).main_expr = castableExpr();
+                setState(641);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 60, _ctx)) {
+                    case 1: {
+                        setState(638);
+                        match(Ktreat);
+                        setState(639);
+                        match(Kas);
+                        setState(640);
+                        ((TreatExprContext) _localctx).seq = sequenceType();
+                    }
+                    break;
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class CastableExprContext extends ParserRuleContext {
+        public CastExprContext main_expr;
+        public SingleTypeContext single;
+
+        public CastExprContext castExpr() {
+            return getRuleContext(CastExprContext.class, 0);
+        }
+
+        public TerminalNode Kcastable() {
+            return getToken(JsoniqParser.Kcastable, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public SingleTypeContext singleType() {
+            return getRuleContext(SingleTypeContext.class, 0);
+        }
+
+        public CastableExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_castableExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitCastableExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final CastableExprContext castableExpr() throws RecognitionException {
+        CastableExprContext _localctx = new CastableExprContext(_ctx, getState());
+        enterRule(_localctx, 90, RULE_castableExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(643);
+                ((CastableExprContext) _localctx).main_expr = castExpr();
+                setState(647);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 61, _ctx)) {
+                    case 1: {
+                        setState(644);
+                        match(Kcastable);
+                        setState(645);
+                        match(Kas);
+                        setState(646);
+                        ((CastableExprContext) _localctx).single = singleType();
+                    }
+                    break;
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class CastExprContext extends ParserRuleContext {
+        public UnaryExprContext main_expr;
+        public SingleTypeContext single;
+
+        public UnaryExprContext unaryExpr() {
+            return getRuleContext(UnaryExprContext.class, 0);
+        }
+
+        public TerminalNode Kcast() {
+            return getToken(JsoniqParser.Kcast, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public SingleTypeContext singleType() {
+            return getRuleContext(SingleTypeContext.class, 0);
+        }
+
+        public CastExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_castExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitCastExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final CastExprContext castExpr() throws RecognitionException {
+        CastExprContext _localctx = new CastExprContext(_ctx, getState());
+        enterRule(_localctx, 92, RULE_castExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(649);
+                ((CastExprContext) _localctx).main_expr = unaryExpr();
+                setState(653);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 62, _ctx)) {
+                    case 1: {
+                        setState(650);
+                        match(Kcast);
+                        setState(651);
+                        match(Kas);
+                        setState(652);
+                        ((CastExprContext) _localctx).single = singleType();
+                    }
+                    break;
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class UnaryExprContext extends ParserRuleContext {
+        public Token s47;
+        public List<Token> op = new ArrayList<Token>();
+        public Token s46;
+        public Token _tset1305;
+        public SimpleMapExprContext main_expr;
+
+        public SimpleMapExprContext simpleMapExpr() {
+            return getRuleContext(SimpleMapExprContext.class, 0);
+        }
+
+        public UnaryExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_unaryExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitUnaryExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final UnaryExprContext unaryExpr() throws RecognitionException {
+        UnaryExprContext _localctx = new UnaryExprContext(_ctx, getState());
+        enterRule(_localctx, 94, RULE_unaryExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(658);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__45 || _la == T__46) {
+                    {
+                        {
+                            setState(655);
+                            ((UnaryExprContext) _localctx)._tset1305 = _input.LT(1);
+                            _la = _input.LA(1);
+                            if (!(_la == T__45 || _la == T__46)) {
+                                ((UnaryExprContext) _localctx)._tset1305 = (Token) _errHandler.recoverInline(this);
+                            } else {
+                                if (_input.LA(1) == Token.EOF) {
+                                    matchedEOF = true;
+                                }
+                                _errHandler.reportMatch(this);
+                                consume();
+                            }
+                            ((UnaryExprContext) _localctx).op.add(((UnaryExprContext) _localctx)._tset1305);
+                        }
+                    }
+                    setState(660);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+                setState(661);
+                ((UnaryExprContext) _localctx).main_expr = simpleMapExpr();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class SimpleMapExprContext extends ParserRuleContext {
+        public PostFixExprContext main_expr;
+
+        public List<PostFixExprContext> postFixExpr() {
+            return getRuleContexts(PostFixExprContext.class);
+        }
+
+        public PostFixExprContext postFixExpr(int i) {
+            return getRuleContext(PostFixExprContext.class, i);
+        }
+
+        public SimpleMapExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_simpleMapExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitSimpleMapExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final SimpleMapExprContext simpleMapExpr() throws RecognitionException {
+        SimpleMapExprContext _localctx = new SimpleMapExprContext(_ctx, getState());
+        enterRule(_localctx, 96, RULE_simpleMapExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(663);
+                ((SimpleMapExprContext) _localctx).main_expr = postFixExpr();
+                setState(668);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (_la == T__50) {
+                    {
+                        {
+                            setState(664);
+                            match(T__50);
+                            setState(665);
+                            postFixExpr();
+                        }
+                    }
+                    setState(670);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class PostFixExprContext extends ParserRuleContext {
+        public PrimaryExprContext main_expr;
+
+        public PrimaryExprContext primaryExpr() {
+            return getRuleContext(PrimaryExprContext.class, 0);
+        }
+
+        public List<ArrayLookupContext> arrayLookup() {
+            return getRuleContexts(ArrayLookupContext.class);
+        }
+
+        public ArrayLookupContext arrayLookup(int i) {
+            return getRuleContext(ArrayLookupContext.class, i);
+        }
+
+        public List<PredicateContext> predicate() {
+            return getRuleContexts(PredicateContext.class);
+        }
+
+        public PredicateContext predicate(int i) {
+            return getRuleContext(PredicateContext.class, i);
+        }
+
+        public List<ObjectLookupContext> objectLookup() {
+            return getRuleContexts(ObjectLookupContext.class);
+        }
+
+        public ObjectLookupContext objectLookup(int i) {
+            return getRuleContext(ObjectLookupContext.class, i);
+        }
+
+        public List<ArrayUnboxingContext> arrayUnboxing() {
+            return getRuleContexts(ArrayUnboxingContext.class);
+        }
+
+        public ArrayUnboxingContext arrayUnboxing(int i) {
+            return getRuleContext(ArrayUnboxingContext.class, i);
+        }
+
+        public List<ArgumentListContext> argumentList() {
+            return getRuleContexts(ArgumentListContext.class);
+        }
+
+        public ArgumentListContext argumentList(int i) {
+            return getRuleContext(ArgumentListContext.class, i);
+        }
+
+        public PostFixExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_postFixExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitPostFixExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final PostFixExprContext postFixExpr() throws RecognitionException {
+        PostFixExprContext _localctx = new PostFixExprContext(_ctx, getState());
+        enterRule(_localctx, 98, RULE_postFixExpr);
+        try {
+            int _alt;
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(671);
+                ((PostFixExprContext) _localctx).main_expr = primaryExpr();
+                setState(679);
+                _errHandler.sync(this);
+                _alt = getInterpreter().adaptivePredict(_input, 66, _ctx);
+                while (_alt != 2 && _alt != org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER) {
+                    if (_alt == 1) {
+                        {
+                            setState(677);
+                            _errHandler.sync(this);
+                            switch (getInterpreter().adaptivePredict(_input, 65, _ctx)) {
+                                case 1: {
+                                    setState(672);
+                                    arrayLookup();
+                                }
+                                break;
+                                case 2: {
+                                    setState(673);
+                                    predicate();
+                                }
+                                break;
+                                case 3: {
+                                    setState(674);
+                                    objectLookup();
+                                }
+                                break;
+                                case 4: {
+                                    setState(675);
+                                    arrayUnboxing();
+                                }
+                                break;
+                                case 5: {
+                                    setState(676);
+                                    argumentList();
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    setState(681);
+                    _errHandler.sync(this);
+                    _alt = getInterpreter().adaptivePredict(_input, 66, _ctx);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ArrayLookupContext extends ParserRuleContext {
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public ArrayLookupContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_arrayLookup;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitArrayLookup(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ArrayLookupContext arrayLookup() throws RecognitionException {
+        ArrayLookupContext _localctx = new ArrayLookupContext(_ctx, getState());
+        enterRule(_localctx, 100, RULE_arrayLookup);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(682);
+                match(T__51);
+                setState(683);
+                match(T__51);
+                setState(684);
+                expr();
+                setState(685);
+                match(T__52);
+                setState(686);
+                match(T__52);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ArrayUnboxingContext extends ParserRuleContext {
+        public ArrayUnboxingContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_arrayUnboxing;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitArrayUnboxing(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ArrayUnboxingContext arrayUnboxing() throws RecognitionException {
+        ArrayUnboxingContext _localctx = new ArrayUnboxingContext(_ctx, getState());
+        enterRule(_localctx, 102, RULE_arrayUnboxing);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(688);
+                match(T__51);
+                setState(689);
+                match(T__52);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class PredicateContext extends ParserRuleContext {
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public PredicateContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_predicate;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitPredicate(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final PredicateContext predicate() throws RecognitionException {
+        PredicateContext _localctx = new PredicateContext(_ctx, getState());
+        enterRule(_localctx, 104, RULE_predicate);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(691);
+                match(T__51);
+                setState(692);
+                expr();
+                setState(693);
+                match(T__52);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ObjectLookupContext extends ParserRuleContext {
+        public KeyWordsContext kw;
+        public StringLiteralContext lt;
+        public Token nc;
+        public ParenthesizedExprContext pe;
+        public VarRefContext vr;
+        public ContextItemExprContext ci;
+        public TypesKeywordsContext tkw;
+
+        public KeyWordsContext keyWords() {
+            return getRuleContext(KeyWordsContext.class, 0);
+        }
+
+        public StringLiteralContext stringLiteral() {
+            return getRuleContext(StringLiteralContext.class, 0);
+        }
+
+        public TerminalNode NCName() {
+            return getToken(JsoniqParser.NCName, 0);
+        }
+
+        public ParenthesizedExprContext parenthesizedExpr() {
+            return getRuleContext(ParenthesizedExprContext.class, 0);
+        }
+
+        public VarRefContext varRef() {
+            return getRuleContext(VarRefContext.class, 0);
+        }
+
+        public ContextItemExprContext contextItemExpr() {
+            return getRuleContext(ContextItemExprContext.class, 0);
+        }
+
+        public TypesKeywordsContext typesKeywords() {
+            return getRuleContext(TypesKeywordsContext.class, 0);
+        }
+
+        public ObjectLookupContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_objectLookup;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitObjectLookup(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ObjectLookupContext objectLookup() throws RecognitionException {
+        ObjectLookupContext _localctx = new ObjectLookupContext(_ctx, getState());
+        enterRule(_localctx, 106, RULE_objectLookup);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(695);
+                match(T__53);
+                setState(703);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case Kfor:
+                    case Klet:
+                    case Kwhere:
+                    case Kgroup:
+                    case Kby:
+                    case Korder:
+                    case Kreturn:
+                    case Kif:
+                    case Kin:
+                    case Kas:
+                    case Kat:
+                    case Kallowing:
+                    case Kempty:
+                    case Kcount:
+                    case Kstable:
+                    case Kascending:
+                    case Kdescending:
+                    case Ksome:
+                    case Kevery:
+                    case Ksatisfies:
+                    case Kcollation:
+                    case Kgreatest:
+                    case Kleast:
+                    case Kswitch:
+                    case Kcase:
+                    case Ktry:
+                    case Kcatch:
+                    case Kdefault:
+                    case Kthen:
+                    case Kelse:
+                    case Ktypeswitch:
+                    case Kor:
+                    case Kand:
+                    case Knot:
+                    case Kto:
+                    case Kinstance:
+                    case Kof:
+                    case Ktreat:
+                    case Kcast:
+                    case Kcastable:
+                    case Kversion:
+                    case Kjsoniq:
+                    case Kjson: {
+                        setState(696);
+                        ((ObjectLookupContext) _localctx).kw = keyWords();
+                    }
+                    break;
+                    case STRING: {
+                        setState(697);
+                        ((ObjectLookupContext) _localctx).lt = stringLiteral();
+                    }
+                    break;
+                    case NCName: {
+                        setState(698);
+                        ((ObjectLookupContext) _localctx).nc = match(NCName);
+                    }
+                    break;
+                    case T__26: {
+                        setState(699);
+                        ((ObjectLookupContext) _localctx).pe = parenthesizedExpr();
+                    }
+                    break;
+                    case T__30: {
+                        setState(700);
+                        ((ObjectLookupContext) _localctx).vr = varRef();
+                    }
+                    break;
+                    case T__54: {
+                        setState(701);
+                        ((ObjectLookupContext) _localctx).ci = contextItemExpr();
+                    }
+                    break;
+                    case T__61:
+                    case T__62:
+                    case T__63:
+                    case T__64:
+                    case T__65:
+                    case T__66:
+                    case T__67:
+                    case T__68:
+                    case T__69:
+                    case T__70:
+                    case T__71:
+                    case T__72:
+                    case T__73:
+                    case T__74: {
+                        setState(702);
+                        ((ObjectLookupContext) _localctx).tkw = typesKeywords();
+                    }
+                    break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class PrimaryExprContext extends ParserRuleContext {
+        public TerminalNode NullLiteral() {
+            return getToken(JsoniqParser.NullLiteral, 0);
+        }
+
+        public TerminalNode Literal() {
+            return getToken(JsoniqParser.Literal, 0);
+        }
+
+        public StringLiteralContext stringLiteral() {
+            return getRuleContext(StringLiteralContext.class, 0);
+        }
+
+        public VarRefContext varRef() {
+            return getRuleContext(VarRefContext.class, 0);
+        }
+
+        public ParenthesizedExprContext parenthesizedExpr() {
+            return getRuleContext(ParenthesizedExprContext.class, 0);
+        }
+
+        public ContextItemExprContext contextItemExpr() {
+            return getRuleContext(ContextItemExprContext.class, 0);
+        }
+
+        public ObjectConstructorContext objectConstructor() {
+            return getRuleContext(ObjectConstructorContext.class, 0);
+        }
+
+        public FunctionCallContext functionCall() {
+            return getRuleContext(FunctionCallContext.class, 0);
+        }
+
+        public OrderedExprContext orderedExpr() {
+            return getRuleContext(OrderedExprContext.class, 0);
+        }
+
+        public UnorderedExprContext unorderedExpr() {
+            return getRuleContext(UnorderedExprContext.class, 0);
+        }
+
+        public ArrayConstructorContext arrayConstructor() {
+            return getRuleContext(ArrayConstructorContext.class, 0);
+        }
+
+        public FunctionItemExprContext functionItemExpr() {
+            return getRuleContext(FunctionItemExprContext.class, 0);
+        }
+
+        public PrimaryExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_primaryExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitPrimaryExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final PrimaryExprContext primaryExpr() throws RecognitionException {
+        PrimaryExprContext _localctx = new PrimaryExprContext(_ctx, getState());
+        enterRule(_localctx, 108, RULE_primaryExpr);
+        try {
+            setState(717);
+            _errHandler.sync(this);
+            switch (getInterpreter().adaptivePredict(_input, 68, _ctx)) {
+                case 1:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(705);
+                    match(NullLiteral);
+                }
+                break;
+                case 2:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(706);
+                    match(Literal);
+                }
+                break;
+                case 3:
+                    enterOuterAlt(_localctx, 3);
+                {
+                    setState(707);
+                    stringLiteral();
+                }
+                break;
+                case 4:
+                    enterOuterAlt(_localctx, 4);
+                {
+                    setState(708);
+                    varRef();
+                }
+                break;
+                case 5:
+                    enterOuterAlt(_localctx, 5);
+                {
+                    setState(709);
+                    parenthesizedExpr();
+                }
+                break;
+                case 6:
+                    enterOuterAlt(_localctx, 6);
+                {
+                    setState(710);
+                    contextItemExpr();
+                }
+                break;
+                case 7:
+                    enterOuterAlt(_localctx, 7);
+                {
+                    setState(711);
+                    objectConstructor();
+                }
+                break;
+                case 8:
+                    enterOuterAlt(_localctx, 8);
+                {
+                    setState(712);
+                    functionCall();
+                }
+                break;
+                case 9:
+                    enterOuterAlt(_localctx, 9);
+                {
+                    setState(713);
+                    orderedExpr();
+                }
+                break;
+                case 10:
+                    enterOuterAlt(_localctx, 10);
+                {
+                    setState(714);
+                    unorderedExpr();
+                }
+                break;
+                case 11:
+                    enterOuterAlt(_localctx, 11);
+                {
+                    setState(715);
+                    arrayConstructor();
+                }
+                break;
+                case 12:
+                    enterOuterAlt(_localctx, 12);
+                {
+                    setState(716);
+                    functionItemExpr();
+                }
+                break;
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class VarRefContext extends ParserRuleContext {
+        public Token ns;
+        public Token name;
+
+        public List<TerminalNode> NCName() {
+            return getTokens(JsoniqParser.NCName);
+        }
+
+        public TerminalNode NCName(int i) {
+            return getToken(JsoniqParser.NCName, i);
+        }
+
+        public VarRefContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_varRef;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitVarRef(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final VarRefContext varRef() throws RecognitionException {
+        VarRefContext _localctx = new VarRefContext(_ctx, getState());
+        enterRule(_localctx, 110, RULE_varRef);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(719);
+                match(T__30);
+                setState(722);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 69, _ctx)) {
+                    case 1: {
+                        setState(720);
+                        ((VarRefContext) _localctx).ns = match(NCName);
+                        setState(721);
+                        match(T__9);
+                    }
+                    break;
+                }
+                setState(724);
+                ((VarRefContext) _localctx).name = match(NCName);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ParenthesizedExprContext extends ParserRuleContext {
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public ParenthesizedExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_parenthesizedExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitParenthesizedExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ParenthesizedExprContext parenthesizedExpr() throws RecognitionException {
+        ParenthesizedExprContext _localctx = new ParenthesizedExprContext(_ctx, getState());
+        enterRule(_localctx, 112, RULE_parenthesizedExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(726);
+                match(T__26);
+                setState(728);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & ((1L << (T__6 - 7)) | (1L << (T__7 - 7)) | (1L << (T__9 - 7)) | (1L << (T__25 - 7)) | (1L << (T__26 - 7)) | (1L << (T__28 - 7)) | (1L << (T__30 - 7)) | (1L << (T__45 - 7)) | (1L << (T__46 - 7)) | (1L << (T__51 - 7)) | (1L << (T__54 - 7)) | (1L << (T__56 - 7)) | (1L << (T__61 - 7)) | (1L << (T__62 - 7)) | (1L << (T__63 - 7)) | (1L << (T__64 - 7)) | (1L << (T__65 - 7)) | (1L << (T__66 - 7)) | (1L << (T__67 - 7)) | (1L << (T__68 - 7)) | (1L << (T__69 - 7)))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (T__70 - 71)) | (1L << (T__71 - 71)) | (1L << (T__72 - 71)) | (1L << (T__73 - 71)) | (1L << (T__74 - 71)) | (1L << (Kfor - 71)) | (1L << (Klet - 71)) | (1L << (Kwhere - 71)) | (1L << (Kgroup - 71)) | (1L << (Kby - 71)) | (1L << (Korder - 71)) | (1L << (Kreturn - 71)) | (1L << (Kif - 71)) | (1L << (Kin - 71)) | (1L << (Kas - 71)) | (1L << (Kat - 71)) | (1L << (Kallowing - 71)) | (1L << (Kempty - 71)) | (1L << (Kcount - 71)) | (1L << (Kstable - 71)) | (1L << (Kascending - 71)) | (1L << (Kdescending - 71)) | (1L << (Ksome - 71)) | (1L << (Kevery - 71)) | (1L << (Ksatisfies - 71)) | (1L << (Kcollation - 71)) | (1L << (Kgreatest - 71)) | (1L << (Kleast - 71)) | (1L << (Kswitch - 71)) | (1L << (Kcase - 71)) | (1L << (Ktry - 71)) | (1L << (Kcatch - 71)) | (1L << (Kdefault - 71)) | (1L << (Kthen - 71)) | (1L << (Kelse - 71)) | (1L << (Ktypeswitch - 71)) | (1L << (Kor - 71)) | (1L << (Kand - 71)) | (1L << (Knot - 71)) | (1L << (Kto - 71)) | (1L << (Kinstance - 71)) | (1L << (Kof - 71)) | (1L << (Ktreat - 71)) | (1L << (Kcast - 71)) | (1L << (Kcastable - 71)) | (1L << (Kversion - 71)) | (1L << (Kjsoniq - 71)) | (1L << (Kjson - 71)) | (1L << (STRING - 71)) | (1L << (NullLiteral - 71)) | (1L << (Literal - 71)) | (1L << (NCName - 71)))) != 0)) {
+                    {
+                        setState(727);
+                        expr();
+                    }
+                }
+
+                setState(730);
+                match(T__27);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ContextItemExprContext extends ParserRuleContext {
+        public ContextItemExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_contextItemExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitContextItemExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ContextItemExprContext contextItemExpr() throws RecognitionException {
+        ContextItemExprContext _localctx = new ContextItemExprContext(_ctx, getState());
+        enterRule(_localctx, 114, RULE_contextItemExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(732);
+                match(T__54);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class OrderedExprContext extends ParserRuleContext {
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public OrderedExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_orderedExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitOrderedExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final OrderedExprContext orderedExpr() throws RecognitionException {
+        OrderedExprContext _localctx = new OrderedExprContext(_ctx, getState());
+        enterRule(_localctx, 116, RULE_orderedExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(734);
+                match(T__6);
+                setState(735);
+                match(T__28);
+                setState(736);
+                expr();
+                setState(737);
+                match(T__29);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class UnorderedExprContext extends ParserRuleContext {
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public UnorderedExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_unorderedExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitUnorderedExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final UnorderedExprContext unorderedExpr() throws RecognitionException {
+        UnorderedExprContext _localctx = new UnorderedExprContext(_ctx, getState());
+        enterRule(_localctx, 118, RULE_unorderedExpr);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(739);
+                match(T__7);
+                setState(740);
+                match(T__28);
+                setState(741);
+                expr();
+                setState(742);
+                match(T__29);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class FunctionCallContext extends ParserRuleContext {
+        public Token ns;
+        public KeyWordsContext kw;
+        public NCNameOrKeyWordContext fn_name;
+
+        public ArgumentListContext argumentList() {
+            return getRuleContext(ArgumentListContext.class, 0);
+        }
+
+        public NCNameOrKeyWordContext nCNameOrKeyWord() {
+            return getRuleContext(NCNameOrKeyWordContext.class, 0);
+        }
+
+        public List<KeyWordsContext> keyWords() {
+            return getRuleContexts(KeyWordsContext.class);
+        }
+
+        public KeyWordsContext keyWords(int i) {
+            return getRuleContext(KeyWordsContext.class, i);
+        }
+
+        public TerminalNode NCName() {
+            return getToken(JsoniqParser.NCName, 0);
+        }
+
+        public FunctionCallContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_functionCall;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitFunctionCall(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final FunctionCallContext functionCall() throws RecognitionException {
+        FunctionCallContext _localctx = new FunctionCallContext(_ctx, getState());
+        enterRule(_localctx, 120, RULE_functionCall);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(750);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 72, _ctx)) {
+                    case 1: {
+                        setState(747);
+                        _errHandler.sync(this);
+                        switch (_input.LA(1)) {
+                            case NCName: {
+                                setState(744);
+                                ((FunctionCallContext) _localctx).ns = match(NCName);
+                            }
+                            break;
+                            case Kfor:
+                            case Klet:
+                            case Kwhere:
+                            case Kgroup:
+                            case Kby:
+                            case Korder:
+                            case Kreturn:
+                            case Kif:
+                            case Kin:
+                            case Kas:
+                            case Kat:
+                            case Kallowing:
+                            case Kempty:
+                            case Kcount:
+                            case Kstable:
+                            case Kascending:
+                            case Kdescending:
+                            case Ksome:
+                            case Kevery:
+                            case Ksatisfies:
+                            case Kcollation:
+                            case Kgreatest:
+                            case Kleast:
+                            case Kswitch:
+                            case Kcase:
+                            case Ktry:
+                            case Kcatch:
+                            case Kdefault:
+                            case Kthen:
+                            case Kelse:
+                            case Ktypeswitch:
+                            case Kor:
+                            case Kand:
+                            case Knot:
+                            case Kto:
+                            case Kinstance:
+                            case Kof:
+                            case Ktreat:
+                            case Kcast:
+                            case Kcastable:
+                            case Kversion:
+                            case Kjsoniq:
+                            case Kjson: {
+                                setState(745);
+                                ((FunctionCallContext) _localctx).kw = keyWords();
+                            }
+                            break;
+                            case T__9: {
+                            }
+                            break;
+                            default:
+                                throw new NoViableAltException(this);
+                        }
+                        setState(749);
+                        match(T__9);
+                    }
+                    break;
+                }
+                setState(754);
+                _errHandler.sync(this);
+                switch (_input.LA(1)) {
+                    case T__61:
+                    case T__62:
+                    case T__63:
+                    case T__64:
+                    case T__65:
+                    case T__66:
+                    case T__67:
+                    case T__68:
+                    case T__69:
+                    case T__70:
+                    case T__71:
+                    case T__72:
+                    case T__73:
+                    case T__74:
+                    case NCName: {
+                        setState(752);
+                        ((FunctionCallContext) _localctx).fn_name = nCNameOrKeyWord();
+                    }
+                    break;
+                    case Kfor:
+                    case Klet:
+                    case Kwhere:
+                    case Kgroup:
+                    case Kby:
+                    case Korder:
+                    case Kreturn:
+                    case Kif:
+                    case Kin:
+                    case Kas:
+                    case Kat:
+                    case Kallowing:
+                    case Kempty:
+                    case Kcount:
+                    case Kstable:
+                    case Kascending:
+                    case Kdescending:
+                    case Ksome:
+                    case Kevery:
+                    case Ksatisfies:
+                    case Kcollation:
+                    case Kgreatest:
+                    case Kleast:
+                    case Kswitch:
+                    case Kcase:
+                    case Ktry:
+                    case Kcatch:
+                    case Kdefault:
+                    case Kthen:
+                    case Kelse:
+                    case Ktypeswitch:
+                    case Kor:
+                    case Kand:
+                    case Knot:
+                    case Kto:
+                    case Kinstance:
+                    case Kof:
+                    case Ktreat:
+                    case Kcast:
+                    case Kcastable:
+                    case Kversion:
+                    case Kjsoniq:
+                    case Kjson: {
+                        setState(753);
+                        ((FunctionCallContext) _localctx).kw = keyWords();
+                    }
+                    break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+                setState(756);
+                argumentList();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ArgumentListContext extends ParserRuleContext {
+        public ArgumentContext argument;
+        public List<ArgumentContext> args = new ArrayList<ArgumentContext>();
+
+        public List<ArgumentContext> argument() {
+            return getRuleContexts(ArgumentContext.class);
+        }
+
+        public ArgumentContext argument(int i) {
+            return getRuleContext(ArgumentContext.class, i);
+        }
+
+        public ArgumentListContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_argumentList;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitArgumentList(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ArgumentListContext argumentList() throws RecognitionException {
+        ArgumentListContext _localctx = new ArgumentListContext(_ctx, getState());
+        enterRule(_localctx, 122, RULE_argumentList);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(758);
+                match(T__26);
+                setState(765);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                while (((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & ((1L << (T__6 - 7)) | (1L << (T__7 - 7)) | (1L << (T__9 - 7)) | (1L << (T__25 - 7)) | (1L << (T__26 - 7)) | (1L << (T__28 - 7)) | (1L << (T__30 - 7)) | (1L << (T__45 - 7)) | (1L << (T__46 - 7)) | (1L << (T__51 - 7)) | (1L << (T__54 - 7)) | (1L << (T__56 - 7)) | (1L << (T__61 - 7)) | (1L << (T__62 - 7)) | (1L << (T__63 - 7)) | (1L << (T__64 - 7)) | (1L << (T__65 - 7)) | (1L << (T__66 - 7)) | (1L << (T__67 - 7)) | (1L << (T__68 - 7)) | (1L << (T__69 - 7)))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (T__70 - 71)) | (1L << (T__71 - 71)) | (1L << (T__72 - 71)) | (1L << (T__73 - 71)) | (1L << (T__74 - 71)) | (1L << (Kfor - 71)) | (1L << (Klet - 71)) | (1L << (Kwhere - 71)) | (1L << (Kgroup - 71)) | (1L << (Kby - 71)) | (1L << (Korder - 71)) | (1L << (Kreturn - 71)) | (1L << (Kif - 71)) | (1L << (Kin - 71)) | (1L << (Kas - 71)) | (1L << (Kat - 71)) | (1L << (Kallowing - 71)) | (1L << (Kempty - 71)) | (1L << (Kcount - 71)) | (1L << (Kstable - 71)) | (1L << (Kascending - 71)) | (1L << (Kdescending - 71)) | (1L << (Ksome - 71)) | (1L << (Kevery - 71)) | (1L << (Ksatisfies - 71)) | (1L << (Kcollation - 71)) | (1L << (Kgreatest - 71)) | (1L << (Kleast - 71)) | (1L << (Kswitch - 71)) | (1L << (Kcase - 71)) | (1L << (Ktry - 71)) | (1L << (Kcatch - 71)) | (1L << (Kdefault - 71)) | (1L << (Kthen - 71)) | (1L << (Kelse - 71)) | (1L << (Ktypeswitch - 71)) | (1L << (Kor - 71)) | (1L << (Kand - 71)) | (1L << (Knot - 71)) | (1L << (Kto - 71)) | (1L << (Kinstance - 71)) | (1L << (Kof - 71)) | (1L << (Ktreat - 71)) | (1L << (Kcast - 71)) | (1L << (Kcastable - 71)) | (1L << (Kversion - 71)) | (1L << (Kjsoniq - 71)) | (1L << (Kjson - 71)) | (1L << (STRING - 71)) | (1L << (ArgumentPlaceholder - 71)) | (1L << (NullLiteral - 71)) | (1L << (Literal - 71)) | (1L << (NCName - 71)))) != 0)) {
+                    {
+                        {
+                            setState(759);
+                            ((ArgumentListContext) _localctx).argument = argument();
+                            ((ArgumentListContext) _localctx).args.add(((ArgumentListContext) _localctx).argument);
+                            setState(761);
+                            _errHandler.sync(this);
+                            _la = _input.LA(1);
+                            if (_la == T__21) {
+                                {
+                                    setState(760);
+                                    match(T__21);
+                                }
+                            }
+
+                        }
+                    }
+                    setState(767);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                }
+                setState(768);
+                match(T__27);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ArgumentContext extends ParserRuleContext {
+        public ExprSingleContext exprSingle() {
+            return getRuleContext(ExprSingleContext.class, 0);
+        }
+
+        public TerminalNode ArgumentPlaceholder() {
+            return getToken(JsoniqParser.ArgumentPlaceholder, 0);
+        }
+
+        public ArgumentContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_argument;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitArgument(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ArgumentContext argument() throws RecognitionException {
+        ArgumentContext _localctx = new ArgumentContext(_ctx, getState());
+        enterRule(_localctx, 124, RULE_argument);
+        try {
+            setState(772);
+            _errHandler.sync(this);
+            switch (_input.LA(1)) {
+                case T__6:
+                case T__7:
+                case T__9:
+                case T__25:
+                case T__26:
+                case T__28:
+                case T__30:
+                case T__45:
+                case T__46:
+                case T__51:
+                case T__54:
+                case T__56:
+                case T__61:
+                case T__62:
+                case T__63:
+                case T__64:
+                case T__65:
+                case T__66:
+                case T__67:
+                case T__68:
+                case T__69:
+                case T__70:
+                case T__71:
+                case T__72:
+                case T__73:
+                case T__74:
+                case Kfor:
+                case Klet:
+                case Kwhere:
+                case Kgroup:
+                case Kby:
+                case Korder:
+                case Kreturn:
+                case Kif:
+                case Kin:
+                case Kas:
+                case Kat:
+                case Kallowing:
+                case Kempty:
+                case Kcount:
+                case Kstable:
+                case Kascending:
+                case Kdescending:
+                case Ksome:
+                case Kevery:
+                case Ksatisfies:
+                case Kcollation:
+                case Kgreatest:
+                case Kleast:
+                case Kswitch:
+                case Kcase:
+                case Ktry:
+                case Kcatch:
+                case Kdefault:
+                case Kthen:
+                case Kelse:
+                case Ktypeswitch:
+                case Kor:
+                case Kand:
+                case Knot:
+                case Kto:
+                case Kinstance:
+                case Kof:
+                case Ktreat:
+                case Kcast:
+                case Kcastable:
+                case Kversion:
+                case Kjsoniq:
+                case Kjson:
+                case STRING:
+                case NullLiteral:
+                case Literal:
+                case NCName:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(770);
+                    exprSingle();
+                }
+                break;
+                case ArgumentPlaceholder:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(771);
+                    match(ArgumentPlaceholder);
+                }
+                break;
+                default:
+                    throw new NoViableAltException(this);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class FunctionItemExprContext extends ParserRuleContext {
+        public NamedFunctionRefContext namedFunctionRef() {
+            return getRuleContext(NamedFunctionRefContext.class, 0);
+        }
+
+        public InlineFunctionExprContext inlineFunctionExpr() {
+            return getRuleContext(InlineFunctionExprContext.class, 0);
+        }
+
+        public FunctionItemExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_functionItemExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitFunctionItemExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final FunctionItemExprContext functionItemExpr() throws RecognitionException {
+        FunctionItemExprContext _localctx = new FunctionItemExprContext(_ctx, getState());
+        enterRule(_localctx, 126, RULE_functionItemExpr);
+        try {
+            setState(776);
+            _errHandler.sync(this);
+            switch (_input.LA(1)) {
+                case NCName:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(774);
+                    namedFunctionRef();
+                }
+                break;
+                case T__25:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(775);
+                    inlineFunctionExpr();
+                }
+                break;
+                default:
+                    throw new NoViableAltException(this);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class NamedFunctionRefContext extends ParserRuleContext {
+        public Token fn_name;
+        public Token arity;
+
+        public TerminalNode NCName() {
+            return getToken(JsoniqParser.NCName, 0);
+        }
+
+        public TerminalNode Literal() {
+            return getToken(JsoniqParser.Literal, 0);
+        }
+
+        public NamedFunctionRefContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_namedFunctionRef;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitNamedFunctionRef(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final NamedFunctionRefContext namedFunctionRef() throws RecognitionException {
+        NamedFunctionRefContext _localctx = new NamedFunctionRefContext(_ctx, getState());
+        enterRule(_localctx, 128, RULE_namedFunctionRef);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(778);
+                ((NamedFunctionRefContext) _localctx).fn_name = match(NCName);
+                setState(779);
+                match(T__55);
+                setState(780);
+                ((NamedFunctionRefContext) _localctx).arity = match(Literal);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class InlineFunctionExprContext extends ParserRuleContext {
+        public SequenceTypeContext return_type;
+        public ExprContext fn_body;
+
+        public ParamListContext paramList() {
+            return getRuleContext(ParamListContext.class, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public SequenceTypeContext sequenceType() {
+            return getRuleContext(SequenceTypeContext.class, 0);
+        }
+
+        public InlineFunctionExprContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_inlineFunctionExpr;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitInlineFunctionExpr(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final InlineFunctionExprContext inlineFunctionExpr() throws RecognitionException {
+        InlineFunctionExprContext _localctx = new InlineFunctionExprContext(_ctx, getState());
+        enterRule(_localctx, 130, RULE_inlineFunctionExpr);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(782);
+                match(T__25);
+                setState(783);
+                match(T__26);
+                setState(785);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == T__30) {
+                    {
+                        setState(784);
+                        paramList();
+                    }
+                }
+
+                setState(787);
+                match(T__27);
+                setState(790);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (_la == Kas) {
+                    {
+                        setState(788);
+                        match(Kas);
+                        setState(789);
+                        ((InlineFunctionExprContext) _localctx).return_type = sequenceType();
+                    }
+                }
+
+                {
+                    setState(792);
+                    match(T__28);
+                    setState(793);
+                    ((InlineFunctionExprContext) _localctx).fn_body = expr();
+                    setState(794);
+                    match(T__29);
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class SequenceTypeContext extends ParserRuleContext {
+        public ItemTypeContext item;
+        public Token s121;
+        public List<Token> question = new ArrayList<Token>();
+        public Token s33;
+        public List<Token> star = new ArrayList<Token>();
+        public Token s46;
+        public List<Token> plus = new ArrayList<Token>();
+
+        public ItemTypeContext itemType() {
+            return getRuleContext(ItemTypeContext.class, 0);
+        }
+
+        public SequenceTypeContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_sequenceType;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitSequenceType(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final SequenceTypeContext sequenceType() throws RecognitionException {
+        SequenceTypeContext _localctx = new SequenceTypeContext(_ctx, getState());
+        enterRule(_localctx, 132, RULE_sequenceType);
+        try {
+            setState(804);
+            _errHandler.sync(this);
+            switch (_input.LA(1)) {
+                case T__26:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(796);
+                    match(T__26);
+                    setState(797);
+                    match(T__27);
+                }
+                break;
+                case T__58:
+                case T__59:
+                case T__60:
+                case T__61:
+                case T__62:
+                case T__63:
+                case T__64:
+                case T__65:
+                case T__66:
+                case T__67:
+                case T__68:
+                case T__69:
+                case T__70:
+                case T__71:
+                case T__72:
+                case T__73:
+                case T__74:
+                case T__75:
+                case Kjson:
+                case NullLiteral:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(798);
+                    ((SequenceTypeContext) _localctx).item = itemType();
+                    setState(802);
+                    _errHandler.sync(this);
+                    switch (getInterpreter().adaptivePredict(_input, 80, _ctx)) {
+                        case 1: {
+                            setState(799);
+                            ((SequenceTypeContext) _localctx).s121 = match(ArgumentPlaceholder);
+                            ((SequenceTypeContext) _localctx).question.add(((SequenceTypeContext) _localctx).s121);
+                        }
+                        break;
+                        case 2: {
+                            setState(800);
+                            ((SequenceTypeContext) _localctx).s33 = match(T__32);
+                            ((SequenceTypeContext) _localctx).star.add(((SequenceTypeContext) _localctx).s33);
+                        }
+                        break;
+                        case 3: {
+                            setState(801);
+                            ((SequenceTypeContext) _localctx).s46 = match(T__45);
+                            ((SequenceTypeContext) _localctx).plus.add(((SequenceTypeContext) _localctx).s46);
+                        }
+                        break;
+                    }
+                }
+                break;
+                default:
+                    throw new NoViableAltException(this);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ObjectConstructorContext extends ParserRuleContext {
+        public Token s57;
+        public List<Token> merge_operator = new ArrayList<Token>();
+
+        public List<PairConstructorContext> pairConstructor() {
+            return getRuleContexts(PairConstructorContext.class);
+        }
+
+        public PairConstructorContext pairConstructor(int i) {
+            return getRuleContext(PairConstructorContext.class, i);
+        }
+
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public ObjectConstructorContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_objectConstructor;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitObjectConstructor(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ObjectConstructorContext objectConstructor() throws RecognitionException {
+        ObjectConstructorContext _localctx = new ObjectConstructorContext(_ctx, getState());
+        enterRule(_localctx, 134, RULE_objectConstructor);
+        int _la;
+        try {
+            setState(822);
+            _errHandler.sync(this);
+            switch (_input.LA(1)) {
+                case T__28:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(806);
+                    match(T__28);
+                    setState(815);
+                    _errHandler.sync(this);
+                    _la = _input.LA(1);
+                    if (((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & ((1L << (T__6 - 7)) | (1L << (T__7 - 7)) | (1L << (T__9 - 7)) | (1L << (T__25 - 7)) | (1L << (T__26 - 7)) | (1L << (T__28 - 7)) | (1L << (T__30 - 7)) | (1L << (T__45 - 7)) | (1L << (T__46 - 7)) | (1L << (T__51 - 7)) | (1L << (T__54 - 7)) | (1L << (T__56 - 7)) | (1L << (T__61 - 7)) | (1L << (T__62 - 7)) | (1L << (T__63 - 7)) | (1L << (T__64 - 7)) | (1L << (T__65 - 7)) | (1L << (T__66 - 7)) | (1L << (T__67 - 7)) | (1L << (T__68 - 7)) | (1L << (T__69 - 7)))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (T__70 - 71)) | (1L << (T__71 - 71)) | (1L << (T__72 - 71)) | (1L << (T__73 - 71)) | (1L << (T__74 - 71)) | (1L << (Kfor - 71)) | (1L << (Klet - 71)) | (1L << (Kwhere - 71)) | (1L << (Kgroup - 71)) | (1L << (Kby - 71)) | (1L << (Korder - 71)) | (1L << (Kreturn - 71)) | (1L << (Kif - 71)) | (1L << (Kin - 71)) | (1L << (Kas - 71)) | (1L << (Kat - 71)) | (1L << (Kallowing - 71)) | (1L << (Kempty - 71)) | (1L << (Kcount - 71)) | (1L << (Kstable - 71)) | (1L << (Kascending - 71)) | (1L << (Kdescending - 71)) | (1L << (Ksome - 71)) | (1L << (Kevery - 71)) | (1L << (Ksatisfies - 71)) | (1L << (Kcollation - 71)) | (1L << (Kgreatest - 71)) | (1L << (Kleast - 71)) | (1L << (Kswitch - 71)) | (1L << (Kcase - 71)) | (1L << (Ktry - 71)) | (1L << (Kcatch - 71)) | (1L << (Kdefault - 71)) | (1L << (Kthen - 71)) | (1L << (Kelse - 71)) | (1L << (Ktypeswitch - 71)) | (1L << (Kor - 71)) | (1L << (Kand - 71)) | (1L << (Knot - 71)) | (1L << (Kto - 71)) | (1L << (Kinstance - 71)) | (1L << (Kof - 71)) | (1L << (Ktreat - 71)) | (1L << (Kcast - 71)) | (1L << (Kcastable - 71)) | (1L << (Kversion - 71)) | (1L << (Kjsoniq - 71)) | (1L << (Kjson - 71)) | (1L << (STRING - 71)) | (1L << (NullLiteral - 71)) | (1L << (Literal - 71)) | (1L << (NCName - 71)))) != 0)) {
+                        {
+                            setState(807);
+                            pairConstructor();
+                            setState(812);
+                            _errHandler.sync(this);
+                            _la = _input.LA(1);
+                            while (_la == T__21) {
+                                {
+                                    {
+                                        setState(808);
+                                        match(T__21);
+                                        setState(809);
+                                        pairConstructor();
+                                    }
+                                }
+                                setState(814);
+                                _errHandler.sync(this);
+                                _la = _input.LA(1);
+                            }
+                        }
+                    }
+
+                    setState(817);
+                    match(T__29);
+                }
+                break;
+                case T__56:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(818);
+                    ((ObjectConstructorContext) _localctx).s57 = match(T__56);
+                    ((ObjectConstructorContext) _localctx).merge_operator.add(((ObjectConstructorContext) _localctx).s57);
+                    setState(819);
+                    expr();
+                    setState(820);
+                    match(T__57);
+                }
+                break;
+                default:
+                    throw new NoViableAltException(this);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ItemTypeContext extends ParserRuleContext {
+        public JSONItemTestContext jSONItemTest() {
+            return getRuleContext(JSONItemTestContext.class, 0);
+        }
+
+        public AtomicTypeContext atomicType() {
+            return getRuleContext(AtomicTypeContext.class, 0);
+        }
+
+        public ItemTypeContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_itemType;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitItemType(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ItemTypeContext itemType() throws RecognitionException {
+        ItemTypeContext _localctx = new ItemTypeContext(_ctx, getState());
+        enterRule(_localctx, 136, RULE_itemType);
+        try {
+            setState(827);
+            _errHandler.sync(this);
+            switch (_input.LA(1)) {
+                case T__58:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(824);
+                    match(T__58);
+                }
+                break;
+                case T__59:
+                case T__60:
+                case Kjson:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(825);
+                    jSONItemTest();
+                }
+                break;
+                case T__61:
+                case T__62:
+                case T__63:
+                case T__64:
+                case T__65:
+                case T__66:
+                case T__67:
+                case T__68:
+                case T__69:
+                case T__70:
+                case T__71:
+                case T__72:
+                case T__73:
+                case T__74:
+                case T__75:
+                case NullLiteral:
+                    enterOuterAlt(_localctx, 3);
+                {
+                    setState(826);
+                    atomicType();
+                }
+                break;
+                default:
+                    throw new NoViableAltException(this);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class JSONItemTestContext extends ParserRuleContext {
+        public TerminalNode Kjson() {
+            return getToken(JsoniqParser.Kjson, 0);
+        }
+
+        public JSONItemTestContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_jSONItemTest;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitJSONItemTest(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final JSONItemTestContext jSONItemTest() throws RecognitionException {
+        JSONItemTestContext _localctx = new JSONItemTestContext(_ctx, getState());
+        enterRule(_localctx, 138, RULE_jSONItemTest);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(829);
+                _la = _input.LA(1);
+                if (!(((((_la - 60)) & ~0x3f) == 0 && ((1L << (_la - 60)) & ((1L << (T__59 - 60)) | (1L << (T__60 - 60)) | (1L << (Kjson - 60)))) != 0))) {
+                    _errHandler.recoverInline(this);
+                } else {
+                    if (_input.LA(1) == Token.EOF) {
+                        matchedEOF = true;
+                    }
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordStringContext extends ParserRuleContext {
+        public KeyWordStringContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordString;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordString(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordStringContext keyWordString() throws RecognitionException {
+        KeyWordStringContext _localctx = new KeyWordStringContext(_ctx, getState());
+        enterRule(_localctx, 140, RULE_keyWordString);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(831);
+                match(T__61);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordIntegerContext extends ParserRuleContext {
+        public KeyWordIntegerContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordInteger;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordInteger(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordIntegerContext keyWordInteger() throws RecognitionException {
+        KeyWordIntegerContext _localctx = new KeyWordIntegerContext(_ctx, getState());
+        enterRule(_localctx, 142, RULE_keyWordInteger);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(833);
+                match(T__62);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordDecimalContext extends ParserRuleContext {
+        public KeyWordDecimalContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordDecimal;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordDecimal(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordDecimalContext keyWordDecimal() throws RecognitionException {
+        KeyWordDecimalContext _localctx = new KeyWordDecimalContext(_ctx, getState());
+        enterRule(_localctx, 144, RULE_keyWordDecimal);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(835);
+                match(T__63);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordDoubleContext extends ParserRuleContext {
+        public KeyWordDoubleContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordDouble;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordDouble(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordDoubleContext keyWordDouble() throws RecognitionException {
+        KeyWordDoubleContext _localctx = new KeyWordDoubleContext(_ctx, getState());
+        enterRule(_localctx, 146, RULE_keyWordDouble);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(837);
+                match(T__64);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordBooleanContext extends ParserRuleContext {
+        public KeyWordBooleanContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordBoolean;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordBoolean(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordBooleanContext keyWordBoolean() throws RecognitionException {
+        KeyWordBooleanContext _localctx = new KeyWordBooleanContext(_ctx, getState());
+        enterRule(_localctx, 148, RULE_keyWordBoolean);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(839);
+                match(T__65);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordDurationContext extends ParserRuleContext {
+        public KeyWordDurationContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordDuration;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordDuration(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordDurationContext keyWordDuration() throws RecognitionException {
+        KeyWordDurationContext _localctx = new KeyWordDurationContext(_ctx, getState());
+        enterRule(_localctx, 150, RULE_keyWordDuration);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(841);
+                match(T__66);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordYearMonthDurationContext extends ParserRuleContext {
+        public KeyWordYearMonthDurationContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordYearMonthDuration;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordYearMonthDuration(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordYearMonthDurationContext keyWordYearMonthDuration() throws RecognitionException {
+        KeyWordYearMonthDurationContext _localctx = new KeyWordYearMonthDurationContext(_ctx, getState());
+        enterRule(_localctx, 152, RULE_keyWordYearMonthDuration);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(843);
+                match(T__67);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordDayTimeDurationContext extends ParserRuleContext {
+        public KeyWordDayTimeDurationContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordDayTimeDuration;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordDayTimeDuration(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordDayTimeDurationContext keyWordDayTimeDuration() throws RecognitionException {
+        KeyWordDayTimeDurationContext _localctx = new KeyWordDayTimeDurationContext(_ctx, getState());
+        enterRule(_localctx, 154, RULE_keyWordDayTimeDuration);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(845);
+                match(T__68);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordHexBinaryContext extends ParserRuleContext {
+        public KeyWordHexBinaryContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordHexBinary;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordHexBinary(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordHexBinaryContext keyWordHexBinary() throws RecognitionException {
+        KeyWordHexBinaryContext _localctx = new KeyWordHexBinaryContext(_ctx, getState());
+        enterRule(_localctx, 156, RULE_keyWordHexBinary);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(847);
+                match(T__69);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordBase64BinaryContext extends ParserRuleContext {
+        public KeyWordBase64BinaryContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordBase64Binary;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordBase64Binary(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordBase64BinaryContext keyWordBase64Binary() throws RecognitionException {
+        KeyWordBase64BinaryContext _localctx = new KeyWordBase64BinaryContext(_ctx, getState());
+        enterRule(_localctx, 158, RULE_keyWordBase64Binary);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(849);
+                match(T__70);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordDateTimeContext extends ParserRuleContext {
+        public KeyWordDateTimeContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordDateTime;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordDateTime(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordDateTimeContext keyWordDateTime() throws RecognitionException {
+        KeyWordDateTimeContext _localctx = new KeyWordDateTimeContext(_ctx, getState());
+        enterRule(_localctx, 160, RULE_keyWordDateTime);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(851);
+                match(T__71);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordDateContext extends ParserRuleContext {
+        public KeyWordDateContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordDate;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordDate(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordDateContext keyWordDate() throws RecognitionException {
+        KeyWordDateContext _localctx = new KeyWordDateContext(_ctx, getState());
+        enterRule(_localctx, 162, RULE_keyWordDate);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(853);
+                match(T__72);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordTimeContext extends ParserRuleContext {
+        public KeyWordTimeContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordTime;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordTime(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordTimeContext keyWordTime() throws RecognitionException {
+        KeyWordTimeContext _localctx = new KeyWordTimeContext(_ctx, getState());
+        enterRule(_localctx, 164, RULE_keyWordTime);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(855);
+                match(T__73);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordAnyURIContext extends ParserRuleContext {
+        public KeyWordAnyURIContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWordAnyURI;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWordAnyURI(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordAnyURIContext keyWordAnyURI() throws RecognitionException {
+        KeyWordAnyURIContext _localctx = new KeyWordAnyURIContext(_ctx, getState());
+        enterRule(_localctx, 166, RULE_keyWordAnyURI);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(857);
+                match(T__74);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class TypesKeywordsContext extends ParserRuleContext {
+        public KeyWordStringContext keyWordString() {
+            return getRuleContext(KeyWordStringContext.class, 0);
+        }
+
+        public KeyWordIntegerContext keyWordInteger() {
+            return getRuleContext(KeyWordIntegerContext.class, 0);
+        }
+
+        public KeyWordDecimalContext keyWordDecimal() {
+            return getRuleContext(KeyWordDecimalContext.class, 0);
+        }
+
+        public KeyWordDoubleContext keyWordDouble() {
+            return getRuleContext(KeyWordDoubleContext.class, 0);
+        }
+
+        public KeyWordBooleanContext keyWordBoolean() {
+            return getRuleContext(KeyWordBooleanContext.class, 0);
+        }
+
+        public KeyWordDurationContext keyWordDuration() {
+            return getRuleContext(KeyWordDurationContext.class, 0);
+        }
+
+        public KeyWordYearMonthDurationContext keyWordYearMonthDuration() {
+            return getRuleContext(KeyWordYearMonthDurationContext.class, 0);
+        }
+
+        public KeyWordDayTimeDurationContext keyWordDayTimeDuration() {
+            return getRuleContext(KeyWordDayTimeDurationContext.class, 0);
+        }
+
+        public KeyWordDateTimeContext keyWordDateTime() {
+            return getRuleContext(KeyWordDateTimeContext.class, 0);
+        }
+
+        public KeyWordDateContext keyWordDate() {
+            return getRuleContext(KeyWordDateContext.class, 0);
+        }
+
+        public KeyWordTimeContext keyWordTime() {
+            return getRuleContext(KeyWordTimeContext.class, 0);
+        }
+
+        public KeyWordHexBinaryContext keyWordHexBinary() {
+            return getRuleContext(KeyWordHexBinaryContext.class, 0);
+        }
+
+        public KeyWordBase64BinaryContext keyWordBase64Binary() {
+            return getRuleContext(KeyWordBase64BinaryContext.class, 0);
+        }
+
+        public KeyWordAnyURIContext keyWordAnyURI() {
+            return getRuleContext(KeyWordAnyURIContext.class, 0);
+        }
+
+        public TypesKeywordsContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_typesKeywords;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitTypesKeywords(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final TypesKeywordsContext typesKeywords() throws RecognitionException {
+        TypesKeywordsContext _localctx = new TypesKeywordsContext(_ctx, getState());
+        enterRule(_localctx, 168, RULE_typesKeywords);
+        try {
+            setState(873);
+            _errHandler.sync(this);
+            switch (_input.LA(1)) {
+                case T__61:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(859);
+                    keyWordString();
+                }
+                break;
+                case T__62:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(860);
+                    keyWordInteger();
+                }
+                break;
+                case T__63:
+                    enterOuterAlt(_localctx, 3);
+                {
+                    setState(861);
+                    keyWordDecimal();
+                }
+                break;
+                case T__64:
+                    enterOuterAlt(_localctx, 4);
+                {
+                    setState(862);
+                    keyWordDouble();
+                }
+                break;
+                case T__65:
+                    enterOuterAlt(_localctx, 5);
+                {
+                    setState(863);
+                    keyWordBoolean();
+                }
+                break;
+                case T__66:
+                    enterOuterAlt(_localctx, 6);
+                {
+                    setState(864);
+                    keyWordDuration();
+                }
+                break;
+                case T__67:
+                    enterOuterAlt(_localctx, 7);
+                {
+                    setState(865);
+                    keyWordYearMonthDuration();
+                }
+                break;
+                case T__68:
+                    enterOuterAlt(_localctx, 8);
+                {
+                    setState(866);
+                    keyWordDayTimeDuration();
+                }
+                break;
+                case T__71:
+                    enterOuterAlt(_localctx, 9);
+                {
+                    setState(867);
+                    keyWordDateTime();
+                }
+                break;
+                case T__72:
+                    enterOuterAlt(_localctx, 10);
+                {
+                    setState(868);
+                    keyWordDate();
+                }
+                break;
+                case T__73:
+                    enterOuterAlt(_localctx, 11);
+                {
+                    setState(869);
+                    keyWordTime();
+                }
+                break;
+                case T__69:
+                    enterOuterAlt(_localctx, 12);
+                {
+                    setState(870);
+                    keyWordHexBinary();
+                }
+                break;
+                case T__70:
+                    enterOuterAlt(_localctx, 13);
+                {
+                    setState(871);
+                    keyWordBase64Binary();
+                }
+                break;
+                case T__74:
+                    enterOuterAlt(_localctx, 14);
+                {
+                    setState(872);
+                    keyWordAnyURI();
+                }
+                break;
+                default:
+                    throw new NoViableAltException(this);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class SingleTypeContext extends ParserRuleContext {
+        public AtomicTypeContext item;
+        public Token s121;
+        public List<Token> question = new ArrayList<Token>();
+
+        public AtomicTypeContext atomicType() {
+            return getRuleContext(AtomicTypeContext.class, 0);
+        }
+
+        public SingleTypeContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_singleType;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitSingleType(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final SingleTypeContext singleType() throws RecognitionException {
+        SingleTypeContext _localctx = new SingleTypeContext(_ctx, getState());
+        enterRule(_localctx, 170, RULE_singleType);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(875);
+                ((SingleTypeContext) _localctx).item = atomicType();
+                setState(877);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 87, _ctx)) {
+                    case 1: {
+                        setState(876);
+                        ((SingleTypeContext) _localctx).s121 = match(ArgumentPlaceholder);
+                        ((SingleTypeContext) _localctx).question.add(((SingleTypeContext) _localctx).s121);
+                    }
+                    break;
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class AtomicTypeContext extends ParserRuleContext {
+        public TypesKeywordsContext typesKeywords() {
+            return getRuleContext(TypesKeywordsContext.class, 0);
+        }
+
+        public TerminalNode NullLiteral() {
+            return getToken(JsoniqParser.NullLiteral, 0);
+        }
+
+        public AtomicTypeContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_atomicType;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitAtomicType(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final AtomicTypeContext atomicType() throws RecognitionException {
+        AtomicTypeContext _localctx = new AtomicTypeContext(_ctx, getState());
+        enterRule(_localctx, 172, RULE_atomicType);
+        try {
+            setState(882);
+            _errHandler.sync(this);
+            switch (_input.LA(1)) {
+                case T__75:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(879);
+                    match(T__75);
+                }
+                break;
+                case T__61:
+                case T__62:
+                case T__63:
+                case T__64:
+                case T__65:
+                case T__66:
+                case T__67:
+                case T__68:
+                case T__69:
+                case T__70:
+                case T__71:
+                case T__72:
+                case T__73:
+                case T__74:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(880);
+                    typesKeywords();
+                }
+                break;
+                case NullLiteral:
+                    enterOuterAlt(_localctx, 3);
+                {
+                    setState(881);
+                    match(NullLiteral);
+                }
+                break;
+                default:
+                    throw new NoViableAltException(this);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class NCNameOrKeyWordContext extends ParserRuleContext {
+        public TerminalNode NCName() {
+            return getToken(JsoniqParser.NCName, 0);
+        }
+
+        public TypesKeywordsContext typesKeywords() {
+            return getRuleContext(TypesKeywordsContext.class, 0);
+        }
+
+        public NCNameOrKeyWordContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_nCNameOrKeyWord;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitNCNameOrKeyWord(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final NCNameOrKeyWordContext nCNameOrKeyWord() throws RecognitionException {
+        NCNameOrKeyWordContext _localctx = new NCNameOrKeyWordContext(_ctx, getState());
+        enterRule(_localctx, 174, RULE_nCNameOrKeyWord);
+        try {
+            setState(886);
+            _errHandler.sync(this);
+            switch (_input.LA(1)) {
+                case NCName:
+                    enterOuterAlt(_localctx, 1);
+                {
+                    setState(884);
+                    match(NCName);
+                }
+                break;
+                case T__61:
+                case T__62:
+                case T__63:
+                case T__64:
+                case T__65:
+                case T__66:
+                case T__67:
+                case T__68:
+                case T__69:
+                case T__70:
+                case T__71:
+                case T__72:
+                case T__73:
+                case T__74:
+                    enterOuterAlt(_localctx, 2);
+                {
+                    setState(885);
+                    typesKeywords();
+                }
+                break;
+                default:
+                    throw new NoViableAltException(this);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class PairConstructorContext extends ParserRuleContext {
+        public ExprSingleContext lhs;
+        public Token name;
+        public ExprSingleContext rhs;
+
+        public List<ExprSingleContext> exprSingle() {
+            return getRuleContexts(ExprSingleContext.class);
+        }
+
+        public ExprSingleContext exprSingle(int i) {
+            return getRuleContext(ExprSingleContext.class, i);
+        }
+
+        public TerminalNode NCName() {
+            return getToken(JsoniqParser.NCName, 0);
+        }
+
+        public PairConstructorContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_pairConstructor;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitPairConstructor(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final PairConstructorContext pairConstructor() throws RecognitionException {
+        PairConstructorContext _localctx = new PairConstructorContext(_ctx, getState());
+        enterRule(_localctx, 176, RULE_pairConstructor);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(890);
+                _errHandler.sync(this);
+                switch (getInterpreter().adaptivePredict(_input, 90, _ctx)) {
+                    case 1: {
+                        setState(888);
+                        ((PairConstructorContext) _localctx).lhs = exprSingle();
+                    }
+                    break;
+                    case 2: {
+                        setState(889);
+                        ((PairConstructorContext) _localctx).name = match(NCName);
+                    }
+                    break;
+                }
+                setState(892);
+                _la = _input.LA(1);
+                if (!(_la == T__9 || _la == ArgumentPlaceholder)) {
+                    _errHandler.recoverInline(this);
+                } else {
+                    if (_input.LA(1) == Token.EOF) {
+                        matchedEOF = true;
+                    }
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
+                setState(893);
+                ((PairConstructorContext) _localctx).rhs = exprSingle();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class ArrayConstructorContext extends ParserRuleContext {
+        public ExprContext expr() {
+            return getRuleContext(ExprContext.class, 0);
+        }
+
+        public ArrayConstructorContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_arrayConstructor;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitArrayConstructor(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final ArrayConstructorContext arrayConstructor() throws RecognitionException {
+        ArrayConstructorContext _localctx = new ArrayConstructorContext(_ctx, getState());
+        enterRule(_localctx, 178, RULE_arrayConstructor);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(895);
+                match(T__51);
+                setState(897);
+                _errHandler.sync(this);
+                _la = _input.LA(1);
+                if (((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & ((1L << (T__6 - 7)) | (1L << (T__7 - 7)) | (1L << (T__9 - 7)) | (1L << (T__25 - 7)) | (1L << (T__26 - 7)) | (1L << (T__28 - 7)) | (1L << (T__30 - 7)) | (1L << (T__45 - 7)) | (1L << (T__46 - 7)) | (1L << (T__51 - 7)) | (1L << (T__54 - 7)) | (1L << (T__56 - 7)) | (1L << (T__61 - 7)) | (1L << (T__62 - 7)) | (1L << (T__63 - 7)) | (1L << (T__64 - 7)) | (1L << (T__65 - 7)) | (1L << (T__66 - 7)) | (1L << (T__67 - 7)) | (1L << (T__68 - 7)) | (1L << (T__69 - 7)))) != 0) || ((((_la - 71)) & ~0x3f) == 0 && ((1L << (_la - 71)) & ((1L << (T__70 - 71)) | (1L << (T__71 - 71)) | (1L << (T__72 - 71)) | (1L << (T__73 - 71)) | (1L << (T__74 - 71)) | (1L << (Kfor - 71)) | (1L << (Klet - 71)) | (1L << (Kwhere - 71)) | (1L << (Kgroup - 71)) | (1L << (Kby - 71)) | (1L << (Korder - 71)) | (1L << (Kreturn - 71)) | (1L << (Kif - 71)) | (1L << (Kin - 71)) | (1L << (Kas - 71)) | (1L << (Kat - 71)) | (1L << (Kallowing - 71)) | (1L << (Kempty - 71)) | (1L << (Kcount - 71)) | (1L << (Kstable - 71)) | (1L << (Kascending - 71)) | (1L << (Kdescending - 71)) | (1L << (Ksome - 71)) | (1L << (Kevery - 71)) | (1L << (Ksatisfies - 71)) | (1L << (Kcollation - 71)) | (1L << (Kgreatest - 71)) | (1L << (Kleast - 71)) | (1L << (Kswitch - 71)) | (1L << (Kcase - 71)) | (1L << (Ktry - 71)) | (1L << (Kcatch - 71)) | (1L << (Kdefault - 71)) | (1L << (Kthen - 71)) | (1L << (Kelse - 71)) | (1L << (Ktypeswitch - 71)) | (1L << (Kor - 71)) | (1L << (Kand - 71)) | (1L << (Knot - 71)) | (1L << (Kto - 71)) | (1L << (Kinstance - 71)) | (1L << (Kof - 71)) | (1L << (Ktreat - 71)) | (1L << (Kcast - 71)) | (1L << (Kcastable - 71)) | (1L << (Kversion - 71)) | (1L << (Kjsoniq - 71)) | (1L << (Kjson - 71)) | (1L << (STRING - 71)) | (1L << (NullLiteral - 71)) | (1L << (Literal - 71)) | (1L << (NCName - 71)))) != 0)) {
+                    {
+                        setState(896);
+                        expr();
+                    }
+                }
+
+                setState(899);
+                match(T__52);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class UriLiteralContext extends ParserRuleContext {
+        public StringLiteralContext stringLiteral() {
+            return getRuleContext(StringLiteralContext.class, 0);
+        }
+
+        public UriLiteralContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_uriLiteral;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitUriLiteral(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final UriLiteralContext uriLiteral() throws RecognitionException {
+        UriLiteralContext _localctx = new UriLiteralContext(_ctx, getState());
+        enterRule(_localctx, 180, RULE_uriLiteral);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(901);
+                stringLiteral();
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class StringLiteralContext extends ParserRuleContext {
+        public TerminalNode STRING() {
+            return getToken(JsoniqParser.STRING, 0);
+        }
+
+        public StringLiteralContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_stringLiteral;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitStringLiteral(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final StringLiteralContext stringLiteral() throws RecognitionException {
+        StringLiteralContext _localctx = new StringLiteralContext(_ctx, getState());
+        enterRule(_localctx, 182, RULE_stringLiteral);
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(903);
+                match(STRING);
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static class KeyWordsContext extends ParserRuleContext {
+        public TerminalNode Kjsoniq() {
+            return getToken(JsoniqParser.Kjsoniq, 0);
+        }
+
+        public TerminalNode Kjson() {
+            return getToken(JsoniqParser.Kjson, 0);
+        }
+
+        public TerminalNode Kversion() {
+            return getToken(JsoniqParser.Kversion, 0);
+        }
+
+        public TerminalNode Ktypeswitch() {
+            return getToken(JsoniqParser.Ktypeswitch, 0);
+        }
+
+        public TerminalNode Kor() {
+            return getToken(JsoniqParser.Kor, 0);
+        }
+
+        public TerminalNode Kand() {
+            return getToken(JsoniqParser.Kand, 0);
+        }
+
+        public TerminalNode Knot() {
+            return getToken(JsoniqParser.Knot, 0);
+        }
+
+        public TerminalNode Kto() {
+            return getToken(JsoniqParser.Kto, 0);
+        }
+
+        public TerminalNode Kinstance() {
+            return getToken(JsoniqParser.Kinstance, 0);
+        }
+
+        public TerminalNode Kof() {
+            return getToken(JsoniqParser.Kof, 0);
+        }
+
+        public TerminalNode Ktreat() {
+            return getToken(JsoniqParser.Ktreat, 0);
+        }
+
+        public TerminalNode Kcast() {
+            return getToken(JsoniqParser.Kcast, 0);
+        }
+
+        public TerminalNode Kcastable() {
+            return getToken(JsoniqParser.Kcastable, 0);
+        }
+
+        public TerminalNode Kdefault() {
+            return getToken(JsoniqParser.Kdefault, 0);
+        }
+
+        public TerminalNode Kthen() {
+            return getToken(JsoniqParser.Kthen, 0);
+        }
+
+        public TerminalNode Kelse() {
+            return getToken(JsoniqParser.Kelse, 0);
+        }
+
+        public TerminalNode Kcollation() {
+            return getToken(JsoniqParser.Kcollation, 0);
+        }
+
+        public TerminalNode Kgreatest() {
+            return getToken(JsoniqParser.Kgreatest, 0);
+        }
+
+        public TerminalNode Kleast() {
+            return getToken(JsoniqParser.Kleast, 0);
+        }
+
+        public TerminalNode Kswitch() {
+            return getToken(JsoniqParser.Kswitch, 0);
+        }
+
+        public TerminalNode Kcase() {
+            return getToken(JsoniqParser.Kcase, 0);
+        }
+
+        public TerminalNode Ktry() {
+            return getToken(JsoniqParser.Ktry, 0);
+        }
+
+        public TerminalNode Kcatch() {
+            return getToken(JsoniqParser.Kcatch, 0);
+        }
+
+        public TerminalNode Ksome() {
+            return getToken(JsoniqParser.Ksome, 0);
+        }
+
+        public TerminalNode Kevery() {
+            return getToken(JsoniqParser.Kevery, 0);
+        }
+
+        public TerminalNode Ksatisfies() {
+            return getToken(JsoniqParser.Ksatisfies, 0);
+        }
+
+        public TerminalNode Kstable() {
+            return getToken(JsoniqParser.Kstable, 0);
+        }
+
+        public TerminalNode Kascending() {
+            return getToken(JsoniqParser.Kascending, 0);
+        }
+
+        public TerminalNode Kdescending() {
+            return getToken(JsoniqParser.Kdescending, 0);
+        }
+
+        public TerminalNode Kempty() {
+            return getToken(JsoniqParser.Kempty, 0);
+        }
+
+        public TerminalNode Kallowing() {
+            return getToken(JsoniqParser.Kallowing, 0);
+        }
+
+        public TerminalNode Kas() {
+            return getToken(JsoniqParser.Kas, 0);
+        }
+
+        public TerminalNode Kat() {
+            return getToken(JsoniqParser.Kat, 0);
+        }
+
+        public TerminalNode Kin() {
+            return getToken(JsoniqParser.Kin, 0);
+        }
+
+        public TerminalNode Kif() {
+            return getToken(JsoniqParser.Kif, 0);
+        }
+
+        public TerminalNode Kfor() {
+            return getToken(JsoniqParser.Kfor, 0);
+        }
+
+        public TerminalNode Klet() {
+            return getToken(JsoniqParser.Klet, 0);
+        }
+
+        public TerminalNode Kwhere() {
+            return getToken(JsoniqParser.Kwhere, 0);
+        }
+
+        public TerminalNode Kgroup() {
+            return getToken(JsoniqParser.Kgroup, 0);
+        }
+
+        public TerminalNode Kby() {
+            return getToken(JsoniqParser.Kby, 0);
+        }
+
+        public TerminalNode Korder() {
+            return getToken(JsoniqParser.Korder, 0);
+        }
+
+        public TerminalNode Kcount() {
+            return getToken(JsoniqParser.Kcount, 0);
+        }
+
+        public TerminalNode Kreturn() {
+            return getToken(JsoniqParser.Kreturn, 0);
+        }
+
+        public KeyWordsContext(ParserRuleContext parent, int invokingState) {
+            super(parent, invokingState);
+        }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_keyWords;
+        }
+
+        @Override
+        public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+            if (visitor instanceof JsoniqVisitor) {
+                return ((JsoniqVisitor<? extends T>) visitor).visitKeyWords(this);
+            } else {
+                return visitor.visitChildren(this);
+            }
+        }
+    }
+
+    public final KeyWordsContext keyWords() throws RecognitionException {
+        KeyWordsContext _localctx = new KeyWordsContext(_ctx, getState());
+        enterRule(_localctx, 184, RULE_keyWords);
+        int _la;
+        try {
+            enterOuterAlt(_localctx, 1);
+            {
+                setState(905);
+                _la = _input.LA(1);
+                if (!(((((_la - 77)) & ~0x3f) == 0 && ((1L << (_la - 77)) & ((1L << (Kfor - 77)) | (1L << (Klet - 77)) | (1L << (Kwhere - 77)) | (1L << (Kgroup - 77)) | (1L << (Kby - 77)) | (1L << (Korder - 77)) | (1L << (Kreturn - 77)) | (1L << (Kif - 77)) | (1L << (Kin - 77)) | (1L << (Kas - 77)) | (1L << (Kat - 77)) | (1L << (Kallowing - 77)) | (1L << (Kempty - 77)) | (1L << (Kcount - 77)) | (1L << (Kstable - 77)) | (1L << (Kascending - 77)) | (1L << (Kdescending - 77)) | (1L << (Ksome - 77)) | (1L << (Kevery - 77)) | (1L << (Ksatisfies - 77)) | (1L << (Kcollation - 77)) | (1L << (Kgreatest - 77)) | (1L << (Kleast - 77)) | (1L << (Kswitch - 77)) | (1L << (Kcase - 77)) | (1L << (Ktry - 77)) | (1L << (Kcatch - 77)) | (1L << (Kdefault - 77)) | (1L << (Kthen - 77)) | (1L << (Kelse - 77)) | (1L << (Ktypeswitch - 77)) | (1L << (Kor - 77)) | (1L << (Kand - 77)) | (1L << (Knot - 77)) | (1L << (Kto - 77)) | (1L << (Kinstance - 77)) | (1L << (Kof - 77)) | (1L << (Ktreat - 77)) | (1L << (Kcast - 77)) | (1L << (Kcastable - 77)) | (1L << (Kversion - 77)) | (1L << (Kjsoniq - 77)) | (1L << (Kjson - 77)))) != 0))) {
+                    _errHandler.recoverInline(this);
+                } else {
+                    if (_input.LA(1) == Token.EOF) {
+                        matchedEOF = true;
+                    }
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
+            }
+        } catch (RecognitionException re) {
+            _localctx.exception = re;
+            _errHandler.reportError(this, re);
+            _errHandler.recover(this, re);
+        } finally {
+            exitRule();
+        }
+        return _localctx;
+    }
+
+    public static final String _serializedATN =
+            "\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3\u0086\u038e\4\2\t" +
+                    "\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13" +
+                    "\t\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22" +
+                    "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31" +
+                    "\4\32\t\32\4\33\t\33\4\34\t\34\4\35\t\35\4\36\t\36\4\37\t\37\4 \t \4!" +
+                    "\t!\4\"\t\"\4#\t#\4$\t$\4%\t%\4&\t&\4\'\t\'\4(\t(\4)\t)\4*\t*\4+\t+\4" +
+                    ",\t,\4-\t-\4.\t.\4/\t/\4\60\t\60\4\61\t\61\4\62\t\62\4\63\t\63\4\64\t" +
+                    "\64\4\65\t\65\4\66\t\66\4\67\t\67\48\t8\49\t9\4:\t:\4;\t;\4<\t<\4=\t=" +
+                    "\4>\t>\4?\t?\4@\t@\4A\tA\4B\tB\4C\tC\4D\tD\4E\tE\4F\tF\4G\tG\4H\tH\4I" +
+                    "\tI\4J\tJ\4K\tK\4L\tL\4M\tM\4N\tN\4O\tO\4P\tP\4Q\tQ\4R\tR\4S\tS\4T\tT" +
+                    "\4U\tU\4V\tV\4W\tW\4X\tX\4Y\tY\4Z\tZ\4[\t[\4\\\t\\\4]\t]\4^\t^\3\2\3\2" +
+                    "\3\2\3\2\3\2\5\2\u00c2\n\2\3\2\3\2\5\2\u00c6\n\2\3\3\3\3\3\3\3\4\3\4\3" +
+                    "\4\3\4\3\4\3\4\3\4\3\4\3\5\3\5\3\5\3\5\3\5\5\5\u00d8\n\5\3\5\3\5\7\5\u00dc" +
+                    "\n\5\f\5\16\5\u00df\13\5\3\5\3\5\5\5\u00e3\n\5\3\5\3\5\7\5\u00e7\n\5\f" +
+                    "\5\16\5\u00ea\13\5\3\6\3\6\3\6\3\6\3\6\3\7\3\7\3\7\3\7\3\b\3\b\3\b\3\b" +
+                    "\3\b\3\b\3\t\3\t\3\t\3\t\5\t\u00ff\n\t\3\t\3\t\3\t\5\t\u0104\n\t\3\t\3" +
+                    "\t\3\t\3\t\7\t\u010a\n\t\f\t\16\t\u010d\13\t\3\n\3\n\3\13\3\13\3\13\3" +
+                    "\13\3\13\5\13\u0116\n\13\3\13\3\13\3\13\3\13\3\13\7\13\u011d\n\13\f\13" +
+                    "\16\13\u0120\13\13\5\13\u0122\n\13\3\f\3\f\3\f\3\f\3\f\5\f\u0129\n\f\3" +
+                    "\f\3\f\3\f\3\f\3\f\5\f\u0130\n\f\5\f\u0132\n\f\3\r\3\r\3\r\3\r\5\r\u0138" +
+                    "\n\r\3\r\3\r\3\r\5\r\u013d\n\r\3\r\3\r\3\r\5\r\u0142\n\r\3\r\3\r\3\r\3" +
+                    "\r\3\r\5\r\u0149\n\r\3\16\3\16\3\16\7\16\u014e\n\16\f\16\16\16\u0151\13" +
+                    "\16\3\17\3\17\3\17\3\17\5\17\u0157\n\17\3\20\3\20\3\20\7\20\u015c\n\20" +
+                    "\f\20\16\20\u015f\13\20\3\21\3\21\3\21\3\21\3\21\3\21\3\21\5\21\u0168" +
+                    "\n\21\3\22\3\22\5\22\u016c\n\22\3\22\3\22\3\22\3\22\3\22\3\22\7\22\u0174" +
+                    "\n\22\f\22\16\22\u0177\13\22\3\22\3\22\3\22\3\23\3\23\3\23\3\23\7\23\u0180" +
+                    "\n\23\f\23\16\23\u0183\13\23\3\24\3\24\3\24\5\24\u0188\n\24\3\24\3\24" +
+                    "\5\24\u018c\n\24\3\24\3\24\5\24\u0190\n\24\3\24\3\24\3\24\3\25\3\25\3" +
+                    "\25\3\25\7\25\u0199\n\25\f\25\16\25\u019c\13\25\3\26\3\26\3\26\5\26\u01a1" +
+                    "\n\26\3\26\3\26\3\26\3\27\3\27\3\27\3\30\3\30\3\30\3\30\3\30\7\30\u01ae" +
+                    "\n\30\f\30\16\30\u01b1\13\30\3\31\3\31\3\31\5\31\u01b6\n\31\3\31\3\31" +
+                    "\5\31\u01ba\n\31\3\31\3\31\5\31\u01be\n\31\3\32\3\32\3\32\3\32\3\32\5" +
+                    "\32\u01c5\n\32\3\32\3\32\3\32\7\32\u01ca\n\32\f\32\16\32\u01cd\13\32\3" +
+                    "\33\3\33\3\33\5\33\u01d2\n\33\3\33\3\33\3\33\5\33\u01d7\n\33\5\33\u01d9" +
+                    "\n\33\3\33\3\33\5\33\u01dd\n\33\3\34\3\34\3\34\3\35\3\35\5\35\u01e4\n" +
+                    "\35\3\35\3\35\3\35\7\35\u01e9\n\35\f\35\16\35\u01ec\13\35\3\35\3\35\3" +
+                    "\35\3\36\3\36\3\36\5\36\u01f4\n\36\3\36\3\36\3\36\3\37\3\37\3\37\3\37" +
+                    "\3\37\6\37\u01fe\n\37\r\37\16\37\u01ff\3\37\3\37\3\37\3\37\3 \3 \6 \u0208" +
+                    "\n \r \16 \u0209\3 \3 \3 \3!\3!\3!\3!\3!\6!\u0214\n!\r!\16!\u0215\3!\3" +
+                    "!\5!\u021a\n!\3!\3!\3!\3\"\3\"\3\"\3\"\5\"\u0223\n\"\3\"\3\"\3\"\7\"\u0228" +
+                    "\n\"\f\"\16\"\u022b\13\"\3\"\3\"\3\"\3#\3#\3#\3#\3#\3#\3#\3#\3#\3$\3$" +
+                    "\3$\3$\3$\3$\3$\3$\3$\3$\3%\3%\3%\7%\u0246\n%\f%\16%\u0249\13%\3&\3&\3" +
+                    "&\7&\u024e\n&\f&\16&\u0251\13&\3\'\5\'\u0254\n\'\3\'\3\'\3(\3(\3(\5(\u025b" +
+                    "\n(\3)\3)\3)\7)\u0260\n)\f)\16)\u0263\13)\3*\3*\3*\5*\u0268\n*\3+\3+\3" +
+                    "+\7+\u026d\n+\f+\16+\u0270\13+\3,\3,\3,\7,\u0275\n,\f,\16,\u0278\13,\3" +
+                    "-\3-\3-\3-\5-\u027e\n-\3.\3.\3.\3.\5.\u0284\n.\3/\3/\3/\3/\5/\u028a\n" +
+                    "/\3\60\3\60\3\60\3\60\5\60\u0290\n\60\3\61\7\61\u0293\n\61\f\61\16\61" +
+                    "\u0296\13\61\3\61\3\61\3\62\3\62\3\62\7\62\u029d\n\62\f\62\16\62\u02a0" +
+                    "\13\62\3\63\3\63\3\63\3\63\3\63\3\63\7\63\u02a8\n\63\f\63\16\63\u02ab" +
+                    "\13\63\3\64\3\64\3\64\3\64\3\64\3\64\3\65\3\65\3\65\3\66\3\66\3\66\3\66" +
+                    "\3\67\3\67\3\67\3\67\3\67\3\67\3\67\3\67\5\67\u02c2\n\67\38\38\38\38\3" +
+                    "8\38\38\38\38\38\38\38\58\u02d0\n8\39\39\39\59\u02d5\n9\39\39\3:\3:\5" +
+                    ":\u02db\n:\3:\3:\3;\3;\3<\3<\3<\3<\3<\3=\3=\3=\3=\3=\3>\3>\3>\5>\u02ee" +
+                    "\n>\3>\5>\u02f1\n>\3>\3>\5>\u02f5\n>\3>\3>\3?\3?\3?\5?\u02fc\n?\7?\u02fe" +
+                    "\n?\f?\16?\u0301\13?\3?\3?\3@\3@\5@\u0307\n@\3A\3A\5A\u030b\nA\3B\3B\3" +
+                    "B\3B\3C\3C\3C\5C\u0314\nC\3C\3C\3C\5C\u0319\nC\3C\3C\3C\3C\3D\3D\3D\3" +
+                    "D\3D\3D\5D\u0325\nD\5D\u0327\nD\3E\3E\3E\3E\7E\u032d\nE\fE\16E\u0330\13" +
+                    "E\5E\u0332\nE\3E\3E\3E\3E\3E\5E\u0339\nE\3F\3F\3F\5F\u033e\nF\3G\3G\3" +
+                    "H\3H\3I\3I\3J\3J\3K\3K\3L\3L\3M\3M\3N\3N\3O\3O\3P\3P\3Q\3Q\3R\3R\3S\3" +
+                    "S\3T\3T\3U\3U\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\3V\5V\u036c\nV\3" +
+                    "W\3W\5W\u0370\nW\3X\3X\3X\5X\u0375\nX\3Y\3Y\5Y\u0379\nY\3Z\3Z\5Z\u037d" +
+                    "\nZ\3Z\3Z\3Z\3[\3[\5[\u0384\n[\3[\3[\3\\\3\\\3]\3]\3^\3^\3^\2\2_\2\4\6" +
+                    "\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>@BDFHJLNPRT" +
+                    "VXZ\\^`bdfhjlnprtvxz|~\u0080\u0082\u0084\u0086\u0088\u008a\u008c\u008e" +
+                    "\u0090\u0092\u0094\u0096\u0098\u009a\u009c\u009e\u00a0\u00a2\u00a4\u00a6" +
+                    "\u00a8\u00aa\u00ac\u00ae\u00b0\u00b2\u00b4\u00b6\u00b8\u00ba\2\13\3\2" +
+                    "\t\n\3\2de\3\2\r\26\4\2\6\6$.\3\2\60\61\4\2##\62\64\4\2>?yy\4\2\f\f{{" +
+                    "\3\2Oy\2\u03bc\2\u00c1\3\2\2\2\4\u00c7\3\2\2\2\6\u00ca\3\2\2\2\b\u00dd" +
+                    "\3\2\2\2\n\u00eb\3\2\2\2\f\u00f0\3\2\2\2\16\u00f4\3\2\2\2\20\u00fa\3\2" +
+                    "\2\2\22\u010e\3\2\2\2\24\u0110\3\2\2\2\26\u0123\3\2\2\2\30\u0133\3\2\2" +
+                    "\2\32\u014a\3\2\2\2\34\u0152\3\2\2\2\36\u0158\3\2\2\2 \u0167\3\2\2\2\"" +
+                    "\u016b\3\2\2\2$\u017b\3\2\2\2&\u0184\3\2\2\2(\u0194\3\2\2\2*\u019d\3\2" +
+                    "\2\2,\u01a5\3\2\2\2.\u01a8\3\2\2\2\60\u01b2\3\2\2\2\62\u01c4\3\2\2\2\64" +
+                    "\u01ce\3\2\2\2\66\u01de\3\2\2\28\u01e3\3\2\2\2:\u01f0\3\2\2\2<\u01f8\3" +
+                    "\2\2\2>\u0207\3\2\2\2@\u020e\3\2\2\2B\u021e\3\2\2\2D\u022f\3\2\2\2F\u0238" +
+                    "\3\2\2\2H\u0242\3\2\2\2J\u024a\3\2\2\2L\u0253\3\2\2\2N\u0257\3\2\2\2P" +
+                    "\u025c\3\2\2\2R\u0264\3\2\2\2T\u0269\3\2\2\2V\u0271\3\2\2\2X\u0279\3\2" +
+                    "\2\2Z\u027f\3\2\2\2\\\u0285\3\2\2\2^\u028b\3\2\2\2`\u0294\3\2\2\2b\u0299" +
+                    "\3\2\2\2d\u02a1\3\2\2\2f\u02ac\3\2\2\2h\u02b2\3\2\2\2j\u02b5\3\2\2\2l" +
+                    "\u02b9\3\2\2\2n\u02cf\3\2\2\2p\u02d1\3\2\2\2r\u02d8\3\2\2\2t\u02de\3\2" +
+                    "\2\2v\u02e0\3\2\2\2x\u02e5\3\2\2\2z\u02f0\3\2\2\2|\u02f8\3\2\2\2~\u0306" +
+                    "\3\2\2\2\u0080\u030a\3\2\2\2\u0082\u030c\3\2\2\2\u0084\u0310\3\2\2\2\u0086" +
+                    "\u0326\3\2\2\2\u0088\u0338\3\2\2\2\u008a\u033d\3\2\2\2\u008c\u033f\3\2" +
+                    "\2\2\u008e\u0341\3\2\2\2\u0090\u0343\3\2\2\2\u0092\u0345\3\2\2\2\u0094" +
+                    "\u0347\3\2\2\2\u0096\u0349\3\2\2\2\u0098\u034b\3\2\2\2\u009a\u034d\3\2" +
+                    "\2\2\u009c\u034f\3\2\2\2\u009e\u0351\3\2\2\2\u00a0\u0353\3\2\2\2\u00a2" +
+                    "\u0355\3\2\2\2\u00a4\u0357\3\2\2\2\u00a6\u0359\3\2\2\2\u00a8\u035b\3\2" +
+                    "\2\2\u00aa\u036b\3\2\2\2\u00ac\u036d\3\2\2\2\u00ae\u0374\3\2\2\2\u00b0" +
+                    "\u0378\3\2\2\2\u00b2\u037c\3\2\2\2\u00b4\u0381\3\2\2\2\u00b6\u0387\3\2" +
+                    "\2\2\u00b8\u0389\3\2\2\2\u00ba\u038b\3\2\2\2\u00bc\u00bd\7x\2\2\u00bd" +
+                    "\u00be\7w\2\2\u00be\u00bf\5\u00b8]\2\u00bf\u00c0\7\3\2\2\u00c0\u00c2\3" +
+                    "\2\2\2\u00c1\u00bc\3\2\2\2\u00c1\u00c2\3\2\2\2\u00c2\u00c5\3\2\2\2\u00c3" +
+                    "\u00c6\5\6\4\2\u00c4\u00c6\5\4\3\2\u00c5\u00c3\3\2\2\2\u00c5\u00c4\3\2" +
+                    "\2\2\u00c6\3\3\2\2\2\u00c7\u00c8\5\b\5\2\u00c8\u00c9\5\36\20\2\u00c9\5" +
+                    "\3\2\2\2\u00ca\u00cb\7\4\2\2\u00cb\u00cc\7\5\2\2\u00cc\u00cd\7\u0084\2" +
+                    "\2\u00cd\u00ce\7\6\2\2\u00ce\u00cf\5\u00b6\\\2\u00cf\u00d0\7\3\2\2\u00d0" +
+                    "\u00d1\5\b\5\2\u00d1\7\3\2\2\2\u00d2\u00d8\5\n\6\2\u00d3\u00d8\5\f\7\2" +
+                    "\u00d4\u00d8\5\16\b\2\u00d5\u00d8\5\20\t\2\u00d6\u00d8\5\24\13\2\u00d7" +
+                    "\u00d2\3\2\2\2\u00d7\u00d3\3\2\2\2\u00d7\u00d4\3\2\2\2\u00d7\u00d5\3\2" +
+                    "\2\2\u00d7\u00d6\3\2\2\2\u00d8\u00d9\3\2\2\2\u00d9\u00da\7\3\2\2\u00da" +
+                    "\u00dc\3\2\2\2\u00db\u00d7\3\2\2\2\u00dc\u00df\3\2\2\2\u00dd\u00db\3\2" +
+                    "\2\2\u00dd\u00de\3\2\2\2\u00de\u00e8\3\2\2\2\u00df\u00dd\3\2\2\2\u00e0" +
+                    "\u00e3\5\30\r\2\u00e1\u00e3\5\26\f\2\u00e2\u00e0\3\2\2\2\u00e2\u00e1\3" +
+                    "\2\2\2\u00e3\u00e4\3\2\2\2\u00e4\u00e5\7\3\2\2\u00e5\u00e7\3\2\2\2\u00e6" +
+                    "\u00e2\3\2\2\2\u00e7\u00ea\3\2\2\2\u00e8\u00e6\3\2\2\2\u00e8\u00e9\3\2" +
+                    "\2\2\u00e9\t\3\2\2\2\u00ea\u00e8\3\2\2\2\u00eb\u00ec\7\7\2\2\u00ec\u00ed" +
+                    "\7j\2\2\u00ed\u00ee\7c\2\2\u00ee\u00ef\5\u00b6\\\2\u00ef\13\3\2\2\2\u00f0" +
+                    "\u00f1\7\7\2\2\u00f1\u00f2\7\b\2\2\u00f2\u00f3\t\2\2\2\u00f3\r\3\2\2\2" +
+                    "\u00f4\u00f5\7\7\2\2\u00f5\u00f6\7j\2\2\u00f6\u00f7\7T\2\2\u00f7\u00f8" +
+                    "\7[\2\2\u00f8\u00f9\t\3\2\2\u00f9\17\3\2\2\2\u00fa\u0103\7\7\2\2\u00fb" +
+                    "\u00fe\7\13\2\2\u00fc\u00fd\7\u0084\2\2\u00fd\u00ff\7\f\2\2\u00fe\u00fc" +
+                    "\3\2\2\2\u00fe\u00ff\3\2\2\2\u00ff\u0100\3\2\2\2\u0100\u0104\7\u0084\2" +
+                    "\2\u0101\u0102\7j\2\2\u0102\u0104\7\13\2\2\u0103\u00fb\3\2\2\2\u0103\u0101" +
+                    "\3\2\2\2\u0104\u010b\3\2\2\2\u0105\u0106\5\22\n\2\u0106\u0107\7\6\2\2" +
+                    "\u0107\u0108\5\u00b8]\2\u0108\u010a\3\2\2\2\u0109\u0105\3\2\2\2\u010a" +
+                    "\u010d\3\2\2\2\u010b\u0109\3\2\2\2\u010b\u010c\3\2\2\2\u010c\21\3\2\2" +
+                    "\2\u010d\u010b\3\2\2\2\u010e\u010f\t\4\2\2\u010f\23\3\2\2\2\u0110\u0111" +
+                    "\7\27\2\2\u0111\u0115\7\4\2\2\u0112\u0113\7\5\2\2\u0113\u0114\7\u0084" +
+                    "\2\2\u0114\u0116\7\6\2\2\u0115\u0112\3\2\2\2\u0115\u0116\3\2\2\2\u0116" +
+                    "\u0117\3\2\2\2\u0117\u0121\5\u00b6\\\2\u0118\u0119\7Y\2\2\u0119\u011e" +
+                    "\5\u00b6\\\2\u011a\u011b\7\30\2\2\u011b\u011d\5\u00b6\\\2\u011c\u011a" +
+                    "\3\2\2\2\u011d\u0120\3\2\2\2\u011e\u011c\3\2\2\2\u011e\u011f\3\2\2\2\u011f" +
+                    "\u0122\3\2\2\2\u0120\u011e\3\2\2\2\u0121\u0118\3\2\2\2\u0121\u0122\3\2" +
+                    "\2\2\u0122\25\3\2\2\2\u0123\u0124\7\7\2\2\u0124\u0125\7\31\2\2\u0125\u0128" +
+                    "\5p9\2\u0126\u0127\7X\2\2\u0127\u0129\5\u0086D\2\u0128\u0126\3\2\2\2\u0128" +
+                    "\u0129\3\2\2\2\u0129\u0131\3\2\2\2\u012a\u012b\7\32\2\2\u012b\u0132\5" +
+                    " \21\2\u012c\u012f\7\33\2\2\u012d\u012e\7\32\2\2\u012e\u0130\5 \21\2\u012f" +
+                    "\u012d\3\2\2\2\u012f\u0130\3\2\2\2\u0130\u0132\3\2\2\2\u0131\u012a\3\2" +
+                    "\2\2\u0131\u012c\3\2\2\2\u0132\27\3\2\2\2\u0133\u0134\7\7\2\2\u0134\u0137" +
+                    "\7\34\2\2\u0135\u0136\7\u0084\2\2\u0136\u0138\7\f\2\2\u0137\u0135\3\2" +
+                    "\2\2\u0137\u0138\3\2\2\2\u0138\u0139\3\2\2\2\u0139\u013a\7\u0084\2\2\u013a" +
+                    "\u013c\7\35\2\2\u013b\u013d\5\32\16\2\u013c\u013b\3\2\2\2\u013c\u013d" +
+                    "\3\2\2\2\u013d\u013e\3\2\2\2\u013e\u0141\7\36\2\2\u013f\u0140\7X\2\2\u0140" +
+                    "\u0142\5\u0086D\2\u0141\u013f\3\2\2\2\u0141\u0142\3\2\2\2\u0142\u0148" +
+                    "\3\2\2\2\u0143\u0144\7\37\2\2\u0144\u0145\5\36\20\2\u0145\u0146\7 \2\2" +
+                    "\u0146\u0149\3\2\2\2\u0147\u0149\7\33\2\2\u0148\u0143\3\2\2\2\u0148\u0147" +
+                    "\3\2\2\2\u0149\31\3\2\2\2\u014a\u014f\5\34\17\2\u014b\u014c\7\30\2\2\u014c" +
+                    "\u014e\5\34\17\2\u014d\u014b\3\2\2\2\u014e\u0151\3\2\2\2\u014f\u014d\3" +
+                    "\2\2\2\u014f\u0150\3\2\2\2\u0150\33\3\2\2\2\u0151\u014f\3\2\2\2\u0152" +
+                    "\u0153\7!\2\2\u0153\u0156\7\u0084\2\2\u0154\u0155\7X\2\2\u0155\u0157\5" +
+                    "\u0086D\2\u0156\u0154\3\2\2\2\u0156\u0157\3\2\2\2\u0157\35\3\2\2\2\u0158" +
+                    "\u015d\5 \21\2\u0159\u015a\7\30\2\2\u015a\u015c\5 \21\2\u015b\u0159\3" +
+                    "\2\2\2\u015c\u015f\3\2\2\2\u015d\u015b\3\2\2\2\u015d\u015e\3\2\2\2\u015e" +
+                    "\37\3\2\2\2\u015f\u015d\3\2\2\2\u0160\u0168\5\"\22\2\u0161\u0168\58\35" +
+                    "\2\u0162\u0168\5<\37\2\u0163\u0168\5@!\2\u0164\u0168\5D#\2\u0165\u0168" +
+                    "\5F$\2\u0166\u0168\5H%\2\u0167\u0160\3\2\2\2\u0167\u0161\3\2\2\2\u0167" +
+                    "\u0162\3\2\2\2\u0167\u0163\3\2\2\2\u0167\u0164\3\2\2\2\u0167\u0165\3\2" +
+                    "\2\2\u0167\u0166\3\2\2\2\u0168!\3\2\2\2\u0169\u016c\5$\23\2\u016a\u016c" +
+                    "\5(\25\2\u016b\u0169\3\2\2\2\u016b\u016a\3\2\2\2\u016c\u0175\3\2\2\2\u016d" +
+                    "\u0174\5$\23\2\u016e\u0174\5,\27\2\u016f\u0174\5(\25\2\u0170\u0174\5." +
+                    "\30\2\u0171\u0174\5\62\32\2\u0172\u0174\5\66\34\2\u0173\u016d\3\2\2\2" +
+                    "\u0173\u016e\3\2\2\2\u0173\u016f\3\2\2\2\u0173\u0170\3\2\2\2\u0173\u0171" +
+                    "\3\2\2\2\u0173\u0172\3\2\2\2\u0174\u0177\3\2\2\2\u0175\u0173\3\2\2\2\u0175" +
+                    "\u0176\3\2\2\2\u0176\u0178\3\2\2\2\u0177\u0175\3\2\2\2\u0178\u0179\7U" +
+                    "\2\2\u0179\u017a\5 \21\2\u017a#\3\2\2\2\u017b\u017c\7O\2\2\u017c\u0181" +
+                    "\5&\24\2\u017d\u017e\7\30\2\2\u017e\u0180\5&\24\2\u017f\u017d\3\2\2\2" +
+                    "\u0180\u0183\3\2\2\2\u0181\u017f\3\2\2\2\u0181\u0182\3\2\2\2\u0182%\3" +
+                    "\2\2\2\u0183\u0181\3\2\2\2\u0184\u0187\5p9\2\u0185\u0186\7X\2\2\u0186" +
+                    "\u0188\5\u0086D\2\u0187\u0185\3\2\2\2\u0187\u0188\3\2\2\2\u0188\u018b" +
+                    "\3\2\2\2\u0189\u018a\7Z\2\2\u018a\u018c\7[\2\2\u018b\u0189\3\2\2\2\u018b" +
+                    "\u018c\3\2\2\2\u018c\u018f\3\2\2\2\u018d\u018e\7Y\2\2\u018e\u0190\5p9" +
+                    "\2\u018f\u018d\3\2\2\2\u018f\u0190\3\2\2\2\u0190\u0191\3\2\2\2\u0191\u0192" +
+                    "\7W\2\2\u0192\u0193\5 \21\2\u0193\'\3\2\2\2\u0194\u0195\7P\2\2\u0195\u019a" +
+                    "\5*\26\2\u0196\u0197\7\30\2\2\u0197\u0199\5*\26\2\u0198\u0196\3\2\2\2" +
+                    "\u0199\u019c\3\2\2\2\u019a\u0198\3\2\2\2\u019a\u019b\3\2\2\2\u019b)\3" +
+                    "\2\2\2\u019c\u019a\3\2\2\2\u019d\u01a0\5p9\2\u019e\u019f\7X\2\2\u019f" +
+                    "\u01a1\5\u0086D\2\u01a0\u019e\3\2\2\2\u01a0\u01a1\3\2\2\2\u01a1\u01a2" +
+                    "\3\2\2\2\u01a2\u01a3\7\32\2\2\u01a3\u01a4\5 \21\2\u01a4+\3\2\2\2\u01a5" +
+                    "\u01a6\7Q\2\2\u01a6\u01a7\5 \21\2\u01a7-\3\2\2\2\u01a8\u01a9\7R\2\2\u01a9" +
+                    "\u01aa\7S\2\2\u01aa\u01af\5\60\31\2\u01ab\u01ac\7\30\2\2\u01ac\u01ae\5" +
+                    "\60\31\2\u01ad\u01ab\3\2\2\2\u01ae\u01b1\3\2\2\2\u01af\u01ad\3\2\2\2\u01af" +
+                    "\u01b0\3\2\2\2\u01b0/\3\2\2\2\u01b1\u01af\3\2\2\2\u01b2\u01b9\5p9\2\u01b3" +
+                    "\u01b4\7X\2\2\u01b4\u01b6\5\u0086D\2\u01b5\u01b3\3\2\2\2\u01b5\u01b6\3" +
+                    "\2\2\2\u01b6\u01b7\3\2\2\2\u01b7\u01b8\7\32\2\2\u01b8\u01ba\5 \21\2\u01b9" +
+                    "\u01b5\3\2\2\2\u01b9\u01ba\3\2\2\2\u01ba\u01bd\3\2\2\2\u01bb\u01bc\7c" +
+                    "\2\2\u01bc\u01be\5\u00b6\\\2\u01bd\u01bb\3\2\2\2\u01bd\u01be\3\2\2\2\u01be" +
+                    "\61\3\2\2\2\u01bf\u01c0\7T\2\2\u01c0\u01c5\7S\2\2\u01c1\u01c2\7]\2\2\u01c2" +
+                    "\u01c3\7T\2\2\u01c3\u01c5\7S\2\2\u01c4\u01bf\3\2\2\2\u01c4\u01c1\3\2\2" +
+                    "\2\u01c5\u01c6\3\2\2\2\u01c6\u01cb\5\64\33\2\u01c7\u01c8\7\30\2\2\u01c8" +
+                    "\u01ca\5\64\33\2\u01c9\u01c7\3\2\2\2\u01ca\u01cd\3\2\2\2\u01cb\u01c9\3" +
+                    "\2\2\2\u01cb\u01cc\3\2\2\2\u01cc\63\3\2\2\2\u01cd\u01cb\3\2\2\2\u01ce" +
+                    "\u01d1\5 \21\2\u01cf\u01d2\7^\2\2\u01d0\u01d2\7_\2\2\u01d1\u01cf\3\2\2" +
+                    "\2\u01d1\u01d0\3\2\2\2\u01d1\u01d2\3\2\2\2\u01d2\u01d8\3\2\2\2\u01d3\u01d6" +
+                    "\7[\2\2\u01d4\u01d7\7d\2\2\u01d5\u01d7\7e\2\2\u01d6\u01d4\3\2\2\2\u01d6" +
+                    "\u01d5\3\2\2\2\u01d7\u01d9\3\2\2\2\u01d8\u01d3\3\2\2\2\u01d8\u01d9\3\2" +
+                    "\2\2\u01d9\u01dc\3\2\2\2\u01da\u01db\7c\2\2\u01db\u01dd\5\u00b6\\\2\u01dc" +
+                    "\u01da\3\2\2\2\u01dc\u01dd\3\2\2\2\u01dd\65\3\2\2\2\u01de\u01df\7\\\2" +
+                    "\2\u01df\u01e0\5p9\2\u01e0\67\3\2\2\2\u01e1\u01e4\7`\2\2\u01e2\u01e4\7" +
+                    "a\2\2\u01e3\u01e1\3\2\2\2\u01e3\u01e2\3\2\2\2\u01e4\u01e5\3\2\2\2\u01e5" +
+                    "\u01ea\5:\36\2\u01e6\u01e7\7\30\2\2\u01e7\u01e9\5:\36\2\u01e8\u01e6\3" +
+                    "\2\2\2\u01e9\u01ec\3\2\2\2\u01ea\u01e8\3\2\2\2\u01ea\u01eb\3\2\2\2\u01eb" +
+                    "\u01ed\3\2\2\2\u01ec\u01ea\3\2\2\2\u01ed\u01ee\7b\2\2\u01ee\u01ef\5 \21" +
+                    "\2\u01ef9\3\2\2\2\u01f0\u01f3\5p9\2\u01f1\u01f2\7X\2\2\u01f2\u01f4\5\u0086" +
+                    "D\2\u01f3\u01f1\3\2\2\2\u01f3\u01f4\3\2\2\2\u01f4\u01f5\3\2\2\2\u01f5" +
+                    "\u01f6\7W\2\2\u01f6\u01f7\5 \21\2\u01f7;\3\2\2\2\u01f8\u01f9\7f\2\2\u01f9" +
+                    "\u01fa\7\35\2\2\u01fa\u01fb\5\36\20\2\u01fb\u01fd\7\36\2\2\u01fc\u01fe" +
+                    "\5> \2\u01fd\u01fc\3\2\2\2\u01fe\u01ff\3\2\2\2\u01ff\u01fd\3\2\2\2\u01ff" +
+                    "\u0200\3\2\2\2\u0200\u0201\3\2\2\2\u0201\u0202\7j\2\2\u0202\u0203\7U\2" +
+                    "\2\u0203\u0204\5 \21\2\u0204=\3\2\2\2\u0205\u0206\7g\2\2\u0206\u0208\5" +
+                    " \21\2\u0207\u0205\3\2\2\2\u0208\u0209\3\2\2\2\u0209\u0207\3\2\2\2\u0209" +
+                    "\u020a\3\2\2\2\u020a\u020b\3\2\2\2\u020b\u020c\7U\2\2\u020c\u020d\5 \21" +
+                    "\2\u020d?\3\2\2\2\u020e\u020f\7m\2\2\u020f\u0210\7\35\2\2\u0210\u0211" +
+                    "\5\36\20\2\u0211\u0213\7\36\2\2\u0212\u0214\5B\"\2\u0213\u0212\3\2\2\2" +
+                    "\u0214\u0215\3\2\2\2\u0215\u0213\3\2\2\2\u0215\u0216\3\2\2\2\u0216\u0217" +
+                    "\3\2\2\2\u0217\u0219\7j\2\2\u0218\u021a\5p9\2\u0219\u0218\3\2\2\2\u0219" +
+                    "\u021a\3\2\2\2\u021a\u021b\3\2\2\2\u021b\u021c\7U\2\2\u021c\u021d\5 \21" +
+                    "\2\u021dA\3\2\2\2\u021e\u0222\7g\2\2\u021f\u0220\5p9\2\u0220\u0221\7X" +
+                    "\2\2\u0221\u0223\3\2\2\2\u0222\u021f\3\2\2\2\u0222\u0223\3\2\2\2\u0223" +
+                    "\u0224\3\2\2\2\u0224\u0229\5\u0086D\2\u0225\u0226\7\"\2\2\u0226\u0228" +
+                    "\5\u0086D\2\u0227\u0225\3\2\2\2\u0228\u022b\3\2\2\2\u0229\u0227\3\2\2" +
+                    "\2\u0229\u022a\3\2\2\2\u022a\u022c\3\2\2\2\u022b\u0229\3\2\2\2\u022c\u022d" +
+                    "\7U\2\2\u022d\u022e\5 \21\2\u022eC\3\2\2\2\u022f\u0230\7V\2\2\u0230\u0231" +
+                    "\7\35\2\2\u0231\u0232\5\36\20\2\u0232\u0233\7\36\2\2\u0233\u0234\7k\2" +
+                    "\2\u0234\u0235\5 \21\2\u0235\u0236\7l\2\2\u0236\u0237\5 \21\2\u0237E\3" +
+                    "\2\2\2\u0238\u0239\7h\2\2\u0239\u023a\7\37\2\2\u023a\u023b\5\36\20\2\u023b" +
+                    "\u023c\7 \2\2\u023c\u023d\7i\2\2\u023d\u023e\7#\2\2\u023e\u023f\7\37\2" +
+                    "\2\u023f\u0240\5\36\20\2\u0240\u0241\7 \2\2\u0241G\3\2\2\2\u0242\u0247" +
+                    "\5J&\2\u0243\u0244\7n\2\2\u0244\u0246\5J&\2\u0245\u0243\3\2\2\2\u0246" +
+                    "\u0249\3\2\2\2\u0247\u0245\3\2\2\2\u0247\u0248\3\2\2\2\u0248I\3\2\2\2" +
+                    "\u0249\u0247\3\2\2\2\u024a\u024f\5L\'\2\u024b\u024c\7o\2\2\u024c\u024e" +
+                    "\5L\'\2\u024d\u024b\3\2\2\2\u024e\u0251\3\2\2\2\u024f\u024d\3\2\2\2\u024f" +
+                    "\u0250\3\2\2\2\u0250K\3\2\2\2\u0251\u024f\3\2\2\2\u0252\u0254\7p\2\2\u0253" +
+                    "\u0252\3\2\2\2\u0253\u0254\3\2\2\2\u0254\u0255\3\2\2\2\u0255\u0256\5N" +
+                    "(\2\u0256M\3\2\2\2\u0257\u025a\5P)\2\u0258\u0259\t\5\2\2\u0259\u025b\5" +
+                    "P)\2\u025a\u0258\3\2\2\2\u025a\u025b\3\2\2\2\u025bO\3\2\2\2\u025c\u0261" +
+                    "\5R*\2\u025d\u025e\7/\2\2\u025e\u0260\5R*\2\u025f\u025d\3\2\2\2\u0260" +
+                    "\u0263\3\2\2\2\u0261\u025f\3\2\2\2\u0261\u0262\3\2\2\2\u0262Q\3\2\2\2" +
+                    "\u0263\u0261\3\2\2\2\u0264\u0267\5T+\2\u0265\u0266\7q\2\2\u0266\u0268" +
+                    "\5T+\2\u0267\u0265\3\2\2\2\u0267\u0268\3\2\2\2\u0268S\3\2\2\2\u0269\u026e" +
+                    "\5V,\2\u026a\u026b\t\6\2\2\u026b\u026d\5V,\2\u026c\u026a\3\2\2\2\u026d" +
+                    "\u0270\3\2\2\2\u026e\u026c\3\2\2\2\u026e\u026f\3\2\2\2\u026fU\3\2\2\2" +
+                    "\u0270\u026e\3\2\2\2\u0271\u0276\5X-\2\u0272\u0273\t\7\2\2\u0273\u0275" +
+                    "\5X-\2\u0274\u0272\3\2\2\2\u0275\u0278\3\2\2\2\u0276\u0274\3\2\2\2\u0276" +
+                    "\u0277\3\2\2\2\u0277W\3\2\2\2\u0278\u0276\3\2\2\2\u0279\u027d\5Z.\2\u027a" +
+                    "\u027b\7r\2\2\u027b\u027c\7s\2\2\u027c\u027e\5\u0086D\2\u027d\u027a\3" +
+                    "\2\2\2\u027d\u027e\3\2\2\2\u027eY\3\2\2\2\u027f\u0283\5\\/\2\u0280\u0281" +
+                    "\7t\2\2\u0281\u0282\7X\2\2\u0282\u0284\5\u0086D\2\u0283\u0280\3\2\2\2" +
+                    "\u0283\u0284\3\2\2\2\u0284[\3\2\2\2\u0285\u0289\5^\60\2\u0286\u0287\7" +
+                    "v\2\2\u0287\u0288\7X\2\2\u0288\u028a\5\u00acW\2\u0289\u0286\3\2\2\2\u0289" +
+                    "\u028a\3\2\2\2\u028a]\3\2\2\2\u028b\u028f\5`\61\2\u028c\u028d\7u\2\2\u028d" +
+                    "\u028e\7X\2\2\u028e\u0290\5\u00acW\2\u028f\u028c\3\2\2\2\u028f\u0290\3" +
+                    "\2\2\2\u0290_\3\2\2\2\u0291\u0293\t\6\2\2\u0292\u0291\3\2\2\2\u0293\u0296" +
+                    "\3\2\2\2\u0294\u0292\3\2\2\2\u0294\u0295\3\2\2\2\u0295\u0297\3\2\2\2\u0296" +
+                    "\u0294\3\2\2\2\u0297\u0298\5b\62\2\u0298a\3\2\2\2\u0299\u029e\5d\63\2" +
+                    "\u029a\u029b\7\65\2\2\u029b\u029d\5d\63\2\u029c\u029a\3\2\2\2\u029d\u02a0" +
+                    "\3\2\2\2\u029e\u029c\3\2\2\2\u029e\u029f\3\2\2\2\u029fc\3\2\2\2\u02a0" +
+                    "\u029e\3\2\2\2\u02a1\u02a9\5n8\2\u02a2\u02a8\5f\64\2\u02a3\u02a8\5j\66" +
+                    "\2\u02a4\u02a8\5l\67\2\u02a5\u02a8\5h\65\2\u02a6\u02a8\5|?\2\u02a7\u02a2" +
+                    "\3\2\2\2\u02a7\u02a3\3\2\2\2\u02a7\u02a4\3\2\2\2\u02a7\u02a5\3\2\2\2\u02a7" +
+                    "\u02a6\3\2\2\2\u02a8\u02ab\3\2\2\2\u02a9\u02a7\3\2\2\2\u02a9\u02aa\3\2" +
+                    "\2\2\u02aae\3\2\2\2\u02ab\u02a9\3\2\2\2\u02ac\u02ad\7\66\2\2\u02ad\u02ae" +
+                    "\7\66\2\2\u02ae\u02af\5\36\20\2\u02af\u02b0\7\67\2\2\u02b0\u02b1\7\67" +
+                    "\2\2\u02b1g\3\2\2\2\u02b2\u02b3\7\66\2\2\u02b3\u02b4\7\67\2\2\u02b4i\3" +
+                    "\2\2\2\u02b5\u02b6\7\66\2\2\u02b6\u02b7\5\36\20\2\u02b7\u02b8\7\67\2\2" +
+                    "\u02b8k\3\2\2\2\u02b9\u02c1\78\2\2\u02ba\u02c2\5\u00ba^\2\u02bb\u02c2" +
+                    "\5\u00b8]\2\u02bc\u02c2\7\u0084\2\2\u02bd\u02c2\5r:\2\u02be\u02c2\5p9" +
+                    "\2\u02bf\u02c2\5t;\2\u02c0\u02c2\5\u00aaV\2\u02c1\u02ba\3\2\2\2\u02c1" +
+                    "\u02bb\3\2\2\2\u02c1\u02bc\3\2\2\2\u02c1\u02bd\3\2\2\2\u02c1\u02be\3\2" +
+                    "\2\2\u02c1\u02bf\3\2\2\2\u02c1\u02c0\3\2\2\2\u02c2m\3\2\2\2\u02c3\u02d0" +
+                    "\7|\2\2\u02c4\u02d0\7}\2\2\u02c5\u02d0\5\u00b8]\2\u02c6\u02d0\5p9\2\u02c7" +
+                    "\u02d0\5r:\2\u02c8\u02d0\5t;\2\u02c9\u02d0\5\u0088E\2\u02ca\u02d0\5z>" +
+                    "\2\u02cb\u02d0\5v<\2\u02cc\u02d0\5x=\2\u02cd\u02d0\5\u00b4[\2\u02ce\u02d0" +
+                    "\5\u0080A\2\u02cf\u02c3\3\2\2\2\u02cf\u02c4\3\2\2\2\u02cf\u02c5\3\2\2" +
+                    "\2\u02cf\u02c6\3\2\2\2\u02cf\u02c7\3\2\2\2\u02cf\u02c8\3\2\2\2\u02cf\u02c9" +
+                    "\3\2\2\2\u02cf\u02ca\3\2\2\2\u02cf\u02cb\3\2\2\2\u02cf\u02cc\3\2\2\2\u02cf" +
+                    "\u02cd\3\2\2\2\u02cf\u02ce\3\2\2\2\u02d0o\3\2\2\2\u02d1\u02d4\7!\2\2\u02d2" +
+                    "\u02d3\7\u0084\2\2\u02d3\u02d5\7\f\2\2\u02d4\u02d2\3\2\2\2\u02d4\u02d5" +
+                    "\3\2\2\2\u02d5\u02d6\3\2\2\2\u02d6\u02d7\7\u0084\2\2\u02d7q\3\2\2\2\u02d8" +
+                    "\u02da\7\35\2\2\u02d9\u02db\5\36\20\2\u02da\u02d9\3\2\2\2\u02da\u02db" +
+                    "\3\2\2\2\u02db\u02dc\3\2\2\2\u02dc\u02dd\7\36\2\2\u02dds\3\2\2\2\u02de" +
+                    "\u02df\79\2\2\u02dfu\3\2\2\2\u02e0\u02e1\7\t\2\2\u02e1\u02e2\7\37\2\2" +
+                    "\u02e2\u02e3\5\36\20\2\u02e3\u02e4\7 \2\2\u02e4w\3\2\2\2\u02e5\u02e6\7" +
+                    "\n\2\2\u02e6\u02e7\7\37\2\2\u02e7\u02e8\5\36\20\2\u02e8\u02e9\7 \2\2\u02e9" +
+                    "y\3\2\2\2\u02ea\u02ee\7\u0084\2\2\u02eb\u02ee\5\u00ba^\2\u02ec\u02ee\3" +
+                    "\2\2\2\u02ed\u02ea\3\2\2\2\u02ed\u02eb\3\2\2\2\u02ed\u02ec\3\2\2\2\u02ee" +
+                    "\u02ef\3\2\2\2\u02ef\u02f1\7\f\2\2\u02f0\u02ed\3\2\2\2\u02f0\u02f1\3\2" +
+                    "\2\2\u02f1\u02f4\3\2\2\2\u02f2\u02f5\5\u00b0Y\2\u02f3\u02f5\5\u00ba^\2" +
+                    "\u02f4\u02f2\3\2\2\2\u02f4\u02f3\3\2\2\2\u02f5\u02f6\3\2\2\2\u02f6\u02f7" +
+                    "\5|?\2\u02f7{\3\2\2\2\u02f8\u02ff\7\35\2\2\u02f9\u02fb\5~@\2\u02fa\u02fc" +
+                    "\7\30\2\2\u02fb\u02fa\3\2\2\2\u02fb\u02fc\3\2\2\2\u02fc\u02fe\3\2\2\2" +
+                    "\u02fd\u02f9\3\2\2\2\u02fe\u0301\3\2\2\2\u02ff\u02fd\3\2\2\2\u02ff\u0300" +
+                    "\3\2\2\2\u0300\u0302\3\2\2\2\u0301\u02ff\3\2\2\2\u0302\u0303\7\36\2\2" +
+                    "\u0303}\3\2\2\2\u0304\u0307\5 \21\2\u0305\u0307\7{\2\2\u0306\u0304\3\2" +
+                    "\2\2\u0306\u0305\3\2\2\2\u0307\177\3\2\2\2\u0308\u030b\5\u0082B\2\u0309" +
+                    "\u030b\5\u0084C\2\u030a\u0308\3\2\2\2\u030a\u0309\3\2\2\2\u030b\u0081" +
+                    "\3\2\2\2\u030c\u030d\7\u0084\2\2\u030d\u030e\7:\2\2\u030e\u030f\7}\2\2" +
+                    "\u030f\u0083\3\2\2\2\u0310\u0311\7\34\2\2\u0311\u0313\7\35\2\2\u0312\u0314" +
+                    "\5\32\16\2\u0313\u0312\3\2\2\2\u0313\u0314\3\2\2\2\u0314\u0315\3\2\2\2" +
+                    "\u0315\u0318\7\36\2\2\u0316\u0317\7X\2\2\u0317\u0319\5\u0086D\2\u0318" +
+                    "\u0316\3\2\2\2\u0318\u0319\3\2\2\2\u0319\u031a\3\2\2\2\u031a\u031b\7\37" +
+                    "\2\2\u031b\u031c\5\36\20\2\u031c\u031d\7 \2\2\u031d\u0085\3\2\2\2\u031e" +
+                    "\u031f\7\35\2\2\u031f\u0327\7\36\2\2\u0320\u0324\5\u008aF\2\u0321\u0325" +
+                    "\7{\2\2\u0322\u0325\7#\2\2\u0323\u0325\7\60\2\2\u0324\u0321\3\2\2\2\u0324" +
+                    "\u0322\3\2\2\2\u0324\u0323\3\2\2\2\u0324\u0325\3\2\2\2\u0325\u0327\3\2" +
+                    "\2\2\u0326\u031e\3\2\2\2\u0326\u0320\3\2\2\2\u0327\u0087\3\2\2\2\u0328" +
+                    "\u0331\7\37\2\2\u0329\u032e\5\u00b2Z\2\u032a\u032b\7\30\2\2\u032b\u032d" +
+                    "\5\u00b2Z\2\u032c\u032a\3\2\2\2\u032d\u0330\3\2\2\2\u032e\u032c\3\2\2" +
+                    "\2\u032e\u032f\3\2\2\2\u032f\u0332\3\2\2\2\u0330\u032e\3\2\2\2\u0331\u0329" +
+                    "\3\2\2\2\u0331\u0332\3\2\2\2\u0332\u0333\3\2\2\2\u0333\u0339\7 \2\2\u0334" +
+                    "\u0335\7;\2\2\u0335\u0336\5\36\20\2\u0336\u0337\7<\2\2\u0337\u0339\3\2" +
+                    "\2\2\u0338\u0328\3\2\2\2\u0338\u0334\3\2\2\2\u0339\u0089\3\2\2\2\u033a" +
+                    "\u033e\7=\2\2\u033b\u033e\5\u008cG\2\u033c\u033e\5\u00aeX\2\u033d\u033a" +
+                    "\3\2\2\2\u033d\u033b\3\2\2\2\u033d\u033c\3\2\2\2\u033e\u008b\3\2\2\2\u033f" +
+                    "\u0340\t\b\2\2\u0340\u008d\3\2\2\2\u0341\u0342\7@\2\2\u0342\u008f\3\2" +
+                    "\2\2\u0343\u0344\7A\2\2\u0344\u0091\3\2\2\2\u0345\u0346\7B\2\2\u0346\u0093" +
+                    "\3\2\2\2\u0347\u0348\7C\2\2\u0348\u0095\3\2\2\2\u0349\u034a\7D\2\2\u034a" +
+                    "\u0097\3\2\2\2\u034b\u034c\7E\2\2\u034c\u0099\3\2\2\2\u034d\u034e\7F\2" +
+                    "\2\u034e\u009b\3\2\2\2\u034f\u0350\7G\2\2\u0350\u009d\3\2\2\2\u0351\u0352" +
+                    "\7H\2\2\u0352\u009f\3\2\2\2\u0353\u0354\7I\2\2\u0354\u00a1\3\2\2\2\u0355" +
+                    "\u0356\7J\2\2\u0356\u00a3\3\2\2\2\u0357\u0358\7K\2\2\u0358\u00a5\3\2\2" +
+                    "\2\u0359\u035a\7L\2\2\u035a\u00a7\3\2\2\2\u035b\u035c\7M\2\2\u035c\u00a9" +
+                    "\3\2\2\2\u035d\u036c\5\u008eH\2\u035e\u036c\5\u0090I\2\u035f\u036c\5\u0092" +
+                    "J\2\u0360\u036c\5\u0094K\2\u0361\u036c\5\u0096L\2\u0362\u036c\5\u0098" +
+                    "M\2\u0363\u036c\5\u009aN\2\u0364\u036c\5\u009cO\2\u0365\u036c\5\u00a2" +
+                    "R\2\u0366\u036c\5\u00a4S\2\u0367\u036c\5\u00a6T\2\u0368\u036c\5\u009e" +
+                    "P\2\u0369\u036c\5\u00a0Q\2\u036a\u036c\5\u00a8U\2\u036b\u035d\3\2\2\2" +
+                    "\u036b\u035e\3\2\2\2\u036b\u035f\3\2\2\2\u036b\u0360\3\2\2\2\u036b\u0361" +
+                    "\3\2\2\2\u036b\u0362\3\2\2\2\u036b\u0363\3\2\2\2\u036b\u0364\3\2\2\2\u036b" +
+                    "\u0365\3\2\2\2\u036b\u0366\3\2\2\2\u036b\u0367\3\2\2\2\u036b\u0368\3\2" +
+                    "\2\2\u036b\u0369\3\2\2\2\u036b\u036a\3\2\2\2\u036c\u00ab\3\2\2\2\u036d" +
+                    "\u036f\5\u00aeX\2\u036e\u0370\7{\2\2\u036f\u036e\3\2\2\2\u036f\u0370\3" +
+                    "\2\2\2\u0370\u00ad\3\2\2\2\u0371\u0375\7N\2\2\u0372\u0375\5\u00aaV\2\u0373" +
+                    "\u0375\7|\2\2\u0374\u0371\3\2\2\2\u0374\u0372\3\2\2\2\u0374\u0373\3\2" +
+                    "\2\2\u0375\u00af\3\2\2\2\u0376\u0379\7\u0084\2\2\u0377\u0379\5\u00aaV" +
+                    "\2\u0378\u0376\3\2\2\2\u0378\u0377\3\2\2\2\u0379\u00b1\3\2\2\2\u037a\u037d" +
+                    "\5 \21\2\u037b\u037d\7\u0084\2\2\u037c\u037a\3\2\2\2\u037c\u037b\3\2\2" +
+                    "\2\u037d\u037e\3\2\2\2\u037e\u037f\t\t\2\2\u037f\u0380\5 \21\2\u0380\u00b3" +
+                    "\3\2\2\2\u0381\u0383\7\66\2\2\u0382\u0384\5\36\20\2\u0383\u0382\3\2\2" +
+                    "\2\u0383\u0384\3\2\2\2\u0384\u0385\3\2\2\2\u0385\u0386\7\67\2\2\u0386" +
+                    "\u00b5\3\2\2\2\u0387\u0388\5\u00b8]\2\u0388\u00b7\3\2\2\2\u0389\u038a" +
+                    "\7z\2\2\u038a\u00b9\3\2\2\2\u038b\u038c\t\n\2\2\u038c\u00bb\3\2\2\2^\u00c1" +
+                    "\u00c5\u00d7\u00dd\u00e2\u00e8\u00fe\u0103\u010b\u0115\u011e\u0121\u0128" +
+                    "\u012f\u0131\u0137\u013c\u0141\u0148\u014f\u0156\u015d\u0167\u016b\u0173" +
+                    "\u0175\u0181\u0187\u018b\u018f\u019a\u01a0\u01af\u01b5\u01b9\u01bd\u01c4" +
+                    "\u01cb\u01d1\u01d6\u01d8\u01dc\u01e3\u01ea\u01f3\u01ff\u0209\u0215\u0219" +
+                    "\u0222\u0229\u0247\u024f\u0253\u025a\u0261\u0267\u026e\u0276\u027d\u0283" +
+                    "\u0289\u028f\u0294\u029e\u02a7\u02a9\u02c1\u02cf\u02d4\u02da\u02ed\u02f0" +
+                    "\u02f4\u02fb\u02ff\u0306\u030a\u0313\u0318\u0324\u0326\u032e\u0331\u0338" +
+                    "\u033d\u036b\u036f\u0374\u0378\u037c\u0383";
+    public static final ATN _ATN =
+            new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+
+    static {
+        _decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
+        for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {
+            _decisionToDFA[i] = new DFA(_ATN.getDecisionState(i), i);
+        }
+    }
 }

--- a/src/main/java/org/rumbledb/parser/JsoniqVisitor.java
+++ b/src/main/java/org/rumbledb/parser/JsoniqVisitor.java
@@ -10,565 +10,750 @@ import org.antlr.v4.runtime.tree.ParseTreeVisitor;
  * by {@link JsoniqParser}.
  *
  * @param <T> The return type of the visit operation. Use {@link Void} for
- * operations with no return type.
+ *            operations with no return type.
  */
 public interface JsoniqVisitor<T> extends ParseTreeVisitor<T> {
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#module}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitModule(JsoniqParser.ModuleContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#mainModule}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMainModule(JsoniqParser.MainModuleContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#libraryModule}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitLibraryModule(JsoniqParser.LibraryModuleContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#prolog}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitProlog(JsoniqParser.PrologContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#defaultCollationDecl}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitDefaultCollationDecl(JsoniqParser.DefaultCollationDeclContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#orderingModeDecl}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitOrderingModeDecl(JsoniqParser.OrderingModeDeclContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#emptyOrderDecl}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitEmptyOrderDecl(JsoniqParser.EmptyOrderDeclContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#decimalFormatDecl}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitDecimalFormatDecl(JsoniqParser.DecimalFormatDeclContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#dfPropertyName}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitDfPropertyName(JsoniqParser.DfPropertyNameContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#moduleImport}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitModuleImport(JsoniqParser.ModuleImportContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#varDecl}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitVarDecl(JsoniqParser.VarDeclContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#functionDecl}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitFunctionDecl(JsoniqParser.FunctionDeclContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#paramList}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitParamList(JsoniqParser.ParamListContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#param}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitParam(JsoniqParser.ParamContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#expr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitExpr(JsoniqParser.ExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#exprSingle}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitExprSingle(JsoniqParser.ExprSingleContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#flowrExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitFlowrExpr(JsoniqParser.FlowrExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#forClause}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitForClause(JsoniqParser.ForClauseContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#forVar}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitForVar(JsoniqParser.ForVarContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#letClause}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitLetClause(JsoniqParser.LetClauseContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#letVar}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitLetVar(JsoniqParser.LetVarContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#whereClause}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitWhereClause(JsoniqParser.WhereClauseContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#groupByClause}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitGroupByClause(JsoniqParser.GroupByClauseContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#groupByVar}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitGroupByVar(JsoniqParser.GroupByVarContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#orderByClause}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitOrderByClause(JsoniqParser.OrderByClauseContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#orderByExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitOrderByExpr(JsoniqParser.OrderByExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#countClause}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitCountClause(JsoniqParser.CountClauseContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#quantifiedExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitQuantifiedExpr(JsoniqParser.QuantifiedExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#quantifiedExprVar}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitQuantifiedExprVar(JsoniqParser.QuantifiedExprVarContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#switchExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSwitchExpr(JsoniqParser.SwitchExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#switchCaseClause}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSwitchCaseClause(JsoniqParser.SwitchCaseClauseContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#typeSwitchExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTypeSwitchExpr(JsoniqParser.TypeSwitchExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#caseClause}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitCaseClause(JsoniqParser.CaseClauseContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#ifExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitIfExpr(JsoniqParser.IfExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#tryCatchExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTryCatchExpr(JsoniqParser.TryCatchExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#orExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitOrExpr(JsoniqParser.OrExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#andExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitAndExpr(JsoniqParser.AndExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#notExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitNotExpr(JsoniqParser.NotExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#comparisonExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitComparisonExpr(JsoniqParser.ComparisonExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#stringConcatExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitStringConcatExpr(JsoniqParser.StringConcatExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#rangeExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitRangeExpr(JsoniqParser.RangeExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#additiveExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitAdditiveExpr(JsoniqParser.AdditiveExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#multiplicativeExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitMultiplicativeExpr(JsoniqParser.MultiplicativeExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#instanceOfExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitInstanceOfExpr(JsoniqParser.InstanceOfExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#treatExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTreatExpr(JsoniqParser.TreatExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#castableExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitCastableExpr(JsoniqParser.CastableExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#castExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitCastExpr(JsoniqParser.CastExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#unaryExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitUnaryExpr(JsoniqParser.UnaryExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#simpleMapExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSimpleMapExpr(JsoniqParser.SimpleMapExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#postFixExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitPostFixExpr(JsoniqParser.PostFixExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#arrayLookup}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitArrayLookup(JsoniqParser.ArrayLookupContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#arrayUnboxing}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitArrayUnboxing(JsoniqParser.ArrayUnboxingContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#predicate}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitPredicate(JsoniqParser.PredicateContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#objectLookup}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitObjectLookup(JsoniqParser.ObjectLookupContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#primaryExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitPrimaryExpr(JsoniqParser.PrimaryExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#varRef}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitVarRef(JsoniqParser.VarRefContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#parenthesizedExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitParenthesizedExpr(JsoniqParser.ParenthesizedExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#contextItemExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitContextItemExpr(JsoniqParser.ContextItemExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#orderedExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitOrderedExpr(JsoniqParser.OrderedExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#unorderedExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitUnorderedExpr(JsoniqParser.UnorderedExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#functionCall}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitFunctionCall(JsoniqParser.FunctionCallContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#argumentList}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitArgumentList(JsoniqParser.ArgumentListContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#argument}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitArgument(JsoniqParser.ArgumentContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#functionItemExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitFunctionItemExpr(JsoniqParser.FunctionItemExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#namedFunctionRef}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitNamedFunctionRef(JsoniqParser.NamedFunctionRefContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#inlineFunctionExpr}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitInlineFunctionExpr(JsoniqParser.InlineFunctionExprContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#sequenceType}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSequenceType(JsoniqParser.SequenceTypeContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#objectConstructor}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitObjectConstructor(JsoniqParser.ObjectConstructorContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#itemType}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitItemType(JsoniqParser.ItemTypeContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#jSONItemTest}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitJSONItemTest(JsoniqParser.JSONItemTestContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordString}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordString(JsoniqParser.KeyWordStringContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordInteger}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordInteger(JsoniqParser.KeyWordIntegerContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordDecimal}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordDecimal(JsoniqParser.KeyWordDecimalContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordDouble}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordDouble(JsoniqParser.KeyWordDoubleContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordBoolean}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordBoolean(JsoniqParser.KeyWordBooleanContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordDuration}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordDuration(JsoniqParser.KeyWordDurationContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordYearMonthDuration}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordYearMonthDuration(JsoniqParser.KeyWordYearMonthDurationContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordDayTimeDuration}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordDayTimeDuration(JsoniqParser.KeyWordDayTimeDurationContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordHexBinary}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordHexBinary(JsoniqParser.KeyWordHexBinaryContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordBase64Binary}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordBase64Binary(JsoniqParser.KeyWordBase64BinaryContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordDateTime}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordDateTime(JsoniqParser.KeyWordDateTimeContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordDate}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordDate(JsoniqParser.KeyWordDateContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordTime}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordTime(JsoniqParser.KeyWordTimeContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWordAnyURI}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWordAnyURI(JsoniqParser.KeyWordAnyURIContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#typesKeywords}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitTypesKeywords(JsoniqParser.TypesKeywordsContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#singleType}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitSingleType(JsoniqParser.SingleTypeContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#atomicType}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitAtomicType(JsoniqParser.AtomicTypeContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#nCNameOrKeyWord}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitNCNameOrKeyWord(JsoniqParser.NCNameOrKeyWordContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#pairConstructor}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitPairConstructor(JsoniqParser.PairConstructorContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#arrayConstructor}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitArrayConstructor(JsoniqParser.ArrayConstructorContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#uriLiteral}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitUriLiteral(JsoniqParser.UriLiteralContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#stringLiteral}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitStringLiteral(JsoniqParser.StringLiteralContext ctx);
-	/**
-	 * Visit a parse tree produced by {@link JsoniqParser#keyWords}.
-	 * @param ctx the parse tree
-	 * @return the visitor result
-	 */
-	T visitKeyWords(JsoniqParser.KeyWordsContext ctx);
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#module}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitModule(JsoniqParser.ModuleContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#mainModule}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMainModule(JsoniqParser.MainModuleContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#libraryModule}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitLibraryModule(JsoniqParser.LibraryModuleContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#prolog}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitProlog(JsoniqParser.PrologContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#defaultCollationDecl}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitDefaultCollationDecl(JsoniqParser.DefaultCollationDeclContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#orderingModeDecl}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitOrderingModeDecl(JsoniqParser.OrderingModeDeclContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#emptyOrderDecl}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitEmptyOrderDecl(JsoniqParser.EmptyOrderDeclContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#decimalFormatDecl}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitDecimalFormatDecl(JsoniqParser.DecimalFormatDeclContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#dfPropertyName}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitDfPropertyName(JsoniqParser.DfPropertyNameContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#moduleImport}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitModuleImport(JsoniqParser.ModuleImportContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#varDecl}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitVarDecl(JsoniqParser.VarDeclContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#functionDecl}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitFunctionDecl(JsoniqParser.FunctionDeclContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#paramList}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitParamList(JsoniqParser.ParamListContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#param}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitParam(JsoniqParser.ParamContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#expr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitExpr(JsoniqParser.ExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#exprSingle}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitExprSingle(JsoniqParser.ExprSingleContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#flowrExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitFlowrExpr(JsoniqParser.FlowrExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#forClause}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitForClause(JsoniqParser.ForClauseContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#forVar}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitForVar(JsoniqParser.ForVarContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#letClause}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitLetClause(JsoniqParser.LetClauseContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#letVar}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitLetVar(JsoniqParser.LetVarContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#whereClause}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitWhereClause(JsoniqParser.WhereClauseContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#groupByClause}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitGroupByClause(JsoniqParser.GroupByClauseContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#groupByVar}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitGroupByVar(JsoniqParser.GroupByVarContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#orderByClause}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitOrderByClause(JsoniqParser.OrderByClauseContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#orderByExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitOrderByExpr(JsoniqParser.OrderByExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#countClause}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitCountClause(JsoniqParser.CountClauseContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#quantifiedExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitQuantifiedExpr(JsoniqParser.QuantifiedExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#quantifiedExprVar}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitQuantifiedExprVar(JsoniqParser.QuantifiedExprVarContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#switchExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSwitchExpr(JsoniqParser.SwitchExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#switchCaseClause}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSwitchCaseClause(JsoniqParser.SwitchCaseClauseContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#typeSwitchExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTypeSwitchExpr(JsoniqParser.TypeSwitchExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#caseClause}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitCaseClause(JsoniqParser.CaseClauseContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#ifExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitIfExpr(JsoniqParser.IfExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#tryCatchExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTryCatchExpr(JsoniqParser.TryCatchExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#orExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitOrExpr(JsoniqParser.OrExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#andExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitAndExpr(JsoniqParser.AndExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#notExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitNotExpr(JsoniqParser.NotExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#comparisonExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitComparisonExpr(JsoniqParser.ComparisonExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#stringConcatExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitStringConcatExpr(JsoniqParser.StringConcatExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#rangeExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitRangeExpr(JsoniqParser.RangeExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#additiveExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitAdditiveExpr(JsoniqParser.AdditiveExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#multiplicativeExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitMultiplicativeExpr(JsoniqParser.MultiplicativeExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#instanceOfExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitInstanceOfExpr(JsoniqParser.InstanceOfExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#treatExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTreatExpr(JsoniqParser.TreatExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#castableExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitCastableExpr(JsoniqParser.CastableExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#castExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitCastExpr(JsoniqParser.CastExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#unaryExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitUnaryExpr(JsoniqParser.UnaryExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#simpleMapExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSimpleMapExpr(JsoniqParser.SimpleMapExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#postFixExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitPostFixExpr(JsoniqParser.PostFixExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#arrayLookup}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitArrayLookup(JsoniqParser.ArrayLookupContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#arrayUnboxing}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitArrayUnboxing(JsoniqParser.ArrayUnboxingContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#predicate}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitPredicate(JsoniqParser.PredicateContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#objectLookup}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitObjectLookup(JsoniqParser.ObjectLookupContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#primaryExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitPrimaryExpr(JsoniqParser.PrimaryExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#varRef}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitVarRef(JsoniqParser.VarRefContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#parenthesizedExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitParenthesizedExpr(JsoniqParser.ParenthesizedExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#contextItemExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitContextItemExpr(JsoniqParser.ContextItemExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#orderedExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitOrderedExpr(JsoniqParser.OrderedExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#unorderedExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitUnorderedExpr(JsoniqParser.UnorderedExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#functionCall}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitFunctionCall(JsoniqParser.FunctionCallContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#argumentList}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitArgumentList(JsoniqParser.ArgumentListContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#argument}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitArgument(JsoniqParser.ArgumentContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#functionItemExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitFunctionItemExpr(JsoniqParser.FunctionItemExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#namedFunctionRef}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitNamedFunctionRef(JsoniqParser.NamedFunctionRefContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#inlineFunctionExpr}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitInlineFunctionExpr(JsoniqParser.InlineFunctionExprContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#sequenceType}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSequenceType(JsoniqParser.SequenceTypeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#objectConstructor}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitObjectConstructor(JsoniqParser.ObjectConstructorContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#itemType}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitItemType(JsoniqParser.ItemTypeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#jSONItemTest}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitJSONItemTest(JsoniqParser.JSONItemTestContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordString}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordString(JsoniqParser.KeyWordStringContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordInteger}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordInteger(JsoniqParser.KeyWordIntegerContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordDecimal}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordDecimal(JsoniqParser.KeyWordDecimalContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordDouble}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordDouble(JsoniqParser.KeyWordDoubleContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordBoolean}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordBoolean(JsoniqParser.KeyWordBooleanContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordDuration}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordDuration(JsoniqParser.KeyWordDurationContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordYearMonthDuration}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordYearMonthDuration(JsoniqParser.KeyWordYearMonthDurationContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordDayTimeDuration}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordDayTimeDuration(JsoniqParser.KeyWordDayTimeDurationContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordHexBinary}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordHexBinary(JsoniqParser.KeyWordHexBinaryContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordBase64Binary}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordBase64Binary(JsoniqParser.KeyWordBase64BinaryContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordDateTime}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordDateTime(JsoniqParser.KeyWordDateTimeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordDate}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordDate(JsoniqParser.KeyWordDateContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordTime}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordTime(JsoniqParser.KeyWordTimeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWordAnyURI}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWordAnyURI(JsoniqParser.KeyWordAnyURIContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#typesKeywords}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitTypesKeywords(JsoniqParser.TypesKeywordsContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#singleType}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitSingleType(JsoniqParser.SingleTypeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#atomicType}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitAtomicType(JsoniqParser.AtomicTypeContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#nCNameOrKeyWord}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitNCNameOrKeyWord(JsoniqParser.NCNameOrKeyWordContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#pairConstructor}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitPairConstructor(JsoniqParser.PairConstructorContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#arrayConstructor}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitArrayConstructor(JsoniqParser.ArrayConstructorContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#uriLiteral}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitUriLiteral(JsoniqParser.UriLiteralContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#stringLiteral}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitStringLiteral(JsoniqParser.StringLiteralContext ctx);
+
+    /**
+     * Visit a parse tree produced by {@link JsoniqParser#keyWords}.
+     *
+     * @param ctx the parse tree
+     * @return the visitor result
+     */
+    T visitKeyWords(JsoniqParser.KeyWordsContext ctx);
 }


### PR DESCRIPTION
@ghislainfourny feel free to merge this if it looks good to you.

I don't mind performing these formatting tasks but I am wondering if we really need to IntelliJ touch for this or not.

Since spotless dictates our formatting anyways, I believe all IntelliJ does it converting wildcard imports into explicit imports. I remember that you had also configured your Eclipse settings to not use wildcard imports. I would be curious to know if same result is obtained when Eclipse IDE is used.  