### PR TITLE
fix: update GitHub Actions dependencies in QT3 test

### DIFF
--- a/.github/workflows/run-qt3.yml
+++ b/.github/workflows/run-qt3.yml
@@ -29,23 +29,23 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Download JSONiq artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: collected-artifacts-jsoniq
           path: artifacts/jsoniq
       - name: Download XQuery artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: collected-artifacts-xquery
           path: artifacts/xquery
       - name: Generate and post comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { execSync } = require('child_process');


### PR DESCRIPTION
This is due to the Node.js 20 deprecation notice.

Similar pull request has been created for Rumble Test Suite: https://github.com/RumbleDB/rumble-test-suite/pull/10