### PR TITLE
Add test case that shows that importing a module repeatedly is broken.

### DIFF
--- a/src/main/resources/test_files/runtime/LibraryModules/modulerepeatedimport.jq
+++ b/src/main/resources/test_files/runtime/LibraryModules/modulerepeatedimport.jq
@@ -1,0 +1,8 @@
+(:JIQS: ShouldNotParse; ErrorCode="XPST0003"; ErrorMetadata="LINE:0:COLUMN:0:" :)
+module namespace my-module = "moduleimportingmodule.jq";
+import module namespace mod1 = "moduleimportingmodule.jq";
+import module namespace mod2 = "module.jq";
+
+declare function my-module:func() {
+  mod1:func() + mod2:func()
+};


### PR DESCRIPTION
I added a test case which I think should fail currently. I don't know how to run the tests, so I don't know if it actually breaks. I think that this is due to a bug: if I include `moduleA` and `moduleB`, `moduleA` should be allowed to include `moduleB` without me knowing.