### PR TITLE
Finalizing command line parameters for context item values

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -34,4 +34,7 @@ Previous parameters (--shell, --query-path, --server) work in a backward compati
 | --host  | -h | N/A  |  localhost (default) |  Changes the host of the RumbleDB HTTP server to any of your liking |
 | --variable:foo | N/A | variable:foo  |  bar |  --variable:foo bar initialize the global variable $foo to "bar". The query must contain the corresponding global variable declaration, e.g., "declare variable $foo external;" |
 | --context-item | -I | context-item  |  bar |  initializes the global context item $$ to "bar". The query must contain the corresponding global variable declaration, e.g., "declare context item external;" |
+| --context-item-input | -i | context-item-input  | - |  reads the context item value from the standard input |
+| --context-item-input-format | N/A | context-item-input-format  |  text or json |  sets the input format to use
+for parsing the standard input (as text or as a serialized json value) |
 

--- a/src/main/java/org/rumbledb/compiler/DynamicContextVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/DynamicContextVisitor.java
@@ -254,7 +254,7 @@ public class DynamicContextVisitor extends AbstractNodeVisitor<DynamicContext> {
                 );
             return argument;
         }
-        if (name.equals(Name.CONTEXT_ITEM) && this.configuration.readContextItemFromStandardInput()) {
+        if (name.equals(Name.CONTEXT_ITEM) && this.configuration.readFromStandardInput(Name.CONTEXT_ITEM)) {
             StringBuilder stringBuilder = new StringBuilder();
             BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
             String l;
@@ -263,7 +263,22 @@ public class DynamicContextVisitor extends AbstractNodeVisitor<DynamicContext> {
                     stringBuilder.append(l);
                 }
                 value = stringBuilder.toString();
-                items.add(ItemParser.getItemFromString(value, ExceptionMetadata.EMPTY_METADATA));
+                String inputFormat = this.configuration.getInputFormat(Name.CONTEXT_ITEM);
+                switch (inputFormat) {
+                    case "json":
+                        items.add(ItemParser.getItemFromString(value, ExceptionMetadata.EMPTY_METADATA));
+                        break;
+                    case "text":
+                        items.add(ItemFactory.getInstance().createStringItem(value));
+                        break;
+                    default:
+                        throw new AbsentPartOfDynamicContextException(
+                                "Unrecognized input format: "
+                                    + this.configuration.getInputFormat(Name.CONTEXT_ITEM)
+                                    + ". Expecting text or json.",
+                                variableDeclaration.getMetadata()
+                        );
+                }
                 argument.getVariableValues()
                     .addVariableValue(
                         name,

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -196,19 +196,22 @@ public class TranslationVisitor extends org.rumbledb.parser.JsoniqBaseVisitor<No
         Prolog prolog = (Prolog) this.visitProlog(ctx.prolog());
         // We override with a context item declaration if not present already.
         Expression commaExpression = (Expression) this.visitExpr(ctx.expr());
-        if (
-            commaExpression.isContextDependent() && !prolog.hasContextItemDeclaration()
-        ) {
-            System.err.println("[WARNING] Adding context item declaration.");
-            prolog.addDeclaration(
-                new VariableDeclaration(
-                        Name.CONTEXT_ITEM,
-                        true,
-                        SequenceType.ITEM,
-                        null,
-                        createMetadataFromContext(ctx)
-                )
-            );
+        if (!prolog.hasContextItemDeclaration()) {
+            if (
+                this.configuration.readFromStandardInput(Name.CONTEXT_ITEM)
+                    || this.configuration.getUnparsedExternalVariableValue(Name.CONTEXT_ITEM) != null
+            ) {
+                System.err.println("[WARNING] Adding context item declaration.");
+                prolog.addDeclaration(
+                    new VariableDeclaration(
+                            Name.CONTEXT_ITEM,
+                            true,
+                            SequenceType.ITEM,
+                            null,
+                            createMetadataFromContext(ctx)
+                    )
+                );
+            }
         }
 
         MainModule module = new MainModule(prolog, commaExpression, createMetadataFromContext(ctx));

--- a/src/main/java/org/rumbledb/config/RumbleRuntimeConfiguration.java
+++ b/src/main/java/org/rumbledb/config/RumbleRuntimeConfiguration.java
@@ -77,6 +77,7 @@ public class RumbleRuntimeConfiguration implements Serializable, KryoSerializabl
     public RumbleRuntimeConfiguration() {
         this.arguments = new HashMap<>();
         initShortcuts();
+        init();
     }
 
     private void initShortcuts() {

--- a/src/main/java/org/rumbledb/context/DynamicContext.java
+++ b/src/main/java/org/rumbledb/context/DynamicContext.java
@@ -28,7 +28,6 @@ import org.apache.spark.api.java.JavaRDD;
 import org.joda.time.DateTime;
 import org.rumbledb.api.Item;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
-import org.rumbledb.context.DynamicContext.VariableDependency;
 import org.rumbledb.exceptions.OurBadException;
 import org.rumbledb.items.structured.JSoundDataFrame;
 

--- a/src/main/java/org/rumbledb/shell/RumbleJLineShell.java
+++ b/src/main/java/org/rumbledb/shell/RumbleJLineShell.java
@@ -58,7 +58,6 @@ public class RumbleJLineShell {
     private LineReader lineReader;
     private JsoniqQueryExecutor jsoniqQueryExecutor;
     private boolean queryStarted;
-    private String previousLine = "";
     private String currentLine = "";
     private String currentQueryContent = "";
     private String welcomeMessage;
@@ -85,7 +84,6 @@ public class RumbleJLineShell {
                         processQuery();
                     }
                 }
-                this.previousLine = this.currentLine;
             } catch (Exception ex) {
                 handleException(ex, this.configuration.getShowErrorInfo());
             }

--- a/src/test/java/iq/base/AnnotationsTestsBase.java
+++ b/src/test/java/iq/base/AnnotationsTestsBase.java
@@ -54,8 +54,6 @@ public class AnnotationsTestsBase {
     protected List<File> testFiles = new ArrayList<>();
     protected static final RumbleRuntimeConfiguration configuration = new RumbleRuntimeConfiguration(
             new String[] {
-                "--read-context-item-from-standard-input",
-                "no",
                 "--print-iterator-tree",
                 "yes",
                 "--variable:externalUnparsedString",

--- a/src/test/resources/test_files/runtime/PostFixObjectLookup/ErrorPostFixObjectLookup4.jq
+++ b/src/test/resources/test_files/runtime/PostFixObjectLookup/ErrorPostFixObjectLookup4.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="XPDY0002"; :)
+(:JIQS: ShouldCrash; ErrorCode="XPDY0130"; :)
 let $o := {"foobar": 2, "1" : "bar"} return $o.$$
 
 (: context expression undefined :)


### PR DESCRIPTION
Example uses:

    echo '{ "foo" : [ 100, 200 ] }' | java -jar rumbledb.jar -q '$$.foo[]' --context-item-input -

    echo '{ "foo" : [ 100, 200 ] }' | java -jar rumbledb.jar -q '$$.foo[]' -i -

    echo '{}}}}[[[}' | java -jar rumbledb.jar -q '$$' --context-item-input - --context-item-input-format text

    java -jar rumbledb.jar -q '$$' --context-item 'foo'

    java -jar rumbledb.jar -q '$$' -I 'foo'
