### PR TITLE
Implement colored outputs

### DIFF
--- a/src/main/java/org/rumbledb/items/FunctionItem.java
+++ b/src/main/java/org/rumbledb/items/FunctionItem.java
@@ -34,7 +34,6 @@ import org.rumbledb.exceptions.OurBadException;
 import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.runtime.functions.base.FunctionIdentifier;
 import org.rumbledb.runtime.functions.base.FunctionSignature;
-import org.rumbledb.shell.ANSIColor;
 import org.rumbledb.types.ItemType;
 import org.rumbledb.types.SequenceType;
 

--- a/src/main/java/org/rumbledb/items/FunctionItem.java
+++ b/src/main/java/org/rumbledb/items/FunctionItem.java
@@ -34,6 +34,7 @@ import org.rumbledb.exceptions.OurBadException;
 import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.runtime.functions.base.FunctionIdentifier;
 import org.rumbledb.runtime.functions.base.FunctionSignature;
+import org.rumbledb.shell.ANSIColor;
 import org.rumbledb.types.ItemType;
 import org.rumbledb.types.SequenceType;
 

--- a/src/main/java/org/rumbledb/shell/ANSIColor.java
+++ b/src/main/java/org/rumbledb/shell/ANSIColor.java
@@ -1,0 +1,89 @@
+package org.rumbledb.shell;
+
+// https://stackoverflow.com/questions/5762491/how-to-print-color-in-console-using-system-out-println
+public enum ANSIColor {
+    // ANSIColor end string, color reset
+    RESET("\033[0m"),
+
+    // Regular Colors. Normal color, no bold, background color etc.
+    BLACK("\033[0;30m"), // BLACK
+    RED("\033[0;31m"), // RED
+    GREEN("\033[0;32m"), // GREEN
+    YELLOW("\033[0;33m"), // YELLOW
+    BLUE("\033[0;34m"), // BLUE
+    MAGENTA("\033[0;35m"), // MAGENTA
+    CYAN("\033[0;36m"), // CYAN
+    WHITE("\033[0;37m"), // WHITE
+
+    // Bold
+    BLACK_BOLD("\033[1;30m"), // BLACK
+    RED_BOLD("\033[1;31m"), // RED
+    GREEN_BOLD("\033[1;32m"), // GREEN
+    YELLOW_BOLD("\033[1;33m"), // YELLOW
+    BLUE_BOLD("\033[1;34m"), // BLUE
+    MAGENTA_BOLD("\033[1;35m"), // MAGENTA
+    CYAN_BOLD("\033[1;36m"), // CYAN
+    WHITE_BOLD("\033[1;37m"), // WHITE
+
+    // Underline
+    BLACK_UNDERLINED("\033[4;30m"), // BLACK
+    RED_UNDERLINED("\033[4;31m"), // RED
+    GREEN_UNDERLINED("\033[4;32m"), // GREEN
+    YELLOW_UNDERLINED("\033[4;33m"), // YELLOW
+    BLUE_UNDERLINED("\033[4;34m"), // BLUE
+    MAGENTA_UNDERLINED("\033[4;35m"), // MAGENTA
+    CYAN_UNDERLINED("\033[4;36m"), // CYAN
+    WHITE_UNDERLINED("\033[4;37m"), // WHITE
+
+    // Background
+    BLACK_BACKGROUND("\033[40m"), // BLACK
+    RED_BACKGROUND("\033[41m"), // RED
+    GREEN_BACKGROUND("\033[42m"), // GREEN
+    YELLOW_BACKGROUND("\033[43m"), // YELLOW
+    BLUE_BACKGROUND("\033[44m"), // BLUE
+    MAGENTA_BACKGROUND("\033[45m"), // MAGENTA
+    CYAN_BACKGROUND("\033[46m"), // CYAN
+    WHITE_BACKGROUND("\033[47m"), // WHITE
+
+    // High Intensity
+    BLACK_BRIGHT("\033[0;90m"), // BLACK
+    RED_BRIGHT("\033[0;91m"), // RED
+    GREEN_BRIGHT("\033[0;92m"), // GREEN
+    YELLOW_BRIGHT("\033[0;93m"), // YELLOW
+    BLUE_BRIGHT("\033[0;94m"), // BLUE
+    MAGENTA_BRIGHT("\033[0;95m"), // MAGENTA
+    CYAN_BRIGHT("\033[0;96m"), // CYAN
+    WHITE_BRIGHT("\033[0;97m"), // WHITE
+
+    // Bold High Intensity
+    BLACK_BOLD_BRIGHT("\033[1;90m"), // BLACK
+    RED_BOLD_BRIGHT("\033[1;91m"), // RED
+    GREEN_BOLD_BRIGHT("\033[1;92m"), // GREEN
+    YELLOW_BOLD_BRIGHT("\033[1;93m"), // YELLOW
+    BLUE_BOLD_BRIGHT("\033[1;94m"), // BLUE
+    MAGENTA_BOLD_BRIGHT("\033[1;95m"), // MAGENTA
+    CYAN_BOLD_BRIGHT("\033[1;96m"), // CYAN
+    WHITE_BOLD_BRIGHT("\033[1;97m"), // WHITE
+
+    // High Intensity backgrounds
+    BLACK_BACKGROUND_BRIGHT("\033[0;100m"), // BLACK
+    RED_BACKGROUND_BRIGHT("\033[0;101m"), // RED
+    GREEN_BACKGROUND_BRIGHT("\033[0;102m"), // GREEN
+    YELLOW_BACKGROUND_BRIGHT("\033[0;103m"), // YELLOW
+    BLUE_BACKGROUND_BRIGHT("\033[0;104m"), // BLUE
+    MAGENTA_BACKGROUND_BRIGHT("\033[0;105m"), // MAGENTA
+    CYAN_BACKGROUND_BRIGHT("\033[0;106m"), // CYAN
+    WHITE_BACKGROUND_BRIGHT("\033[0;107m"); // WHITE
+
+    private final String code;
+
+    ANSIColor(String code) {
+        this.code = code;
+    }
+
+    @Override
+    public String toString() {
+        return this.code;
+    }
+}
+

