### PR TITLE
Fix lazy map string key enumeration

### DIFF
--- a/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
@@ -102,7 +102,7 @@ public class MapWithAdditionalEntryItem implements Item {
     public List<String> getStringKeys() {
         List<String> result = new ArrayList<>();
         for (String key : this.original.getStringKeys()) {
-            if (key.equals(this.additionalKey.getStringValue())) {
+            if (!key.equals(this.additionalKey.getStringValue())) {
                 result.add(key);
             }
         }


### PR DESCRIPTION
The condition should have `!` prefixed