### PR TITLE
fix: JSONiq and XQuery version string should also accept a version in single quote

### DIFF
--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -244,11 +244,12 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitModule(JsoniqParser.ModuleContext ctx) {
         if (!(ctx.vers == null) && !ctx.vers.isEmpty()) {
-            if (ctx.vers.getText().trim().equals("\"1.0\"")) {
+            String version = processStringLiteral(ctx.vers).trim();
+            if (version.equals("1.0")) {
                 this.moduleContext.setQueryLanguage("jsoniq10");
-            } else if (ctx.vers.getText().trim().equals("\"3.1\"")) {
+            } else if (version.equals("3.1")) {
                 this.moduleContext.setQueryLanguage("jsoniq31");
-            } else if (ctx.vers.getText().trim().equals("\"4.0\"")) {
+            } else if (version.equals("4.0")) {
                 this.moduleContext.setQueryLanguage("jsoniq40");
             } else {
                 throw new JsoniqVersionException(createMetadataFromContext(ctx));

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -227,13 +227,14 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitModule(XQueryParser.ModuleContext ctx) {
         if (!(ctx.vers == null) && !ctx.vers.isEmpty()) {
-            if (ctx.vers.getText().trim().equals("\"1.0\"")) {
+            String version = processStringLiteral(ctx.vers).trim();
+            if (version.equals("1.0")) {
                 this.moduleContext.setQueryLanguage("xquery10");
-            } else if (ctx.vers.getText().trim().equals("\"3.0\"")) {
+            } else if (version.equals("3.0")) {
                 this.moduleContext.setQueryLanguage("xquery31");
-            } else if (ctx.vers.getText().trim().equals("\"3.1\"")) {
+            } else if (version.equals("3.1")) {
                 this.moduleContext.setQueryLanguage("xquery31");
-            } else if (ctx.vers.getText().trim().equals("\"4.0\"")) {
+            } else if (version.equals("4.0")) {
                 this.moduleContext.setQueryLanguage("xquery40");
             } else {
                 throw new JsoniqVersionException(createMetadataFromContext(ctx));

--- a/src/test/resources/test_files/parser/VersionSingleQuotes.jq
+++ b/src/test/resources/test_files/parser/VersionSingleQuotes.jq
@@ -1,0 +1,3 @@
+(:JIQS: ShouldRun; Output="2" :)
+jsoniq version '3.1';
+1 + 1


### PR DESCRIPTION
According to the grammar file, single quoted version number should also be valid as it's a `stringLiteral`:

```
module : // replaced with the versionDecl production to match the JSONiq grammar
         (KW_JSONIQ KW_VERSION vers=stringLiteral (KW_ENCODING encoding=stringLiteral)? SEMICOLON)?
         // TODO: subsequent optional main modules are currently ignored
         (libraryModule | main=mainModule) ;
```