### PR TITLE
Lift up local iteration to RDD instead of throwing error.

### DIFF
--- a/src/main/java/org/rumbledb/runtime/HybridRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/HybridRuntimeIterator.java
@@ -134,8 +134,11 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
             Dataset<Row> df = this.getDataFrame(context);
             JavaRDD<Row> rowRDD = df.javaRDD();
             return rowRDD.map(new RowToItemMapper(getMetadata()));
-        } else {
+        } else if (isRDD()) {
             return getRDDAux(context);
+        } else {
+            List<Item> contents = this.materialize(context);
+            return SparkSessionManager.getInstance().getJavaSparkContext().parallelize(contents);
         }
     }
 


### PR DESCRIPTION
This does not affect existing code, but is a preparation of more code to be merged for conditional expressions, switch expressions and typeswitch expressions where the RDDness of the branches might differ and we need to lift up to RDD to avoid errors.