### PR TITLE
fix: XML attribute parsing error in JSONiq parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,20 +22,9 @@ derby.log
 src/main/java/jsound/
 src/main/resources/log4j.properties
 
-/src/main/java/org/rumbledb/parser/jsoniq/
-!/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
-!/src/main/java/org/rumbledb/parser/jsoniq/JsoniqLexer.g4
-
 # ANTLR
 *.tokens
 *.interp
-
-# ANTLR generated files for XQuery parser
-/src/main/java/org/rumbledb/parser/xquery/XQueryParser.java
-/src/main/java/org/rumbledb/parser/xquery/XQueryParserBaseVisitor.java
-/src/main/java/org/rumbledb/parser/xquery/XQueryParserVisitor.java
-
-# ANTLR generated files for XQuery lexer
-/src/main/java/org/rumbledb/parser/xquery/XQueryLexer.java
+.antlr
 
 .vscode/settings.json

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -4054,8 +4054,22 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
                 (JsoniqParser.DirAttributeValueQuotContext) child,
                 allowEnclosedExpressions
             );
+        } else if (
+            child instanceof TerminalNode
+                &&
+                ((TerminalNode) child).getSymbol().getType() == JsoniqParser.STRING
+        ) {
+            return this.getStringAttributeValueExpressions(((TerminalNode) child).getText(), ctx);
         }
         throw new UnsupportedOperationException("Unsupported attribute value: " + ctx.getText());
