### PR TITLE
Fix lazy object copy keys

### DIFF
--- a/src/main/java/org/rumbledb/items/LazyObjectItem.java
+++ b/src/main/java/org/rumbledb/items/LazyObjectItem.java
@@ -91,14 +91,16 @@ public class LazyObjectItem implements Item {
 
     @Override
     public Item copy(boolean mutable) {
-        List<String> newKeys = new ArrayList<>(this.keys);
+        List<String> newKeys = new ArrayList<>(this.keys.size());
         List<Item> newValues = new ArrayList<>();
         for (String key : this.getKeys()) {
             newKeys.add(key);
             newValues.add(this.getItemByKey(key).copy(mutable));
         }
         Item result = new ObjectItem(newKeys, newValues, ExceptionMetadata.EMPTY_METADATA);
-        result.setMutabilityLevel(0);
+        if (mutable) {
+            result.setMutabilityLevel(0);
+        }
         return result;
 
     }


### PR DESCRIPTION
NewKeys should not be initialized already with existing keys item on copy, because they are added later one by one.

Also, setMutabilityLevel(0) should be called if the copy is mutable