### PR TITLE
Potential security vulnerability in the C library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.12</artifactId>
-            <version>3.1.2</version>
+            <version>3.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Hi, @ghislainfourny , @CanBerker , I'd like to report a vulnerable dependency in **com.github.rumbledb:spark-rumble**.
### Issue Description
I noticed that **com.github.rumbledb:spark-rumble** directly depends on **org.apache.spark:spark-core_2.12:3.1.2** in the `master` branch. However, as shown in the following dependency graph, **org.apache.spark:spark-core_2.12:3.1.2** sufferes from the vulnerability which the C library **zstd(version:1.4.8)** exposed: [CVE-2021-24032](https://nvd.nist.gov/vuln/detail/CVE-2021-24032)
### Dependency Graph between Java and Shared Libraries
![image (12)](https://user-images.githubusercontent.com/103260963/163583890-bff98fec-f01c-40da-a01a-51502df454e0.png)
### Suggested Vulnerability Patch Versions
**org.apache.spark:spark-core_2.12:3.2.0** (**>=3.2.0**) has upgraded this vulnerable C library `zstd` to the patch version **1.5.0**.

Java build tools cannot report vulnerable C libraries, which may induce potential security issues to many downstream Java projects. Could you please upgrade this vulnerable dependency?

Thanks for your help~
Best regards,
Helen Parr