### PR TITLE
Mschoeb dominik merge

### DIFF
--- a/src/main/java/org/rumbledb/compiler/ProjectionPushdownVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/ProjectionPushdownVisitor.java
@@ -58,15 +58,24 @@ public class ProjectionPushdownVisitor extends CloneVisitor {
 
     @Override
     public Node visitLetClause(LetClause clause, Node argument) {
-        if (clause.getReferenced()) {
-            return new LetClause(
-                    clause.getVariableName(),
-                    clause.getActualSequenceType(),
-                    (Expression) visit(clause.getExpression(), argument),
-                    clause.getMetadata()
-            );
-        }
-        return null;
+        return new LetClause(
+                clause.getVariableName(),
+                clause.getActualSequenceType(),
+                (Expression) visit(clause.getExpression(), argument),
+                clause.getMetadata()
+        );
+
+        // code below from dominik
+        // problem is that it removes the last let clause (returns null for that)
+        // if (clause.getReferenced()) {
+        // return new LetClause(
+        // clause.getVariableName(),
+        // clause.getActualSequenceType(),
+        // (Expression) visit(clause.getExpression(), argument),
+        // clause.getMetadata()
+        // );
+        // }
+        // return null;
     }
 
     @Override

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/OrderByClauseSparkIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/OrderByClauseSparkIterator.java
@@ -553,6 +553,16 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
             List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator,
             NativeClauseContext orderContext
     ) {
+        return NativeClauseContext.NoNativeQuery;
+        // below is code from dominik
+        // disabled for now since it accesses resultingType which is not set
+        // return createOrderExpressionDominik(expressionsWithIterator, orderContext);
+    }
+
+    private static NativeClauseContext createOrderExpressionDominik(
+            List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator,
+            NativeClauseContext orderContext
+    ) {
         StringBuilder orderSql = new StringBuilder();
         String orderSeparator = "";
         for (OrderByClauseAnnotatedChildIterator orderIterator : expressionsWithIterator) {


### PR DESCRIPTION
This PR contains some steps towards merging the work of dominik. It includes:

- disable OrderByClauseSparkIterator.createOrderExpression(). many errors happen due to 
OrderByClauseSparkIterator.createOrderExpression() trying to access the resultingtype which is not set. The NativeClauseContext is created in OrderByClauseSparkIterator.tryNativeQuery without a resultingType. I disabled this new functionality and now it just falls back to not using a native query
- In flowr clauses, the last LET clause was often deleted. This happened due to the new ProjectionPushdownVisitor not correctly visiting all let clauses. Now it visits them all

I left in the original codes as references. These two changes decrease the amount of failing tests from 580 to 64 on gitlab

But I think this whole merge is quite a tricky one, the issues that are still left are all over the place and its very tedious. I dont see this being merged without a lot more work and I dont really have the time to continue to do more on this. And if I find some time, I will probably contribute some other smaller improvements to Rumble instead