### PR TITLE
feat: add method to retrieve unmodifiable map of builtin functions

### DIFF
--- a/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
+++ b/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
@@ -246,9 +246,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class BuiltinFunctionCatalogue {
     private static final HashMap<FunctionIdentifier, BuiltinFunction> builtinFunctions;
+
+    public static Map<FunctionIdentifier, BuiltinFunction> getBuiltinFunctions() {
+        return Collections.unmodifiableMap(builtinFunctions);
+    }
 
     public static BuiltinFunction getBuiltinFunction(FunctionIdentifier identifier) {
         if (builtinFunctions.containsKey(identifier)) {


### PR DESCRIPTION
This is useful for LSP, which needs to retrieve the list of builtin functions. Currently it's done via reflection