+    }
+
+    private List<Expression> getStringAttributeValueExpressions(String text, ParserRuleContext ctx) {
+        String rawValue = text.substring(1, text.length() - 1);
+        String unescapedValue = unescapeStringLiteral(rawValue);
+        List<Expression> expressions = new ArrayList<>();
+        expressions.add(new AttributeNodeContentExpression(unescapedValue, createMetadataFromContext(ctx)));
+        return expressions;
     }
 
     private String getNamespaceDeclarationUri(JsoniqParser.DirAttributeValueContext ctx) {

--- a/src/main/java/org/rumbledb/parser/jsoniq/JsoniqLexer.g4
+++ b/src/main/java/org/rumbledb/parser/jsoniq/JsoniqLexer.g4
@@ -20,7 +20,7 @@ package org.rumbledb.parser.jsoniq;
 // handled by the parser and not the lexer.
 
 // Tokens declared but not defined
-tokens {EscapeQuot, EscapeApos, DOUBLE_LBRACE, DOUBLE_RBRACE}
+tokens {EscapeQuot, EscapeApos, DOUBLE_LBRACE, DOUBLE_RBRACE, JsonEscape}
 
 @members {
     ///
@@ -302,6 +302,11 @@ KW_TRUE:               'true';
 KW_FALSE:              'false';
 KW_STATICALLY:         'statically';
 
+fragment ESC            : '\\' (["\\/bfnrt] | UNICODE);
+fragment ESCapos        : '\\' (['\\/bfnrt] | UNICODE);
+fragment UNICODE        : 'u' HEX HEX HEX HEX;
+fragment HEX            : [0-9a-fA-F];
+
 // NAMES
 
 // added the BracedURILiteral rule
@@ -407,6 +412,7 @@ LBRACE_QuotString               : '{' -> type(LBRACE), pushMode(STRING_INTERPOLA
 RBRACE_QuotString               : '}' -> type(RBRACE);
 PredefinedEntityRef_QuotString  : '&' ('lt'|'gt'|'amp'|'quot'|'apos') ';'  -> type(PredefinedEntityRef);
 CharRef_QuotString              : ('&#' [0-9]+ ';' | '&#x' [0-9a-fA-F]+ ';') -> type(CharRef);
+JsonEscape_QuotString           : ESC -> type(JsonEscape);
 ContentChar_QuotString          : ~["&{}] -> type(ContentChar);
 
 mode APOS_LITERAL_STRING;
@@ -420,6 +426,7 @@ LBRACE_AposString               : '{' -> type(LBRACE), pushMode(STRING_INTERPOLA
 RBRACE_AposString               : '}' -> type(RBRACE);
 PredefinedEntityRef_AposString  : '&' ('lt'|'gt'|'amp'|'quot'|'apos') ';'  -> type(PredefinedEntityRef);
 CharRef_AposString              : ('&#' [0-9]+ ';' | '&#x' [0-9a-fA-F]+ ';') -> type(CharRef);
+JsonEscape_AposString           : ESCapos -> type(JsonEscape);
 ContentChar_AposString          : ~['&{}] -> type(ContentChar);
 
 mode STRING_INTERPOLATION_MODE_QUOT;

--- a/src/main/java/org/rumbledb/parser/jsoniq/JsoniqLexer.g4
+++ b/src/main/java/org/rumbledb/parser/jsoniq/JsoniqLexer.g4
@@ -302,12 +302,6 @@ KW_TRUE:               'true';
 KW_FALSE:              'false';
 KW_STATICALLY:         'statically';
 
-STRING                  : '"' (ESC | ~ ["\\])* '"' | '\'' (ESCapos | ~ ['\\])* '\'';
-fragment ESC            : '\\' (["\\/bfnrt] | UNICODE);
-fragment ESCapos        : '\\' (['\\/bfnrt] | UNICODE);
-fragment UNICODE        : 'u' HEX HEX HEX HEX;
-fragment HEX            : [0-9a-fA-F];
-
 // NAMES
 
 // added the BracedURILiteral rule

--- a/src/main/java/org/rumbledb/parser/jsoniq/JsoniqLexer.g4
+++ b/src/main/java/org/rumbledb/parser/jsoniq/JsoniqLexer.g4
@@ -20,7 +20,7 @@ package org.rumbledb.parser.jsoniq;
 // handled by the parser and not the lexer.
 
 // Tokens declared but not defined
-tokens {EscapeQuot, EscapeApos, DOUBLE_LBRACE, DOUBLE_RBRACE, JsonEscape}
+tokens {EscapeQuot, EscapeApos, DOUBLE_LBRACE, DOUBLE_RBRACE}
 
 @members {
     ///
@@ -302,6 +302,7 @@ KW_TRUE:               'true';
 KW_FALSE:              'false';
 KW_STATICALLY:         'statically';
 
+STRING                  : '"' (ESC | ~ ["\\])* '"' | '\'' (ESCapos | ~ ['\\])* '\'';
 fragment ESC            : '\\' (["\\/bfnrt] | UNICODE);
 fragment ESCapos        : '\\' (['\\/bfnrt] | UNICODE);
 fragment UNICODE        : 'u' HEX HEX HEX HEX;
@@ -412,7 +413,6 @@ LBRACE_QuotString               : '{' -> type(LBRACE), pushMode(STRING_INTERPOLA
 RBRACE_QuotString               : '}' -> type(RBRACE);
 PredefinedEntityRef_QuotString  : '&' ('lt'|'gt'|'amp'|'quot'|'apos') ';'  -> type(PredefinedEntityRef);
 CharRef_QuotString              : ('&#' [0-9]+ ';' | '&#x' [0-9a-fA-F]+ ';') -> type(CharRef);
-JsonEscape_QuotString           : ESC -> type(JsonEscape);
 ContentChar_QuotString          : ~["&{}] -> type(ContentChar);
 
 mode APOS_LITERAL_STRING;
@@ -426,7 +426,6 @@ LBRACE_AposString               : '{' -> type(LBRACE), pushMode(STRING_INTERPOLA
 RBRACE_AposString               : '}' -> type(RBRACE);
 PredefinedEntityRef_AposString  : '&' ('lt'|'gt'|'amp'|'quot'|'apos') ';'  -> type(PredefinedEntityRef);
 CharRef_AposString              : ('&#' [0-9]+ ';' | '&#x' [0-9a-fA-F]+ ';') -> type(CharRef);
-JsonEscape_AposString           : ESCapos -> type(JsonEscape);
 ContentChar_AposString          : ~['&{}] -> type(ContentChar);
 
 mode STRING_INTERPOLATION_MODE_QUOT;

--- a/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
+++ b/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
@@ -851,7 +851,30 @@ keywordOKForFunction: KW_ANCESTOR
 
 uriLiteral: stringLiteral ;
 
-stringLiteral: STRING;
+stringLiteralQuot : Quot (PredefinedEntityRef | CharRef | EscapeQuot | stringContentQuot )* Quot ;
+stringLiteralApos : Apos (PredefinedEntityRef | CharRef | EscapeApos | stringContentApos )* Apos ;
+
+stringLiteral : stringLiteralQuot
+              | stringLiteralApos
+              ;
+
+stringContentQuot : ContentChar+
+                  | LBRACE expr? RBRACE?
+                  | RBRACE
+                  | DOUBLE_LBRACE
+                  | DOUBLE_RBRACE
+                  | noQuotesNoBracesNoAmpNoLAng
+                  | stringLiteralApos
+                  ;
+
+stringContentApos : ContentChar+
+                  | LBRACE expr? RBRACE?
+                  | RBRACE
+                  | DOUBLE_LBRACE
+                  | DOUBLE_RBRACE
+                  | noQuotesNoBracesNoAmpNoLAng
+                  | stringLiteralQuot
+                  ;
 
 // ~['"{}<&]: a very common (and long!) subexpression in the W3C EBNF grammar //
 

--- a/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
+++ b/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
@@ -471,6 +471,7 @@ dirAttributeValueQuot : Apos (PredefinedEntityRef | CharRef | EscapeApos | dirAt
 
 dirAttributeValue    : dirAttributeValueApos
                      | dirAttributeValueQuot
+                     | STRING
                      ;
 
 dirAttributeContentQuot : contentChar                     
@@ -851,32 +852,7 @@ keywordOKForFunction: KW_ANCESTOR
 
 uriLiteral: stringLiteral ;
 
-stringLiteralQuot : Quot (PredefinedEntityRef | CharRef | EscapeQuot | stringContentQuot )* Quot ;
-stringLiteralApos : Apos (PredefinedEntityRef | CharRef | EscapeApos | stringContentApos )* Apos ;
-
-stringLiteral : stringLiteralQuot
-              | stringLiteralApos
-              ;
-
-stringContentQuot : ContentChar+
-                  | JsonEscape
-                  | LBRACE expr? RBRACE?
-                  | RBRACE
-                  | DOUBLE_LBRACE
-                  | DOUBLE_RBRACE
-                  | noQuotesNoBracesNoAmpNoLAng
-                  | stringLiteralApos
-                  ;
-
-stringContentApos : ContentChar+
-                  | JsonEscape
-                  | LBRACE expr? RBRACE?
-                  | RBRACE
-                  | DOUBLE_LBRACE
-                  | DOUBLE_RBRACE
-                  | noQuotesNoBracesNoAmpNoLAng
-                  | stringLiteralQuot
-                  ;
+stringLiteral: STRING;
 
 // ~['"{}<&]: a very common (and long!) subexpression in the W3C EBNF grammar //
 

--- a/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
+++ b/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
@@ -859,6 +859,7 @@ stringLiteral : stringLiteralQuot
               ;
 
 stringContentQuot : ContentChar+
+                  | JsonEscape
                   | LBRACE expr? RBRACE?
                   | RBRACE
                   | DOUBLE_LBRACE
@@ -868,6 +869,7 @@ stringContentQuot : ContentChar+
                   ;
 
 stringContentApos : ContentChar+
+                  | JsonEscape
                   | LBRACE expr? RBRACE?
                   | RBRACE
                   | DOUBLE_LBRACE

--- a/src/test/resources/test_files/parser/ErrorWrongJson2.jq
+++ b/src/test/resources/test_files/parser/ErrorWrongJson2.jq
@@ -1,2 +1,2 @@
-(:JIQS: ShouldNotParse; ErrorCode="XPST0003"; ErrorMetadata="LINE:2:COLUMN:23:" :)
+(:JIQS: ShouldNotParse; ErrorCode="XPST0003"; ErrorMetadata="LINE:1:COLUMN:16:" :)
 {"first" : "1" "second": "third", "fourth": [1,2,3], "fifth":{"f":"ff"}, "sixth": null}


### PR DESCRIPTION
close #1519 

Caused by string parsing rule in JSONiq grammar. Copied from XQuery grammar fixes the problem.