### PR TITLE
Fix access to other storage layers than HDFS.

### DIFF
--- a/src/main/java/org/rumbledb/runtime/functions/input/JsonFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/JsonFileFunctionIterator.java
@@ -52,7 +52,7 @@ public class JsonFileFunctionIterator extends RDDRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        if (!UrlValidator.exists(url)) {
+        if (!UrlValidator.check(url, getMetadata())) {
             throw new CannotRetrieveResourceException("File " + url + " not found.", getMetadata());
         }
 

--- a/src/main/java/org/rumbledb/runtime/functions/input/JsonFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/JsonFileFunctionIterator.java
@@ -52,7 +52,7 @@ public class JsonFileFunctionIterator extends RDDRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        if (!UrlValidator.check(url, getMetadata())) {
+        if (!UrlValidator.exists(url, getMetadata())) {
             throw new CannotRetrieveResourceException("File " + url + " not found.", getMetadata());
         }
 

--- a/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
@@ -52,7 +52,7 @@ public class TextFileFunctionIterator extends RDDRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        if (!UrlValidator.exists(url)) {
+        if (!UrlValidator.check(url, getMetadata())) {
             throw new CannotRetrieveResourceException("File " + url + " not found.", getMetadata());
         }
 

--- a/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
@@ -52,7 +52,7 @@ public class TextFileFunctionIterator extends RDDRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        if (!UrlValidator.check(url, getMetadata())) {
+        if (!UrlValidator.exists(url, getMetadata())) {
             throw new CannotRetrieveResourceException("File " + url + " not found.", getMetadata());
         }
 

--- a/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
@@ -23,13 +23,12 @@ public class UrlValidator {
         } catch (URISyntaxException e) {
             throw new OurBadException("Malformed URL: " + url);
         }
-        if (locator.isAbsolute() && !Arrays.asList(allowedSchemes).contains(locator.getScheme()))
-        {
+        if (locator.isAbsolute() && !Arrays.asList(allowedSchemes).contains(locator.getScheme())) {
             throw new OurBadException("Cannot interpret URL: " + url);
         }
         if (
-            !locator.isAbsolute() || (locator.isAbsolute() && locator.getScheme().equals("hdfs")))
-        {
+            !locator.isAbsolute() || (locator.isAbsolute() && locator.getScheme().equals("hdfs"))
+        ) {
             JavaSparkContext sparkContext = SparkSessionManager.getInstance().getJavaSparkContext();
             try {
                 FileSystem fileSystem = FileSystem.get(sparkContext.hadoopConfiguration());

--- a/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
@@ -39,7 +39,10 @@ public class UrlValidator {
                 );
             } catch (IOException e) {
                 e.printStackTrace();
-                throw new CannotRetrieveResourceException("Error while accessing local or HDFS filesystem.", metadata);
+                throw new CannotRetrieveResourceException(
+                        "Error while accessing the " + locator.getScheme() + " filesystem.",
+                        metadata
+                );
             }
         }
     }

--- a/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
@@ -23,21 +23,23 @@ public class UrlValidator {
         } catch (URISyntaxException e) {
             throw new OurBadException("Malformed URL: " + url);
         }
+        if (locator.isAbsolute() && !Arrays.asList(allowedSchemes).contains(locator.getScheme()))
+        {
+            throw new OurBadException("Cannot interpret URL: " + url);
+        }
         if (
-            !locator.isAbsolute()
-                || Arrays.asList(allowedSchemes).contains(locator.getScheme())
-        ) {
+            !locator.isAbsolute() || (locator.isAbsolute() && locator.getScheme().equals("hdfs")))
+        {
             JavaSparkContext sparkContext = SparkSessionManager.getInstance().getJavaSparkContext();
             try {
                 FileSystem fileSystem = FileSystem.get(sparkContext.hadoopConfiguration());
                 Path path = new Path(url);
                 return url.contains("*") || fileSystem.exists(path);
             } catch (IOException e) {
-                throw new SparksoniqRuntimeException("Error while accessing hadoop filesystem.");
+                throw new SparksoniqRuntimeException("Error while accessing local or HDFS filesystem.");
             }
 
         }
-
-        throw new OurBadException("Cannot interpret URL: " + url);
+        return true;
     }
 }

--- a/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
@@ -3,8 +3,9 @@ package org.rumbledb.runtime.functions.input;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.rumbledb.exceptions.CannotRetrieveResourceException;
+import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.OurBadException;
-import org.rumbledb.exceptions.SparksoniqRuntimeException;
 import sparksoniq.spark.SparkSessionManager;
 
 import java.io.IOException;
@@ -16,12 +17,12 @@ public class UrlValidator {
 
     private static final String[] allowedSchemes = { "file", "hdfs", "s3", "s3a", "s3n", "wasb", "gs", "root" };
 
-    public static boolean exists(String url) {
+    public static boolean check(String url, ExceptionMetadata metadata) {
         URI locator = null;
         try {
             locator = new URI(url);
         } catch (URISyntaxException e) {
-            throw new OurBadException("Malformed URL: " + url);
+            throw new CannotRetrieveResourceException("Malformed URL: " + url, metadata);
         }
         if (locator.isAbsolute() && !Arrays.asList(allowedSchemes).contains(locator.getScheme())) {
             throw new OurBadException("Cannot interpret URL: " + url);
@@ -35,7 +36,7 @@ public class UrlValidator {
                 Path path = new Path(url);
                 return url.contains("*") || fileSystem.exists(path);
             } catch (IOException e) {
-                throw new SparksoniqRuntimeException("Error while accessing local or HDFS filesystem.");
+                throw new CannotRetrieveResourceException("Error while accessing local or HDFS filesystem.", metadata);
             }
 
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/UrlValidator.java
@@ -16,7 +16,7 @@ public class UrlValidator {
 
     private static final String[] allowedSchemes = { "file", "hdfs", "s3", "s3a", "s3n", "wasb", "gs", "root" };
 
-    public static boolean check(String url, ExceptionMetadata metadata) {
+    public static boolean exists(String url, ExceptionMetadata metadata) {
         URI locator = null;
         try {
             locator = new URI(url);
@@ -32,11 +32,12 @@ public class UrlValidator {
                 Path path = new Path(url);
                 return url.contains("*") || fileContext.util().exists(path);
 
-            } catch (UnsupportedFileSystemException e)
-            {
-                throw new CannotRetrieveResourceException("No file system is configured for scheme " + url + "!", metadata);
-            }
-            catch (IOException e) {
+            } catch (UnsupportedFileSystemException e) {
+                throw new CannotRetrieveResourceException(
+                        "No file system is configured for scheme " + url + "!",
+                        metadata
+                );
+            } catch (IOException e) {
                 e.printStackTrace();
                 throw new CannotRetrieveResourceException("Error while accessing local or HDFS filesystem.", metadata);
             }


### PR DESCRIPTION
@CanBerker this is the first release since the introduction of the URL validator. Unfortunately, it does not work when reading from other file systems than HDFS on Amazon EMR (like S3). I had to fix the code as we need to use FileContext, not FileSystem.