### PR TITLE
Fix: Exception when grouping with keys of different types

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
@@ -63,10 +63,52 @@ public class FlworKey implements KryoSerializable {
     @Override
     public boolean equals(Object otherKey) {
         if (otherKey instanceof FlworKey) {
-            return this.compareWithFlworKey((FlworKey) otherKey, null) == 0;
+            return this.equalFlworKey((FlworKey) otherKey);
         } else {
             return false;
         }
+    }
+
+    /**
+     * Invariant - two Flworkeys have the same length
+     *
+     * @param flworKey "other" FlworKey to be compared against
+     * @return true if both items are equal, false otherwise (also when types are different)
+     */
+    public boolean equalFlworKey(FlworKey flworKey) {
+        if (this.keyItems.size() != flworKey.keyItems.size()) {
+            throw new OurBadException("Invalid sort key: Key sizes can't be different.");
+        }
+
+        // iterate over every ordering expression of this flworkey
+        int index = 0;
+        while (index < this.keyItems.size()) {
+            Item item1 = this.keyItems.get(index);
+            Item item2 = flworKey.keyItems.get(index);
+
+            // check for incorrect ordering inputs
+            if (
+                (item1 != null && !item1.isAtomic())
+                    ||
+                    (item2 != null && !item2.isAtomic())
+            ) {
+                throw new RumbleException("Non atomic key not allowed");
+            }
+
+            long comparison = ComparisonIterator.compareItems(
+                item1,
+                item2,
+                ComparisonOperator.VC_EQ,
+                ExceptionMetadata.EMPTY_METADATA
+            );
+            if (comparison != 0) {
+                return false;
+            }
+
+            index++;
+        }
+
+        return true;
     }
 
     /**

--- a/src/test/resources/test_files/runtime-spark/DataFrames/GroupbyClauseType2.jq
+++ b/src/test/resources/test_files/runtime-spark/DataFrames/GroupbyClauseType2.jq
@@ -1,0 +1,5 @@
+(:JIQS: ShouldRun; Output=(1, 49) :)
+for $x in ("1", 49)
+group by $x
+order by string($x)
+return $x

--- a/src/test/resources/test_files/runtime/TypeChecking/GroupByClauseType3.jq
+++ b/src/test/resources/test_files/runtime/TypeChecking/GroupByClauseType3.jq
@@ -1,0 +1,5 @@
+(:JIQS: ShouldRun; Output=(1, 49) :)
+for $x in ("1", 49)
+group by $x
+order by string($x)
+return $x


### PR DESCRIPTION
This PR addresses the comparison issue in group by when items of different types are compared.

I opted to create an additional function `boolean equalFlworKey()` that doesn't throw an exception upon type mismatch and instead returns false.

There were other approaches I considered:
- Have `compareWithFlworKey` not throw exception upon type mismatch and return instead -2: Let callers deal with this case
  - 🚫 Caller looses information about why the comparison failed, can't throw error message with detailed error message anymore (without further refactoring)
- Add a boolean flag `compareWithFlworKey` that determines whether exception should be thrown: If true, throw exception upon type mismatch, otherwise return -2
  - 🚫 Changes signature of public method
  - 🚫 Different return values based on function arguments

Please let me know if you'd prefer a different approach.