--- a/src/main/java/org/rumbledb/shell/RumbleJLineShell.java
+++ b/src/main/java/org/rumbledb/shell/RumbleJLineShell.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 
 public class RumbleJLineShell {
     private static final String EXIT_COMMAND = "exit";
-    private static final String PROMPT = "rumble$ ";
+    private static final String PROMPT = ANSIColor.CYAN + "rumble$ " + ANSIColor.RESET;
     private static final String MID_QUERY_PROMPT = ">>> ";
     private final boolean printTime;
     private final RumbleRuntimeConfiguration configuration;
@@ -130,14 +130,14 @@ public class RumbleJLineShell {
                     handleException(new OurBadException(ex.getMessage()), showErrorInfo);
                 }
             } else if (ex instanceof SparksoniqRuntimeException) {
-                System.err.println("⚠️  ️" + ex.getMessage());
+                System.err.println("⚠️  ️" + ANSIColor.RED + ex.getMessage() + ANSIColor.RESET);
                 if (showErrorInfo) {
                     ex.printStackTrace();
                 }
             } else if (!(ex instanceof UserInterruptException)) {
                 System.out.println("An error has occurred: " + ex.getMessage());
                 System.out.println(
-                    "We should investigate this 🙈. Please contact us or file an issue on GitHub with your query."
+                    "We should investigate this 🙈. Please contact us or file an issue on GitHub with your query. "
                 );
                 System.out.println("Link: https://github.com/RumbleDB/rumble/issues");
                 if (showErrorInfo) {
@@ -148,7 +148,7 @@ public class RumbleJLineShell {
     }
 
     public void output(String message) {
-        System.out.println(message);
+        System.out.println(ANSIColor.YELLOW + message + ANSIColor.RESET);
     }
 
     private String getPrompt() {


### PR DESCRIPTION
@ghislainfourny I had a visually customized Rumble version running during my thesis demo. I wanted to share the colored output customization by removing the other demo-specific bits.

If you think this would be nice feature we can tweak the shell's look to your liking and add this to the master. 

Default look:
<img width="1084" alt="image" src="https://user-images.githubusercontent.com/13052327/80794856-372b5580-8b9b-11ea-9484-a56ae72b2147.png">

Custom look at the moment:
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/13052327/80794718-e61b6180-8b9a-11ea-8518-d82ff37a3710.png">


