### PR TITLE
Refactor to use `instanceof` pattern matching

### DIFF
--- a/src/main/java/org/rumbledb/compiler/ExpressionClassificationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/ExpressionClassificationVisitor.java
@@ -60,14 +60,12 @@ public class ExpressionClassificationVisitor extends AbstractNodeVisitor<Express
     protected ExpressionClassification defaultAction(Node node, ExpressionClassification argument) {
         ExpressionClassification expressionClassification = this.visitDescendants(node, argument);
 
-        if (
-            !(node instanceof Expression)
-        ) {
+        if (!(node instanceof Expression expression)) {
             return expressionClassification;
         }
 
-        if (node instanceof InlineFunctionExpression) {
-            ((InlineFunctionExpression) node).setExpressionClassification(expressionClassification);
+        if (node instanceof InlineFunctionExpression inlineFunctionExpression) {
+            inlineFunctionExpression.setExpressionClassification(expressionClassification);
             return expressionClassification;
         }
         if (expressionClassification.isUpdating()) {
@@ -76,7 +74,6 @@ public class ExpressionClassificationVisitor extends AbstractNodeVisitor<Express
                     node.getMetadata()
             );
         }
-        Expression expression = (Expression) node;
         expression.setExpressionClassification(expressionClassification);
         return expressionClassification;
     }

--- a/src/main/java/org/rumbledb/compiler/FunctionInliningVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/FunctionInliningVisitor.java
@@ -39,13 +39,13 @@ public class FunctionInliningVisitor extends CloneVisitor {
     }
 
     private boolean isVariableReferenced(Node expression, Name name) {
-        if (expression instanceof VariableReferenceExpression) {
-            return ((VariableReferenceExpression) expression).getVariableName().equals(name);
+        if (expression instanceof VariableReferenceExpression variableReference) {
+            return variableReference.getVariableName().equals(name);
         }
-        if (expression instanceof Clause) {
+        if (expression instanceof Clause clause) {
             if (
-                ((Clause) expression).getPreviousClause() != null
-                    && isVariableReferenced(((Clause) expression).getPreviousClause(), name)
+                clause.getPreviousClause() != null
+                    && isVariableReferenced(clause.getPreviousClause(), name)
             ) {
                 return true;
             }
@@ -71,9 +71,9 @@ public class FunctionInliningVisitor extends CloneVisitor {
         boolean allArgumentsMatch = true;
         for (int i = 0; i < expression.getArguments().size(); i++) {
             allArgumentsMatch = allArgumentsMatch
-                && expression.getArguments().get(i) instanceof VariableReferenceExpression
+                && expression.getArguments().get(i) instanceof VariableReferenceExpression variableReference
                 && paramNames.get(i)
-                    .equals(((VariableReferenceExpression) expression.getArguments().get(i)).getVariableName());
+                    .equals(variableReference.getVariableName());
         }
         return allArgumentsMatch;
     }
@@ -468,8 +468,8 @@ public class FunctionInliningVisitor extends CloneVisitor {
             Expression argumentExpression = (Expression) visit(expression.getArguments().get(i), argument);
             // only use assignment clause when the variables have different names
             if (
-                argumentExpression instanceof VariableReferenceExpression
-                    && ((VariableReferenceExpression) argumentExpression).getVariableName().equals(paramName)
+                argumentExpression instanceof VariableReferenceExpression variableReference
+                    && variableReference.getVariableName().equals(paramName)
             ) {
                 continue;
             }

--- a/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
@@ -350,8 +350,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
         if (clause.getPreviousClause() != null) {
             previousIterator = this.visitFlowrClause(clause.getPreviousClause(), argument);
         }
-        if (clause instanceof ForClause) {
-            ForClause forClause = (ForClause) clause;
+        if (clause instanceof ForClause forClause) {
             RuntimeIterator assignmentIterator = this.visit(forClause.getExpression(), argument);
             return new ForClauseSparkIterator(
                     previousIterator,
@@ -361,8 +360,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     assignmentIterator,
                     forClause.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
-        } else if (clause instanceof LetClause) {
-            LetClause letClause = (LetClause) clause;
+        } else if (clause instanceof LetClause letClause) {
             RuntimeIterator assignmentIterator = this.visit(letClause.getExpression(), argument);
             return new LetClauseSparkIterator(
                     previousIterator,
@@ -371,9 +369,9 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     assignmentIterator,
                     letClause.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
-        } else if (clause instanceof GroupByClause) {
+        } else if (clause instanceof GroupByClause groupByClause) {
             List<GroupByClauseSparkIteratorExpression> groupingExpressions = new ArrayList<>();
-            for (GroupByVariableDeclaration var : ((GroupByClause) clause).getGroupVariables()) {
+            for (GroupByVariableDeclaration var : groupByClause.getGroupVariables()) {
                 Expression groupByExpression = var.getExpression();
                 RuntimeIterator groupByExpressionIterator = null;
                 if (groupByExpression != null) {
@@ -395,9 +393,9 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     groupingExpressions,
                     clause.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
-        } else if (clause instanceof OrderByClause) {
+        } else if (clause instanceof OrderByClause orderByClause) {
             List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator = new ArrayList<>();
-            for (OrderByClauseSortingKey orderExpr : ((OrderByClause) clause).getSortingKeys()) {
+            for (OrderByClauseSortingKey orderExpr : orderByClause.getSortingKeys()) {
                 OrderByClauseSortingKey.EMPTY_ORDER emptyOrder = orderExpr.getEmptyOrder();
                 if (emptyOrder == OrderByClauseSortingKey.EMPTY_ORDER.NONE) {
                     if (clause.getStaticContext().isEmptySequenceOrderLeast()) {
@@ -418,19 +416,19 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
             return new OrderByClauseSparkIterator(
                     previousIterator,
                     expressionsWithIterator,
-                    ((OrderByClause) clause).isStable(),
+                    orderByClause.isStable(),
                     clause.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
-        } else if (clause instanceof WhereClause) {
+        } else if (clause instanceof WhereClause whereClause) {
             return new WhereClauseSparkIterator(
                     previousIterator,
-                    this.visit(((WhereClause) clause).getWhereExpression(), argument),
+                    this.visit(whereClause.getWhereExpression(), argument),
                     clause.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
-        } else if (clause instanceof CountClause) {
+        } else if (clause instanceof CountClause countClause) {
             return new CountClauseSparkIterator(
                     previousIterator,
-                    ((CountClause) clause).getCountVariableName(),
+                    countClause.getCountVariableName(),
                     clause.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         }
@@ -726,22 +724,22 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
         Expression predicateExpression = expression.getPredicateExpression();
 
         // if we have a int in the predicate we can optimize to a SequenceLookupIterator
-        if (predicateExpression instanceof IntegerLiteralExpression) {
-            String lexicalValue = ((IntegerLiteralExpression) predicateExpression).getLexicalValue();
+        if (predicateExpression instanceof IntegerLiteralExpression integerLiteral) {
+            String lexicalValue = integerLiteral.getLexicalValue();
             if (ItemFactory.getInstance().createIntegerItem(lexicalValue).isInt()) {
                 int n = ItemFactory.getInstance().createIntegerItem(lexicalValue).getIntValue();
                 return getSequenceLookupIterator(expression, mainIterator, n);
             }
         }
 
-        if (predicateExpression instanceof DecimalLiteralExpression) {
-            if (((DecimalLiteralExpression) predicateExpression).isIntValue()) {
-                int n = ((DecimalLiteralExpression) predicateExpression).getValue().intValue();
+        if (predicateExpression instanceof DecimalLiteralExpression decimalLiteral) {
+            if (decimalLiteral.isIntValue()) {
+                int n = decimalLiteral.getValue().intValue();
                 return getSequenceLookupIterator(expression, mainIterator, n);
             }
 
             // if decimal has digits to the right of the decimal point, return empty sequence according to spec
-            if (((DecimalLiteralExpression) predicateExpression).getValue().stripTrailingZeros().scale() > 0) {
+            if (decimalLiteral.getValue().stripTrailingZeros().scale() > 0) {
                 return new EmptySequenceIterator(
                         expression.getStaticContextForRuntime(this.config, this.visitorConfig)
                 );
@@ -749,26 +747,26 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
         }
 
         if (
-            predicateExpression instanceof ComparisonExpression
-                && ((ComparisonExpression) predicateExpression).getComparisonOperator()
+            predicateExpression instanceof ComparisonExpression comparisonExpression
+                && comparisonExpression.getComparisonOperator()
                     .toString()
                     .equals("eq")
         ) {
-            Node left = predicateExpression.getChildren().get(0);
-            Node right = predicateExpression.getChildren().get(1);
+            Node left = comparisonExpression.getChildren().get(0);
+            Node right = comparisonExpression.getChildren().get(1);
 
             Node intLiteral = null;
             if (
-                left instanceof FunctionCallExpression
-                    && ((FunctionCallExpression) left).getFunctionName().getLocalName().equals("position")
+                left instanceof FunctionCallExpression functionCall
+                    && functionCall.getFunctionName().getLocalName().equals("position")
             ) {
                 if (right instanceof IntegerLiteralExpression) {
                     intLiteral = right;
                 }
             }
             if (
-                right instanceof FunctionCallExpression
-                    && ((FunctionCallExpression) right).getFunctionName().getLocalName().equals("position")
+                right instanceof FunctionCallExpression functionCall
+                    && functionCall.getFunctionName().getLocalName().equals("position")
             ) {
                 if (left instanceof IntegerLiteralExpression) {
                     intLiteral = left;

--- a/src/main/java/org/rumbledb/compiler/SequentialClassificationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/SequentialClassificationVisitor.java
@@ -62,10 +62,10 @@ public class SequentialClassificationVisitor extends AbstractNodeVisitor<Descend
 
     protected DescendentSequentialProperties defaultAction(Node node, DescendentSequentialProperties argument) {
         DescendentSequentialProperties result = this.visitDescendants(node, argument);
-        if (node instanceof Expression) {
-            ((Expression) node).setSequential(result.isSequential());
-        } else if (node instanceof Statement) {
-            ((Statement) node).setSequential(result.isSequential());
+        if (node instanceof Expression expression) {
+            expression.setSequential(result.isSequential());
+        } else if (node instanceof Statement statement) {
+            statement.setSequential(result.isSequential());
         }
         return result;
     }

--- a/src/main/java/org/rumbledb/compiler/StaticContextVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/StaticContextVisitor.java
@@ -114,14 +114,14 @@ public class StaticContextVisitor extends AbstractNodeVisitor<StaticContext> {
         if (argument == null) {
             throw new OurBadException("No static context provided!");
         }
-        if (node instanceof Expression) {
-            ((Expression) node).setStaticContext(argument);
+        if (node instanceof Expression expression) {
+            expression.setStaticContext(argument);
         }
-        if (node instanceof Statement) {
-            ((Statement) node).setStaticContext(argument);
+        if (node instanceof Statement statement) {
+            statement.setStaticContext(argument);
         }
-        if (node instanceof Clause) {
-            ((Clause) node).setStaticContext(argument);
+        if (node instanceof Clause clause) {
+            clause.setStaticContext(argument);
         }
         return node.accept(this, argument);
     }

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -875,23 +875,23 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitExprSingle(JsoniqParser.ExprSingleContext ctx) {
         ParseTree content = ctx.children.get(0);
-        if (content instanceof JsoniqParser.ExprSimpleContext) {
-            return this.visitExprSimple((JsoniqParser.ExprSimpleContext) content);
+        if (content instanceof JsoniqParser.ExprSimpleContext exprSimpleContext) {
+            return this.visitExprSimple(exprSimpleContext);
         }
-        if (content instanceof JsoniqParser.FlworExprContext) {
-            return this.visitFlworExpr((JsoniqParser.FlworExprContext) content);
+        if (content instanceof JsoniqParser.FlworExprContext flworExprContext) {
+            return this.visitFlworExpr(flworExprContext);
         }
-        if (content instanceof JsoniqParser.IfExprContext) {
-            return this.visitIfExpr((JsoniqParser.IfExprContext) content);
+        if (content instanceof JsoniqParser.IfExprContext ifExprContext) {
+            return this.visitIfExpr(ifExprContext);
         }
-        if (content instanceof JsoniqParser.SwitchExprContext) {
-            return this.visitSwitchExpr((JsoniqParser.SwitchExprContext) content);
+        if (content instanceof JsoniqParser.SwitchExprContext switchExprContext) {
+            return this.visitSwitchExpr(switchExprContext);
         }
-        if (content instanceof JsoniqParser.TypeswitchExprContext) {
-            return this.visitTypeswitchExpr((JsoniqParser.TypeswitchExprContext) content);
+        if (content instanceof JsoniqParser.TypeswitchExprContext typeswitchExprContext) {
+            return this.visitTypeswitchExpr(typeswitchExprContext);
         }
-        if (content instanceof JsoniqParser.TryCatchExprContext) {
-            return this.visitTryCatchExpr((JsoniqParser.TryCatchExprContext) content);
+        if (content instanceof JsoniqParser.TryCatchExprContext tryCatchExprContext) {
+            return this.visitTryCatchExpr(tryCatchExprContext);
         }
         throw new OurBadException("Unrecognized ExprSingle:" + content.getClass().getName());
     }
@@ -901,54 +901,54 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitExprSimple(JsoniqParser.ExprSimpleContext ctx) {
         ParseTree content = ctx.children.get(0);
-        if (content instanceof JsoniqParser.OrExprContext) {
-            return this.visitOrExpr((JsoniqParser.OrExprContext) content);
+        if (content instanceof JsoniqParser.OrExprContext orExprContext) {
+            return this.visitOrExpr(orExprContext);
         }
-        if (content instanceof JsoniqParser.QuantifiedExprContext) {
-            return this.visitQuantifiedExpr((JsoniqParser.QuantifiedExprContext) content);
+        if (content instanceof JsoniqParser.QuantifiedExprContext quantifiedExprContext) {
+            return this.visitQuantifiedExpr(quantifiedExprContext);
         }
-        if (content instanceof JsoniqParser.DeleteExprContext) {
-            return this.visitDeleteExpr((JsoniqParser.DeleteExprContext) content);
+        if (content instanceof JsoniqParser.DeleteExprContext deleteExprContext) {
+            return this.visitDeleteExpr(deleteExprContext);
         }
-        if (content instanceof JsoniqParser.InsertExprContext) {
-            return this.visitInsertExpr((JsoniqParser.InsertExprContext) content);
+        if (content instanceof JsoniqParser.InsertExprContext insertExprContext) {
+            return this.visitInsertExpr(insertExprContext);
         }
-        if (content instanceof JsoniqParser.ReplaceExprContext) {
-            return this.visitReplaceExpr((JsoniqParser.ReplaceExprContext) content);
+        if (content instanceof JsoniqParser.ReplaceExprContext replaceExprContext) {
+            return this.visitReplaceExpr(replaceExprContext);
         }
-        if (content instanceof JsoniqParser.RenameExprContext) {
-            return this.visitRenameExpr((JsoniqParser.RenameExprContext) content);
+        if (content instanceof JsoniqParser.RenameExprContext renameExprContext) {
+            return this.visitRenameExpr(renameExprContext);
         }
-        if (content instanceof JsoniqParser.AppendExprContext) {
-            return this.visitAppendExpr((JsoniqParser.AppendExprContext) content);
+        if (content instanceof JsoniqParser.AppendExprContext appendExprContext) {
+            return this.visitAppendExpr(appendExprContext);
         }
-        if (content instanceof JsoniqParser.TransformExprContext) {
-            return this.visitTransformExpr((JsoniqParser.TransformExprContext) content);
+        if (content instanceof JsoniqParser.TransformExprContext transformExprContext) {
+            return this.visitTransformExpr(transformExprContext);
         }
-        if (content instanceof JsoniqParser.PathExprContext) {
-            return this.visitPathExpr((JsoniqParser.PathExprContext) content);
+        if (content instanceof JsoniqParser.PathExprContext pathExprContext) {
+            return this.visitPathExpr(pathExprContext);
         }
 
-        if (content instanceof JsoniqParser.CreateCollectionExprContext) {
-            return this.visitCreateCollectionExpr((JsoniqParser.CreateCollectionExprContext) content);
+        if (content instanceof JsoniqParser.CreateCollectionExprContext createCollectionExprContext) {
+            return this.visitCreateCollectionExpr(createCollectionExprContext);
         }
-        if (content instanceof JsoniqParser.DeleteIndexExprContext) {
-            return this.visitDeleteIndexExpr((JsoniqParser.DeleteIndexExprContext) content);
+        if (content instanceof JsoniqParser.DeleteIndexExprContext deleteIndexExprContext) {
+            return this.visitDeleteIndexExpr(deleteIndexExprContext);
         }
-        if (content instanceof JsoniqParser.DeleteSearchExprContext) {
-            return this.visitDeleteSearchExpr((JsoniqParser.DeleteSearchExprContext) content);
+        if (content instanceof JsoniqParser.DeleteSearchExprContext deleteSearchExprContext) {
+            return this.visitDeleteSearchExpr(deleteSearchExprContext);
         }
-        if (content instanceof JsoniqParser.EditCollectionExprContext) {
-            return this.visitEditCollectionExpr((JsoniqParser.EditCollectionExprContext) content);
+        if (content instanceof JsoniqParser.EditCollectionExprContext editCollectionExprContext) {
+            return this.visitEditCollectionExpr(editCollectionExprContext);
         }
-        if (content instanceof JsoniqParser.InsertIndexExprContext) {
-            return this.visitInsertIndexExpr((JsoniqParser.InsertIndexExprContext) content);
+        if (content instanceof JsoniqParser.InsertIndexExprContext insertIndexExprContext) {
+            return this.visitInsertIndexExpr(insertIndexExprContext);
         }
-        if (content instanceof JsoniqParser.InsertSearchExprContext) {
-            return this.visitInsertSearchExpr((JsoniqParser.InsertSearchExprContext) content);
+        if (content instanceof JsoniqParser.InsertSearchExprContext insertSearchExprContext) {
+            return this.visitInsertSearchExpr(insertSearchExprContext);
         }
-        if (content instanceof JsoniqParser.TruncateCollectionExprContext) {
-            return this.visitTruncateCollectionExpr((JsoniqParser.TruncateCollectionExprContext) content);
+        if (content instanceof JsoniqParser.TruncateCollectionExprContext truncateCollectionExprContext) {
+            return this.visitTruncateCollectionExpr(truncateCollectionExprContext);
         }
         throw new OurBadException("Translation Visitor: Unrecognized ExprSimple.");
     }
@@ -980,18 +980,18 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         Clause previousFLWORClause = clause.getLastClause();
 
         for (ParseTree child : ctx.children.subList(1, ctx.children.size() - 2)) {
-            if (child instanceof JsoniqParser.ForClauseContext) {
-                clause = (Clause) this.visitForClause((JsoniqParser.ForClauseContext) child);
-            } else if (child instanceof JsoniqParser.LetClauseContext) {
-                clause = (Clause) this.visitLetClause((JsoniqParser.LetClauseContext) child);
-            } else if (child instanceof JsoniqParser.WhereClauseContext) {
-                clause = (Clause) this.visitWhereClause((JsoniqParser.WhereClauseContext) child);
-            } else if (child instanceof JsoniqParser.GroupByClauseContext) {
-                clause = (Clause) this.visitGroupByClause((JsoniqParser.GroupByClauseContext) child);
-            } else if (child instanceof JsoniqParser.OrderByClauseContext) {
-                clause = (Clause) this.visitOrderByClause((JsoniqParser.OrderByClauseContext) child);
-            } else if (child instanceof JsoniqParser.CountClauseContext) {
-                clause = (Clause) this.visitCountClause((JsoniqParser.CountClauseContext) child);
+            if (child instanceof JsoniqParser.ForClauseContext forClauseContext) {
+                clause = (Clause) this.visitForClause(forClauseContext);
+            } else if (child instanceof JsoniqParser.LetClauseContext letClauseContext) {
+                clause = (Clause) this.visitLetClause(letClauseContext);
+            } else if (child instanceof JsoniqParser.WhereClauseContext whereClauseContext) {
+                clause = (Clause) this.visitWhereClause(whereClauseContext);
+            } else if (child instanceof JsoniqParser.GroupByClauseContext groupByClauseContext) {
+                clause = (Clause) this.visitGroupByClause(groupByClauseContext);
+            } else if (child instanceof JsoniqParser.OrderByClauseContext orderByClauseContext) {
+                clause = (Clause) this.visitOrderByClause(orderByClauseContext);
+            } else if (child instanceof JsoniqParser.CountClauseContext countClauseContext) {
+                clause = (Clause) this.visitCountClause(countClauseContext);
             } else {
                 throw new UnsupportedFeatureException(
                         "FLOWR clause not implemented yet",
@@ -1582,11 +1582,11 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
             List<Expression> values = new ArrayList<>();
             for (JsoniqParser.PairConstructorContext currentPair : ctx.pairConstructor()) {
                 Node lhs = this.visitExprSingle(currentPair.lhs);
-                if (lhs instanceof StepExpr) {
+                if (lhs instanceof StepExpr stepExpr) {
                     if (this.moduleContext.getQueryLanguage().equals("jsoniq10")) {
                         keys.add(
                             new StringLiteralExpression(
-                                    ((StepExpr) lhs).getNodeTest().toString(),
+                                    stepExpr.getNodeTest().toString(),
                                     lhs.getMetadata()
                             )
                         );
@@ -1775,10 +1775,10 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     public Expression getMainExpressionFromUpdateLocatorContext(JsoniqParser.UpdateLocatorContext ctx) {
         Expression mainExpression = (Expression) this.visitPostfixExpr(ctx.main_expr);
-        if (mainExpression instanceof ObjectLookupExpression) {
-            return ((ObjectLookupExpression) mainExpression).getMainExpression();
-        } else if (mainExpression instanceof ArrayLookupExpression) {
-            return ((ArrayLookupExpression) mainExpression).getMainExpression();
+        if (mainExpression instanceof ObjectLookupExpression objectLookupExpression) {
+            return objectLookupExpression.getMainExpression();
+        } else if (mainExpression instanceof ArrayLookupExpression arrayLookupExpression) {
+            return arrayLookupExpression.getMainExpression();
         } else {
             throw new OurBadException("Unrecognized main expression found in update expression.");
         }
@@ -1786,10 +1786,10 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     public Expression getLocatorExpressionFromUpdateLocatorContext(JsoniqParser.UpdateLocatorContext ctx) {
         Expression mainExpression = (Expression) this.visitPostfixExpr(ctx.main_expr);
-        if (mainExpression instanceof ObjectLookupExpression) {
-            return ((ObjectLookupExpression) mainExpression).getLookupExpression();
-        } else if (mainExpression instanceof ArrayLookupExpression) {
-            return ((ArrayLookupExpression) mainExpression).getLookupExpression();
+        if (mainExpression instanceof ObjectLookupExpression objectLookupExpression) {
+            return objectLookupExpression.getLookupExpression();
+        } else if (mainExpression instanceof ArrayLookupExpression arrayLookupExpression) {
+            return arrayLookupExpression.getLookupExpression();
         } else {
             throw new OurBadException("Unrecognized main expression found in update expression.");
         }
@@ -1939,41 +1939,41 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitPrimaryExpr(JsoniqParser.PrimaryExprContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof JsoniqParser.VarRefContext) {
-            return this.visitVarRef((JsoniqParser.VarRefContext) child);
+        if (child instanceof JsoniqParser.VarRefContext varRefContext) {
+            return this.visitVarRef(varRefContext);
         }
-        if (child instanceof JsoniqParser.ObjectConstructorContext) {
-            return this.visitObjectConstructor((JsoniqParser.ObjectConstructorContext) child);
+        if (child instanceof JsoniqParser.ObjectConstructorContext objectConstructorContext) {
+            return this.visitObjectConstructor(objectConstructorContext);
         }
-        if (child instanceof JsoniqParser.ArrayConstructorContext) {
-            return this.visitArrayConstructor((JsoniqParser.ArrayConstructorContext) child);
+        if (child instanceof JsoniqParser.ArrayConstructorContext arrayConstructorContext) {
+            return this.visitArrayConstructor(arrayConstructorContext);
         }
-        if (child instanceof JsoniqParser.ParenthesizedExprContext) {
-            return this.visitParenthesizedExpr((JsoniqParser.ParenthesizedExprContext) child);
+        if (child instanceof JsoniqParser.ParenthesizedExprContext parenthesizedExprContext) {
+            return this.visitParenthesizedExpr(parenthesizedExprContext);
         }
-        if (child instanceof JsoniqParser.LiteralContext) {
-            return this.visitLiteral((JsoniqParser.LiteralContext) child);
+        if (child instanceof JsoniqParser.LiteralContext literalContext) {
+            return this.visitLiteral(literalContext);
         }
-        if (child instanceof JsoniqParser.ContextItemExprContext) {
-            return this.visitContextItemExpr((JsoniqParser.ContextItemExprContext) child);
+        if (child instanceof JsoniqParser.ContextItemExprContext contextItemExprContext) {
+            return this.visitContextItemExpr(contextItemExprContext);
         }
-        if (child instanceof JsoniqParser.FunctionCallContext) {
-            return this.visitFunctionCall((JsoniqParser.FunctionCallContext) child);
+        if (child instanceof JsoniqParser.FunctionCallContext functionCallContext) {
+            return this.visitFunctionCall(functionCallContext);
         }
-        if (child instanceof JsoniqParser.FunctionItemExprContext) {
-            return this.visitFunctionItemExpr((JsoniqParser.FunctionItemExprContext) child);
+        if (child instanceof JsoniqParser.FunctionItemExprContext functionItemExprContext) {
+            return this.visitFunctionItemExpr(functionItemExprContext);
         }
-        if (child instanceof JsoniqParser.BlockExprContext) {
-            return this.visitBlockExpr((JsoniqParser.BlockExprContext) child);
+        if (child instanceof JsoniqParser.BlockExprContext blockExprContext) {
+            return this.visitBlockExpr(blockExprContext);
         }
-        if (child instanceof JsoniqParser.UnaryLookupContext) {
+        if (child instanceof JsoniqParser.UnaryLookupContext unaryLookupContext) {
             return new UnaryLookupExpression(
-                    (Expression) this.visitUnaryLookup((JsoniqParser.UnaryLookupContext) child),
+                    (Expression) this.visitUnaryLookup(unaryLookupContext),
                     createMetadataFromContext(ctx)
             );
         }
-        if (child instanceof JsoniqParser.NodeConstructorContext) {
-            return this.visitNodeConstructor((JsoniqParser.NodeConstructorContext) child);
+        if (child instanceof JsoniqParser.NodeConstructorContext nodeConstructorContext) {
+            return this.visitNodeConstructor(nodeConstructorContext);
         }
         if (child instanceof JsoniqParser.NumericLiteralContext) {
             return this.visitLiteral((JsoniqParser.LiteralContext) child);
@@ -2050,11 +2050,11 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
             List<Expression> values = new ArrayList<>();
             for (JsoniqParser.PairConstructorContext currentPair : ctx.pairConstructor()) {
                 Node lhs = this.visitExprSingle(currentPair.lhs);
-                if (lhs instanceof StepExpr) {
+                if (lhs instanceof StepExpr stepExpr) {
                     if (this.moduleContext.getQueryLanguage().equals("jsoniq10")) {
                         keys.add(
                             new StringLiteralExpression(
-                                    ((StepExpr) lhs).getNodeTest().toString(),
+                                    stepExpr.getNodeTest().toString(),
                                     lhs.getMetadata()
                             )
                         );
@@ -2089,11 +2089,11 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitNodeConstructor(JsoniqParser.NodeConstructorContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof JsoniqParser.DirectConstructorContext) {
-            return this.visitDirectConstructor((JsoniqParser.DirectConstructorContext) child);
+        if (child instanceof JsoniqParser.DirectConstructorContext directConstructorContext) {
+            return this.visitDirectConstructor(directConstructorContext);
         }
-        if (child instanceof JsoniqParser.ComputedConstructorContext) {
-            return this.visitComputedConstructor((JsoniqParser.ComputedConstructorContext) child);
+        if (child instanceof JsoniqParser.ComputedConstructorContext computedConstructorContext) {
+            return this.visitComputedConstructor(computedConstructorContext);
         }
         throw new UnsupportedFeatureException(
                 "Node constructor not yet implemented",
@@ -2112,10 +2112,12 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
                     createMetadataFromContext(ctx)
             );
         }
-        if (child instanceof JsoniqParser.DirElemConstructorOpenCloseContext) {
-            return this.visitDirElemConstructorOpenClose((JsoniqParser.DirElemConstructorOpenCloseContext) child);
-        } else if (child instanceof JsoniqParser.DirElemConstructorSingleTagContext) {
-            return this.visitDirElemConstructorSingleTag((JsoniqParser.DirElemConstructorSingleTagContext) child);
+        if (child instanceof JsoniqParser.DirElemConstructorOpenCloseContext dirElemConstructorOpenCloseContext) {
+            return this.visitDirElemConstructorOpenClose(dirElemConstructorOpenCloseContext);
+        } else if (
+            child instanceof JsoniqParser.DirElemConstructorSingleTagContext dirElemConstructorSingleTagContext
+        ) {
+            return this.visitDirElemConstructorSingleTag(dirElemConstructorSingleTagContext);
         } else if (ctx.PI() != null) {
             return this.visitDirPIConstructor(ctx.PI(), createMetadataFromContext(ctx));
         } else if (ctx.COMMENT() != null) {
@@ -2204,8 +2206,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
             for (JsoniqParser.DirElemContentContext child : ctx.dirElemContent()) {
                 Expression childExpression = (Expression) this.visitDirElemContent(child);
 
-                if (childExpression instanceof TextNodeExpression) {
-                    TextNodeExpression textNode = (TextNodeExpression) childExpression;
+                if (childExpression instanceof TextNodeExpression textNode) {
 
                     // If the parent of a text node is not empty, the Text Node must not contain the zero-length
                     // string as its content.
@@ -2295,10 +2296,10 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitDirElemContent(JsoniqParser.DirElemContentContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof JsoniqParser.DirectConstructorContext) {
-            return this.visitDirectConstructor((JsoniqParser.DirectConstructorContext) child);
-        } else if (child instanceof JsoniqParser.CommonContentContext) {
-            return this.visitCommonContent((JsoniqParser.CommonContentContext) child);
+        if (child instanceof JsoniqParser.DirectConstructorContext directConstructorContext) {
+            return this.visitDirectConstructor(directConstructorContext);
+        } else if (child instanceof JsoniqParser.CommonContentContext commonContentContext) {
+            return this.visitCommonContent(commonContentContext);
         } else {
             // Include lexer hidden-channel characters (e.g. spaces) in this fragment; ParseTree#getText() drops them.
             String text = this.xQueryTokenStream.getText(ctx.getSourceInterval());
@@ -2348,20 +2349,20 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitComputedConstructor(JsoniqParser.ComputedConstructorContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof JsoniqParser.CompDocConstructorContext) {
-            return this.visitCompDocConstructor((JsoniqParser.CompDocConstructorContext) child);
-        } else if (child instanceof JsoniqParser.CompElemConstructorContext) {
-            return this.visitCompElemConstructor((JsoniqParser.CompElemConstructorContext) child);
-        } else if (child instanceof JsoniqParser.CompPIConstructorContext) {
-            return this.visitCompPIConstructor((JsoniqParser.CompPIConstructorContext) child);
-        } else if (child instanceof JsoniqParser.CompTextConstructorContext) {
-            return this.visitCompTextConstructor((JsoniqParser.CompTextConstructorContext) child);
-        } else if (child instanceof JsoniqParser.CompCommentConstructorContext) {
-            return this.visitCompCommentConstructor((JsoniqParser.CompCommentConstructorContext) child);
-        } else if (child instanceof JsoniqParser.CompAttrConstructorContext) {
-            return this.visitCompAttrConstructor((JsoniqParser.CompAttrConstructorContext) child);
-        } else if (child instanceof JsoniqParser.CompNamespaceConstructorContext) {
-            return this.visitCompNamespaceConstructor((JsoniqParser.CompNamespaceConstructorContext) child);
+        if (child instanceof JsoniqParser.CompDocConstructorContext compDocConstructorContext) {
+            return this.visitCompDocConstructor(compDocConstructorContext);
+        } else if (child instanceof JsoniqParser.CompElemConstructorContext compElemConstructorContext) {
+            return this.visitCompElemConstructor(compElemConstructorContext);
+        } else if (child instanceof JsoniqParser.CompPIConstructorContext compPIConstructorContext) {
+            return this.visitCompPIConstructor(compPIConstructorContext);
+        } else if (child instanceof JsoniqParser.CompTextConstructorContext compTextConstructorContext) {
+            return this.visitCompTextConstructor(compTextConstructorContext);
+        } else if (child instanceof JsoniqParser.CompCommentConstructorContext compCommentConstructorContext) {
+            return this.visitCompCommentConstructor(compCommentConstructorContext);
+        } else if (child instanceof JsoniqParser.CompAttrConstructorContext compAttrConstructorContext) {
+            return this.visitCompAttrConstructor(compAttrConstructorContext);
+        } else if (child instanceof JsoniqParser.CompNamespaceConstructorContext compNamespaceConstructorContext) {
+            return this.visitCompNamespaceConstructor(compNamespaceConstructorContext);
         }
         throw new UnsupportedFeatureException("Computed constructor", createMetadataFromContext(ctx));
     }
@@ -2851,11 +2852,11 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitFunctionItemExpr(JsoniqParser.FunctionItemExprContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof JsoniqParser.NamedFunctionRefContext) {
-            return this.visitNamedFunctionRef((JsoniqParser.NamedFunctionRefContext) child);
+        if (child instanceof JsoniqParser.NamedFunctionRefContext namedFunctionRefContext) {
+            return this.visitNamedFunctionRef(namedFunctionRefContext);
         }
-        if (child instanceof JsoniqParser.InlineFunctionExprContext) {
-            return this.visitInlineFunctionExpr((JsoniqParser.InlineFunctionExprContext) child);
+        if (child instanceof JsoniqParser.InlineFunctionExprContext inlineFunctionExprContext) {
+            return this.visitInlineFunctionExpr(inlineFunctionExprContext);
         }
         throw new UnsupportedFeatureException(
                 "Function item expression not yet implemented",
@@ -3212,44 +3213,44 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitStatement(JsoniqParser.StatementContext ctx) {
         ParseTree content = ctx.children.get(0);
-        if (content instanceof JsoniqParser.ApplyStatementContext) {
-            return this.visitApplyStatement((JsoniqParser.ApplyStatementContext) content);
+        if (content instanceof JsoniqParser.ApplyStatementContext applyStatementContext) {
+            return this.visitApplyStatement(applyStatementContext);
         }
-        if (content instanceof JsoniqParser.AssignStatementContext) {
-            return this.visitAssignStatement((JsoniqParser.AssignStatementContext) content);
+        if (content instanceof JsoniqParser.AssignStatementContext assignStatementContext) {
+            return this.visitAssignStatement(assignStatementContext);
         }
-        if (content instanceof JsoniqParser.BlockStatementContext) {
-            return this.visitBlockStatement((JsoniqParser.BlockStatementContext) content);
+        if (content instanceof JsoniqParser.BlockStatementContext blockStatementContext) {
+            return this.visitBlockStatement(blockStatementContext);
         }
-        if (content instanceof JsoniqParser.BreakStatementContext) {
-            return this.visitBreakStatement((JsoniqParser.BreakStatementContext) content);
+        if (content instanceof JsoniqParser.BreakStatementContext breakStatementContext) {
+            return this.visitBreakStatement(breakStatementContext);
         }
-        if (content instanceof JsoniqParser.ContinueStatementContext) {
-            return this.visitContinueStatement((JsoniqParser.ContinueStatementContext) content);
+        if (content instanceof JsoniqParser.ContinueStatementContext continueStatementContext) {
+            return this.visitContinueStatement(continueStatementContext);
         }
-        if (content instanceof JsoniqParser.ExitStatementContext) {
-            return this.visitExitStatement((JsoniqParser.ExitStatementContext) content);
+        if (content instanceof JsoniqParser.ExitStatementContext exitStatementContext) {
+            return this.visitExitStatement(exitStatementContext);
         }
-        if (content instanceof JsoniqParser.FlworStatementContext) {
-            return this.visitFlworStatement((JsoniqParser.FlworStatementContext) content);
+        if (content instanceof JsoniqParser.FlworStatementContext flworStatementContext) {
+            return this.visitFlworStatement(flworStatementContext);
         }
-        if (content instanceof JsoniqParser.IfStatementContext) {
-            return this.visitIfStatement((JsoniqParser.IfStatementContext) content);
+        if (content instanceof JsoniqParser.IfStatementContext ifStatementContext) {
+            return this.visitIfStatement(ifStatementContext);
         }
-        if (content instanceof JsoniqParser.SwitchStatementContext) {
-            return this.visitSwitchStatement((JsoniqParser.SwitchStatementContext) content);
+        if (content instanceof JsoniqParser.SwitchStatementContext switchStatementContext) {
+            return this.visitSwitchStatement(switchStatementContext);
         }
-        if (content instanceof JsoniqParser.TryCatchStatementContext) {
-            return this.visitTryCatchStatement((JsoniqParser.TryCatchStatementContext) content);
+        if (content instanceof JsoniqParser.TryCatchStatementContext tryCatchStatementContext) {
+            return this.visitTryCatchStatement(tryCatchStatementContext);
         }
-        if (content instanceof JsoniqParser.TypeSwitchStatementContext) {
-            return this.visitTypeSwitchStatement((JsoniqParser.TypeSwitchStatementContext) content);
+        if (content instanceof JsoniqParser.TypeSwitchStatementContext typeSwitchStatementContext) {
+            return this.visitTypeSwitchStatement(typeSwitchStatementContext);
         }
-        if (content instanceof JsoniqParser.VarDeclStatementContext) {
-            return this.visitVarDeclStatement((JsoniqParser.VarDeclStatementContext) content);
+        if (content instanceof JsoniqParser.VarDeclStatementContext varDeclStatementContext) {
+            return this.visitVarDeclStatement(varDeclStatementContext);
         }
-        if (content instanceof JsoniqParser.WhileStatementContext) {
-            return this.visitWhileStatement((JsoniqParser.WhileStatementContext) content);
+        if (content instanceof JsoniqParser.WhileStatementContext whileStatementContext) {
+            return this.visitWhileStatement(whileStatementContext);
         }
         throw new OurBadException("Unrecognized Statement.");
     }
@@ -3314,18 +3315,18 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         }
         Clause lastFlowrClause = clause.getLastClause();
         for (ParseTree child : ctx.children.subList(1, ctx.children.size() - 2)) {
-            if (child instanceof JsoniqParser.ForClauseContext) {
-                clause = (Clause) this.visitForClause((JsoniqParser.ForClauseContext) child);
-            } else if (child instanceof JsoniqParser.LetClauseContext) {
-                clause = (Clause) this.visitLetClause((JsoniqParser.LetClauseContext) child);
-            } else if (child instanceof JsoniqParser.WhereClauseContext) {
-                clause = (Clause) this.visitWhereClause((JsoniqParser.WhereClauseContext) child);
-            } else if (child instanceof JsoniqParser.GroupByClauseContext) {
-                clause = (Clause) this.visitGroupByClause((JsoniqParser.GroupByClauseContext) child);
-            } else if (child instanceof JsoniqParser.OrderByClauseContext) {
-                clause = (Clause) this.visitOrderByClause((JsoniqParser.OrderByClauseContext) child);
-            } else if (child instanceof JsoniqParser.CountClauseContext) {
-                clause = (Clause) this.visitCountClause((JsoniqParser.CountClauseContext) child);
+            if (child instanceof JsoniqParser.ForClauseContext forClauseContext) {
+                clause = (Clause) this.visitForClause(forClauseContext);
+            } else if (child instanceof JsoniqParser.LetClauseContext letClauseContext) {
+                clause = (Clause) this.visitLetClause(letClauseContext);
+            } else if (child instanceof JsoniqParser.WhereClauseContext whereClauseContext) {
+                clause = (Clause) this.visitWhereClause(whereClauseContext);
+            } else if (child instanceof JsoniqParser.GroupByClauseContext groupByClauseContext) {
+                clause = (Clause) this.visitGroupByClause(groupByClauseContext);
+            } else if (child instanceof JsoniqParser.OrderByClauseContext orderByClauseContext) {
+                clause = (Clause) this.visitOrderByClause(orderByClauseContext);
+            } else if (child instanceof JsoniqParser.CountClauseContext countClauseContext) {
+                clause = (Clause) this.visitCountClause(countClauseContext);
             } else {
                 throw new UnsupportedFeatureException(
                         "FLOWR clause not implemented yet",
@@ -3765,12 +3766,11 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     // | SchemaAttributeTest | PITest | CommentTest | TextTest
     // | NamespaceNodeTest | AnyKindTest
     private NodeTest getKindTest(ParseTree kindTest) {
-        if (kindTest instanceof JsoniqParser.DocumentTestContext) {
+        if (kindTest instanceof JsoniqParser.DocumentTestContext docContext) {
             // XQuery 3.1 Section 2.5.5.3 - Element Test (used within DocumentTest)
             // DocumentTest ::= "document-node" "(" (ElementTest | SchemaElementTest)? ")"
             // document-node() matches any document node.
             // document-node(element(...)) matches a document node containing an element matching the ElementTest.
-            JsoniqParser.DocumentTestContext docContext = (JsoniqParser.DocumentTestContext) kindTest;
             if (docContext.schemaElementTest() != null) {
                 throw new UnsupportedFeatureException(
                         "Schema element tests within document-node() are not supported",
@@ -3781,7 +3781,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
                 return new DocumentTest(null);
             }
             return new DocumentTest(getKindTest(docContext.elementTest()));
-        } else if (kindTest instanceof JsoniqParser.ElementTestContext) {
+        } else if (kindTest instanceof JsoniqParser.ElementTestContext elementContext) {
             // XQuery 3.1 Section 2.5.5.3 - Element Test
             // ElementTest ::= "element" "(" (ElementNameOrWildcard ("," TypeName "?"?)?)? ")"
             // element() and element(*) match any single element node.
@@ -3789,7 +3789,6 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
             // element(N, T) matches an element node whose name is N and whose type annotation is T.
             // element(*, T) matches any element node whose type annotation is T.
             // element(N, T?) also matches nillable elements (validation-related, unsupported).
-            JsoniqParser.ElementTestContext elementContext = (JsoniqParser.ElementTestContext) kindTest;
             // Reject the nillable marker "?" (validation-related feature)
             if (elementContext.optional != null) {
                 throw new UnsupportedFeatureException(
@@ -3822,15 +3821,13 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
                 return new ElementTest(true);
             }
             return new ElementTest();
-        } else if (kindTest instanceof JsoniqParser.AttributeTestContext) {
+        } else if (kindTest instanceof JsoniqParser.AttributeTestContext attributeTestContext) {
             // XQuery 3.1 Section 2.5.5.5 - Attribute Test
             // AttributeTest ::= "attribute" "(" (AttribNameOrWildcard ("," TypeName)?)? ")"
             // attribute() and attribute(*) match any single attribute node.
             // attribute(N) matches any attribute node whose name is N.
             // attribute(N, T) matches an attribute node whose name is N and whose type annotation is T.
             // attribute(*, T) matches any attribute node whose type annotation is T.
-            JsoniqParser.AttributeTestContext attributeTestContext =
-                (JsoniqParser.AttributeTestContext) kindTest;
             Name attributeName;
             if (attributeTestContext.attributeNameOrWildcard() != null) {
                 boolean hasWildcard = attributeTestContext.attributeNameOrWildcard().attributeName() == null;
@@ -3880,13 +3877,12 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
             // CommentTest ::= "comment" "(" ")"
             // A CommentTest matches any comment node.
             return new CommentTest();
-        } else if (kindTest instanceof JsoniqParser.PiTestContext) {
+        } else if (kindTest instanceof JsoniqParser.PiTestContext piContext) {
             // XQuery 3.1 Section 2.5.5
             // PITest ::= "processing-instruction" "(" (NCName | StringLiteral)? ")"
             // processing-instruction() matches any processing-instruction node.
             // processing-instruction(N) matches any processing-instruction node whose target
             // name equals fn:normalize-space(N).
-            JsoniqParser.PiTestContext piContext = (JsoniqParser.PiTestContext) kindTest;
             if (piContext.ncName() != null) {
                 return new PITest(piContext.ncName().getText());
             }
@@ -4119,14 +4115,14 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
             boolean allowEnclosedExpressions
     ) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof JsoniqParser.DirAttributeValueAposContext) {
+        if (child instanceof JsoniqParser.DirAttributeValueAposContext dirAttributeValueAposContext) {
             return this.getDirAttributeValueAposExpressions(
-                (JsoniqParser.DirAttributeValueAposContext) child,
+                dirAttributeValueAposContext,
                 allowEnclosedExpressions
             );
-        } else if (child instanceof JsoniqParser.DirAttributeValueQuotContext) {
+        } else if (child instanceof JsoniqParser.DirAttributeValueQuotContext dirAttributeValueQuotContext) {
             return this.getDirAttributeValueQuotExpressions(
-                (JsoniqParser.DirAttributeValueQuotContext) child,
+                dirAttributeValueQuotContext,
                 allowEnclosedExpressions
             );
         }
@@ -4199,9 +4195,9 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
             // Process each expression returned from the child
             for (Expression childExpression : childExpressions) {
-                if (childExpression instanceof AttributeNodeContentExpression) {
+                if (childExpression instanceof AttributeNodeContentExpression attributeNodeContentExpression) {
                     // Text content - accumulate it
-                    String content = ((AttributeNodeContentExpression) childExpression).getContent();
+                    String content = (attributeNodeContentExpression).getContent();
 
                     if (textAccumulator == null) {
                         // Start accumulating text content
@@ -4253,14 +4249,14 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         ParseTree child = ctx.children.get(0);
         List<Expression> expressions = new ArrayList<>();
 
-        if (ctx instanceof JsoniqParser.DirAttributeValueAposContext) {
+        if (ctx instanceof JsoniqParser.DirAttributeValueAposContext dirAttributeValueAposContext) {
             return this.getDirAttributeValueAposExpressions(
-                (JsoniqParser.DirAttributeValueAposContext) ctx,
+                dirAttributeValueAposContext,
                 allowEnclosedExpressions
             );
-        } else if (ctx instanceof JsoniqParser.DirAttributeValueQuotContext) {
+        } else if (ctx instanceof JsoniqParser.DirAttributeValueQuotContext dirAttributeValueQuotContext) {
             return this.getDirAttributeValueQuotExpressions(
-                (JsoniqParser.DirAttributeValueQuotContext) ctx,
+                dirAttributeValueQuotContext,
                 allowEnclosedExpressions
             );
         } else if (

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -384,16 +384,15 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
             if (child instanceof XQueryParser.AnnotatedDeclContext) {
                 break;
             }
-            if (child instanceof XQueryParser.DefaultNamespaceDeclContext) {
-                processDefaultNamespaceDecl((XQueryParser.DefaultNamespaceDeclContext) child, phase1);
-            } else if (child instanceof XQueryParser.NamespaceDeclContext) {
-                processNamespaceDecl((XQueryParser.NamespaceDeclContext) child);
-            } else if (child instanceof SetterContext) {
-                processPrologPhase1Setter((SetterContext) child, phase1);
+            if (child instanceof XQueryParser.DefaultNamespaceDeclContext defaultNamespaceDeclContext) {
+                processDefaultNamespaceDecl(defaultNamespaceDeclContext, phase1);
+            } else if (child instanceof XQueryParser.NamespaceDeclContext namespaceDeclContext) {
+                processNamespaceDecl(namespaceDeclContext);
+            } else if (child instanceof SetterContext setterContext) {
+                processPrologPhase1Setter(setterContext, phase1);
             } else if (child instanceof XQueryParser.SchemaImportContext) {
                 // Not supported yet; previously skipped as well.
-            } else if (child instanceof XQueryParser.ModuleImportContext) {
-                XQueryParser.ModuleImportContext namespace = (XQueryParser.ModuleImportContext) child;
+            } else if (child instanceof XQueryParser.ModuleImportContext namespace) {
                 LibraryModule libraryModule = this.processModuleImport(namespace);
                 libraryModules.add(libraryModule);
                 if (namespaces.contains(libraryModule.getNamespace())) {
@@ -795,23 +794,23 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitExprSingle(XQueryParser.ExprSingleContext ctx) {
         ParseTree content = ctx.children.get(0);
-        if (content instanceof XQueryParser.ExprSimpleContext) {
-            return this.visitExprSimple((XQueryParser.ExprSimpleContext) content);
+        if (content instanceof XQueryParser.ExprSimpleContext exprSimpleContext) {
+            return this.visitExprSimple(exprSimpleContext);
         }
-        if (content instanceof XQueryParser.FlworExprContext) {
-            return this.visitFlworExpr((XQueryParser.FlworExprContext) content);
+        if (content instanceof XQueryParser.FlworExprContext flworExprContext) {
+            return this.visitFlworExpr(flworExprContext);
         }
-        if (content instanceof XQueryParser.IfExprContext) {
-            return this.visitIfExpr((XQueryParser.IfExprContext) content);
+        if (content instanceof XQueryParser.IfExprContext ifExprContext) {
+            return this.visitIfExpr(ifExprContext);
         }
-        if (content instanceof XQueryParser.SwitchExprContext) {
-            return this.visitSwitchExpr((XQueryParser.SwitchExprContext) content);
+        if (content instanceof XQueryParser.SwitchExprContext switchExprContext) {
+            return this.visitSwitchExpr(switchExprContext);
         }
-        if (content instanceof XQueryParser.TypeswitchExprContext) {
-            return this.visitTypeswitchExpr((XQueryParser.TypeswitchExprContext) content);
+        if (content instanceof XQueryParser.TypeswitchExprContext typeswitchExprContext) {
+            return this.visitTypeswitchExpr(typeswitchExprContext);
         }
-        if (content instanceof XQueryParser.TryCatchExprContext) {
-            return this.visitTryCatchExpr((XQueryParser.TryCatchExprContext) content);
+        if (content instanceof XQueryParser.TryCatchExprContext tryCatchExprContext) {
+            return this.visitTryCatchExpr(tryCatchExprContext);
         }
         throw new OurBadException("Unrecognized ExprSingle:" + content.getClass().getName());
     }
@@ -821,11 +820,11 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitExprSimple(XQueryParser.ExprSimpleContext ctx) {
         ParseTree content = ctx.children.get(0);
-        if (content instanceof XQueryParser.OrExprContext) {
-            return this.visitOrExpr((XQueryParser.OrExprContext) content);
+        if (content instanceof XQueryParser.OrExprContext orExprContext) {
+            return this.visitOrExpr(orExprContext);
         }
-        if (content instanceof XQueryParser.QuantifiedExprContext) {
-            return this.visitQuantifiedExpr((XQueryParser.QuantifiedExprContext) content);
+        if (content instanceof XQueryParser.QuantifiedExprContext quantifiedExprContext) {
+            return this.visitQuantifiedExpr(quantifiedExprContext);
         }
         // TODO: do these need to be implemented in the xquery translator?
         // if (content instanceof XQueryParser.DeleteExprContext) {
@@ -846,8 +845,8 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         // if (content instanceof XQueryParser.TransformExprContext) {
         // return this.visitTransformExpr((XQueryParser.TransformExprContext) content);
         // }
-        if (content instanceof XQueryParser.PathExprContext) {
-            return this.visitPathExpr((XQueryParser.PathExprContext) content);
+        if (content instanceof XQueryParser.PathExprContext pathExprContext) {
+            return this.visitPathExpr(pathExprContext);
         }
         throw new OurBadException("Unrecognized ExprSimple.");
     }
@@ -879,18 +878,18 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         Clause previousFLWORClause = clause.getLastClause();
 
         for (ParseTree child : ctx.children.subList(1, ctx.children.size() - 2)) {
-            if (child instanceof XQueryParser.ForClauseContext) {
-                clause = (Clause) this.visitForClause((XQueryParser.ForClauseContext) child);
-            } else if (child instanceof XQueryParser.LetClauseContext) {
-                clause = (Clause) this.visitLetClause((XQueryParser.LetClauseContext) child);
-            } else if (child instanceof XQueryParser.WhereClauseContext) {
-                clause = (Clause) this.visitWhereClause((XQueryParser.WhereClauseContext) child);
-            } else if (child instanceof XQueryParser.GroupByClauseContext) {
-                clause = (Clause) this.visitGroupByClause((XQueryParser.GroupByClauseContext) child);
-            } else if (child instanceof XQueryParser.OrderByClauseContext) {
-                clause = (Clause) this.visitOrderByClause((XQueryParser.OrderByClauseContext) child);
-            } else if (child instanceof XQueryParser.CountClauseContext) {
-                clause = (Clause) this.visitCountClause((XQueryParser.CountClauseContext) child);
+            if (child instanceof XQueryParser.ForClauseContext forClauseContext) {
+                clause = (Clause) this.visitForClause(forClauseContext);
+            } else if (child instanceof XQueryParser.LetClauseContext letClauseContext) {
+                clause = (Clause) this.visitLetClause(letClauseContext);
+            } else if (child instanceof XQueryParser.WhereClauseContext whereClauseContext) {
+                clause = (Clause) this.visitWhereClause(whereClauseContext);
+            } else if (child instanceof XQueryParser.GroupByClauseContext groupByClauseContext) {
+                clause = (Clause) this.visitGroupByClause(groupByClauseContext);
+            } else if (child instanceof XQueryParser.OrderByClauseContext orderByClauseContext) {
+                clause = (Clause) this.visitOrderByClause(orderByClauseContext);
+            } else if (child instanceof XQueryParser.CountClauseContext countClauseContext) {
+                clause = (Clause) this.visitCountClause(countClauseContext);
             } else {
                 throw new UnsupportedFeatureException(
                         "FLOWR clause not implemented yet",
@@ -1683,41 +1682,41 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitPrimaryExpr(XQueryParser.PrimaryExprContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof XQueryParser.VarRefContext) {
-            return this.visitVarRef((XQueryParser.VarRefContext) child);
+        if (child instanceof XQueryParser.VarRefContext varRefContext) {
+            return this.visitVarRef(varRefContext);
         }
-        if (child instanceof XQueryParser.ObjectConstructorContext) {
-            return this.visitObjectConstructor((XQueryParser.ObjectConstructorContext) child);
+        if (child instanceof XQueryParser.ObjectConstructorContext objectConstructorContext) {
+            return this.visitObjectConstructor(objectConstructorContext);
         }
-        if (child instanceof XQueryParser.ArrayConstructorContext) {
-            return this.visitArrayConstructor((XQueryParser.ArrayConstructorContext) child);
+        if (child instanceof XQueryParser.ArrayConstructorContext arrayConstructorContext) {
+            return this.visitArrayConstructor(arrayConstructorContext);
         }
-        if (child instanceof XQueryParser.ParenthesizedExprContext) {
-            return this.visitParenthesizedExpr((XQueryParser.ParenthesizedExprContext) child);
+        if (child instanceof XQueryParser.ParenthesizedExprContext parenthesizedExprContext) {
+            return this.visitParenthesizedExpr(parenthesizedExprContext);
         }
-        if (child instanceof XQueryParser.LiteralContext) {
-            return this.visitLiteral((XQueryParser.LiteralContext) child);
+        if (child instanceof XQueryParser.LiteralContext literalContext) {
+            return this.visitLiteral(literalContext);
         }
-        if (child instanceof XQueryParser.ContextItemExprContext) {
-            return this.visitContextItemExpr((XQueryParser.ContextItemExprContext) child);
+        if (child instanceof XQueryParser.ContextItemExprContext contextItemExprContext) {
+            return this.visitContextItemExpr(contextItemExprContext);
         }
-        if (child instanceof XQueryParser.FunctionCallContext) {
-            return this.visitFunctionCall((XQueryParser.FunctionCallContext) child);
+        if (child instanceof XQueryParser.FunctionCallContext functionCallContext) {
+            return this.visitFunctionCall(functionCallContext);
         }
-        if (child instanceof XQueryParser.FunctionItemExprContext) {
-            return this.visitFunctionItemExpr((XQueryParser.FunctionItemExprContext) child);
+        if (child instanceof XQueryParser.FunctionItemExprContext functionItemExprContext) {
+            return this.visitFunctionItemExpr(functionItemExprContext);
         }
-        if (child instanceof XQueryParser.BlockExprContext) {
-            return this.visitBlockExpr((XQueryParser.BlockExprContext) child);
+        if (child instanceof XQueryParser.BlockExprContext blockExprContext) {
+            return this.visitBlockExpr(blockExprContext);
         }
-        if (child instanceof XQueryParser.UnaryLookupContext) {
+        if (child instanceof XQueryParser.UnaryLookupContext unaryLookupContext) {
             return new UnaryLookupExpression(
-                    (Expression) this.visitUnaryLookup((XQueryParser.UnaryLookupContext) child),
+                    (Expression) this.visitUnaryLookup(unaryLookupContext),
                     createMetadataFromContext(ctx)
             );
         }
-        if (child instanceof XQueryParser.NodeConstructorContext) {
-            return this.visitNodeConstructor((XQueryParser.NodeConstructorContext) child);
+        if (child instanceof XQueryParser.NodeConstructorContext nodeConstructorContext) {
+            return this.visitNodeConstructor(nodeConstructorContext);
         }
         throw new UnsupportedFeatureException(
                 "Primary expression not yet implemented",
@@ -1792,11 +1791,11 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitNodeConstructor(XQueryParser.NodeConstructorContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof XQueryParser.DirectConstructorContext) {
-            return this.visitDirectConstructor((XQueryParser.DirectConstructorContext) child);
+        if (child instanceof XQueryParser.DirectConstructorContext directConstructorContext) {
+            return this.visitDirectConstructor(directConstructorContext);
         }
-        if (child instanceof XQueryParser.ComputedConstructorContext) {
-            return this.visitComputedConstructor((XQueryParser.ComputedConstructorContext) child);
+        if (child instanceof XQueryParser.ComputedConstructorContext computedConstructorContext) {
+            return this.visitComputedConstructor(computedConstructorContext);
         }
         throw new UnsupportedFeatureException(
                 "Node constructor not yet implemented",
@@ -1815,10 +1814,12 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
                     createMetadataFromContext(ctx)
             );
         }
-        if (child instanceof XQueryParser.DirElemConstructorOpenCloseContext) {
-            return this.visitDirElemConstructorOpenClose((XQueryParser.DirElemConstructorOpenCloseContext) child);
-        } else if (child instanceof XQueryParser.DirElemConstructorSingleTagContext) {
-            return this.visitDirElemConstructorSingleTag((XQueryParser.DirElemConstructorSingleTagContext) child);
+        if (child instanceof XQueryParser.DirElemConstructorOpenCloseContext dirElemConstructorOpenCloseContext) {
+            return this.visitDirElemConstructorOpenClose(dirElemConstructorOpenCloseContext);
+        } else if (
+            child instanceof XQueryParser.DirElemConstructorSingleTagContext dirElemConstructorSingleTagContext
+        ) {
+            return this.visitDirElemConstructorSingleTag(dirElemConstructorSingleTagContext);
         } else if (ctx.PI() != null) {
             return this.visitDirPIConstructor(ctx.PI(), createMetadataFromContext(ctx));
         } else if (ctx.COMMENT() != null) {
@@ -1907,8 +1908,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
             for (XQueryParser.DirElemContentContext child : ctx.dirElemContent()) {
                 Expression childExpression = (Expression) this.visitDirElemContent(child);
 
-                if (childExpression instanceof TextNodeExpression) {
-                    TextNodeExpression textNode = (TextNodeExpression) childExpression;
+                if (childExpression instanceof TextNodeExpression textNode) {
 
                     // If the parent of a text node is not empty, the Text Node must not contain the zero-length
                     // string as its content.
@@ -1998,10 +1998,10 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitDirElemContent(XQueryParser.DirElemContentContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof XQueryParser.DirectConstructorContext) {
-            return this.visitDirectConstructor((XQueryParser.DirectConstructorContext) child);
-        } else if (child instanceof XQueryParser.CommonContentContext) {
-            return this.visitCommonContent((XQueryParser.CommonContentContext) child);
+        if (child instanceof XQueryParser.DirectConstructorContext directConstructorContext) {
+            return this.visitDirectConstructor(directConstructorContext);
+        } else if (child instanceof XQueryParser.CommonContentContext commonContentContext) {
+            return this.visitCommonContent(commonContentContext);
         } else {
             // Include lexer hidden-channel characters (e.g. spaces) in this fragment; ParseTree#getText() drops them.
             String text = this.xQueryTokenStream.getText(ctx.getSourceInterval());
@@ -2051,20 +2051,20 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitComputedConstructor(XQueryParser.ComputedConstructorContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof XQueryParser.CompDocConstructorContext) {
-            return this.visitCompDocConstructor((XQueryParser.CompDocConstructorContext) child);
-        } else if (child instanceof XQueryParser.CompElemConstructorContext) {
-            return this.visitCompElemConstructor((XQueryParser.CompElemConstructorContext) child);
-        } else if (child instanceof XQueryParser.CompPIConstructorContext) {
-            return this.visitCompPIConstructor((XQueryParser.CompPIConstructorContext) child);
-        } else if (child instanceof XQueryParser.CompTextConstructorContext) {
-            return this.visitCompTextConstructor((XQueryParser.CompTextConstructorContext) child);
-        } else if (child instanceof XQueryParser.CompCommentConstructorContext) {
-            return this.visitCompCommentConstructor((XQueryParser.CompCommentConstructorContext) child);
-        } else if (child instanceof XQueryParser.CompAttrConstructorContext) {
-            return this.visitCompAttrConstructor((XQueryParser.CompAttrConstructorContext) child);
-        } else if (child instanceof XQueryParser.CompNamespaceConstructorContext) {
-            return this.visitCompNamespaceConstructor((XQueryParser.CompNamespaceConstructorContext) child);
+        if (child instanceof XQueryParser.CompDocConstructorContext compDocConstructorContext) {
+            return this.visitCompDocConstructor(compDocConstructorContext);
+        } else if (child instanceof XQueryParser.CompElemConstructorContext compElemConstructorContext) {
+            return this.visitCompElemConstructor(compElemConstructorContext);
+        } else if (child instanceof XQueryParser.CompPIConstructorContext compPIConstructorContext) {
+            return this.visitCompPIConstructor(compPIConstructorContext);
+        } else if (child instanceof XQueryParser.CompTextConstructorContext compTextConstructorContext) {
+            return this.visitCompTextConstructor(compTextConstructorContext);
+        } else if (child instanceof XQueryParser.CompCommentConstructorContext compCommentConstructorContext) {
+            return this.visitCompCommentConstructor(compCommentConstructorContext);
+        } else if (child instanceof XQueryParser.CompAttrConstructorContext compAttrConstructorContext) {
+            return this.visitCompAttrConstructor(compAttrConstructorContext);
+        } else if (child instanceof XQueryParser.CompNamespaceConstructorContext compNamespaceConstructorContext) {
+            return this.visitCompNamespaceConstructor(compNamespaceConstructorContext);
         }
         throw new UnsupportedFeatureException("Computed constructor", createMetadataFromContext(ctx));
     }
@@ -2215,8 +2215,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitArrayConstructor(XQueryParser.ArrayConstructorContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof XQueryParser.SquareArrayConstructorContext) {
-            XQueryParser.SquareArrayConstructorContext sqCtx = (XQueryParser.SquareArrayConstructorContext) child;
+        if (child instanceof XQueryParser.SquareArrayConstructorContext sqCtx) {
             List<XQueryParser.ExprSingleContext> memberCtxs = sqCtx.exprSingle();
             if (memberCtxs == null || memberCtxs.isEmpty()) {
                 return new ArrayConstructorExpression(
@@ -2528,11 +2527,11 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitFunctionItemExpr(XQueryParser.FunctionItemExprContext ctx) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof XQueryParser.NamedFunctionRefContext) {
-            return this.visitNamedFunctionRef((XQueryParser.NamedFunctionRefContext) child);
+        if (child instanceof XQueryParser.NamedFunctionRefContext namedFunctionRefContext) {
+            return this.visitNamedFunctionRef(namedFunctionRefContext);
         }
-        if (child instanceof XQueryParser.InlineFunctionExprContext) {
-            return this.visitInlineFunctionExpr((XQueryParser.InlineFunctionExprContext) child);
+        if (child instanceof XQueryParser.InlineFunctionExprContext inlineFunctionExprContext) {
+            return this.visitInlineFunctionExpr(inlineFunctionExprContext);
         }
         throw new UnsupportedFeatureException(
                 "Function item expression not yet implemented",
@@ -2889,44 +2888,44 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitStatement(XQueryParser.StatementContext ctx) {
         ParseTree content = ctx.children.get(0);
-        if (content instanceof XQueryParser.ApplyStatementContext) {
-            return this.visitApplyStatement((XQueryParser.ApplyStatementContext) content);
+        if (content instanceof XQueryParser.ApplyStatementContext applyStatementContext) {
+            return this.visitApplyStatement(applyStatementContext);
         }
-        if (content instanceof XQueryParser.AssignStatementContext) {
-            return this.visitAssignStatement((XQueryParser.AssignStatementContext) content);
+        if (content instanceof XQueryParser.AssignStatementContext assignStatementContext) {
+            return this.visitAssignStatement(assignStatementContext);
         }
-        if (content instanceof XQueryParser.BlockStatementContext) {
-            return this.visitBlockStatement((XQueryParser.BlockStatementContext) content);
+        if (content instanceof XQueryParser.BlockStatementContext blockStatementContext) {
+            return this.visitBlockStatement(blockStatementContext);
         }
-        if (content instanceof XQueryParser.BreakStatementContext) {
-            return this.visitBreakStatement((XQueryParser.BreakStatementContext) content);
+        if (content instanceof XQueryParser.BreakStatementContext breakStatementContext) {
+            return this.visitBreakStatement(breakStatementContext);
         }
-        if (content instanceof XQueryParser.ContinueStatementContext) {
-            return this.visitContinueStatement((XQueryParser.ContinueStatementContext) content);
+        if (content instanceof XQueryParser.ContinueStatementContext continueStatementContext) {
+            return this.visitContinueStatement(continueStatementContext);
         }
-        if (content instanceof XQueryParser.ExitStatementContext) {
-            return this.visitExitStatement((XQueryParser.ExitStatementContext) content);
+        if (content instanceof XQueryParser.ExitStatementContext exitStatementContext) {
+            return this.visitExitStatement(exitStatementContext);
         }
-        if (content instanceof XQueryParser.FlworStatementContext) {
-            return this.visitFlworStatement((XQueryParser.FlworStatementContext) content);
+        if (content instanceof XQueryParser.FlworStatementContext flworStatementContext) {
+            return this.visitFlworStatement(flworStatementContext);
         }
-        if (content instanceof XQueryParser.IfStatementContext) {
-            return this.visitIfStatement((XQueryParser.IfStatementContext) content);
+        if (content instanceof XQueryParser.IfStatementContext ifStatementContext) {
+            return this.visitIfStatement(ifStatementContext);
         }
-        if (content instanceof XQueryParser.SwitchStatementContext) {
-            return this.visitSwitchStatement((XQueryParser.SwitchStatementContext) content);
+        if (content instanceof XQueryParser.SwitchStatementContext switchStatementContext) {
+            return this.visitSwitchStatement(switchStatementContext);
         }
-        if (content instanceof XQueryParser.TryCatchStatementContext) {
-            return this.visitTryCatchStatement((XQueryParser.TryCatchStatementContext) content);
+        if (content instanceof XQueryParser.TryCatchStatementContext tryCatchStatementContext) {
+            return this.visitTryCatchStatement(tryCatchStatementContext);
         }
-        if (content instanceof XQueryParser.TypeSwitchStatementContext) {
-            return this.visitTypeSwitchStatement((XQueryParser.TypeSwitchStatementContext) content);
+        if (content instanceof XQueryParser.TypeSwitchStatementContext typeSwitchStatementContext) {
+            return this.visitTypeSwitchStatement(typeSwitchStatementContext);
         }
-        if (content instanceof XQueryParser.VarDeclStatementContext) {
-            return this.visitVarDeclStatement((XQueryParser.VarDeclStatementContext) content);
+        if (content instanceof XQueryParser.VarDeclStatementContext varDeclStatementContext) {
+            return this.visitVarDeclStatement(varDeclStatementContext);
         }
-        if (content instanceof XQueryParser.WhileStatementContext) {
-            return this.visitWhileStatement((XQueryParser.WhileStatementContext) content);
+        if (content instanceof XQueryParser.WhileStatementContext whileStatementContext) {
+            return this.visitWhileStatement(whileStatementContext);
         }
         throw new OurBadException("Unrecognized Statement.");
     }
@@ -2991,18 +2990,18 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         }
         Clause lastFlowrClause = clause.getLastClause();
         for (ParseTree child : ctx.children.subList(1, ctx.children.size() - 2)) {
-            if (child instanceof XQueryParser.ForClauseContext) {
-                clause = (Clause) this.visitForClause((XQueryParser.ForClauseContext) child);
-            } else if (child instanceof XQueryParser.LetClauseContext) {
-                clause = (Clause) this.visitLetClause((XQueryParser.LetClauseContext) child);
-            } else if (child instanceof XQueryParser.WhereClauseContext) {
-                clause = (Clause) this.visitWhereClause((XQueryParser.WhereClauseContext) child);
-            } else if (child instanceof XQueryParser.GroupByClauseContext) {
-                clause = (Clause) this.visitGroupByClause((XQueryParser.GroupByClauseContext) child);
-            } else if (child instanceof XQueryParser.OrderByClauseContext) {
-                clause = (Clause) this.visitOrderByClause((XQueryParser.OrderByClauseContext) child);
-            } else if (child instanceof XQueryParser.CountClauseContext) {
-                clause = (Clause) this.visitCountClause((XQueryParser.CountClauseContext) child);
+            if (child instanceof XQueryParser.ForClauseContext forClauseContext) {
+                clause = (Clause) this.visitForClause(forClauseContext);
+            } else if (child instanceof XQueryParser.LetClauseContext letClauseContext) {
+                clause = (Clause) this.visitLetClause(letClauseContext);
+            } else if (child instanceof XQueryParser.WhereClauseContext whereClauseContext) {
+                clause = (Clause) this.visitWhereClause(whereClauseContext);
+            } else if (child instanceof XQueryParser.GroupByClauseContext groupByClauseContext) {
+                clause = (Clause) this.visitGroupByClause(groupByClauseContext);
+            } else if (child instanceof XQueryParser.OrderByClauseContext orderByClauseContext) {
+                clause = (Clause) this.visitOrderByClause(orderByClauseContext);
+            } else if (child instanceof XQueryParser.CountClauseContext countClauseContext) {
+                clause = (Clause) this.visitCountClause(countClauseContext);
             } else {
                 throw new UnsupportedFeatureException(
                         "FLOWR clause not implemented yet",
@@ -3434,12 +3433,11 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     // | SchemaAttributeTest | PITest | CommentTest | TextTest
     // | NamespaceNodeTest | AnyKindTest
     private NodeTest getKindTest(ParseTree kindTest) {
-        if (kindTest instanceof XQueryParser.DocumentTestContext) {
+        if (kindTest instanceof XQueryParser.DocumentTestContext docContext) {
             // XQuery 3.1 Section 2.5.5.3 - Element Test (used within DocumentTest)
             // DocumentTest ::= "document-node" "(" (ElementTest | SchemaElementTest)? ")"
             // document-node() matches any document node.
             // document-node(element(...)) matches a document node containing an element matching the ElementTest.
-            XQueryParser.DocumentTestContext docContext = (XQueryParser.DocumentTestContext) kindTest;
             if (docContext.schemaElementTest() != null) {
                 throw new UnsupportedFeatureException(
                         "Schema element tests within document-node() are not supported",
@@ -3450,7 +3448,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
                 return new DocumentTest(null);
             }
             return new DocumentTest(getKindTest(docContext.elementTest()));
-        } else if (kindTest instanceof XQueryParser.ElementTestContext) {
+        } else if (kindTest instanceof XQueryParser.ElementTestContext elementContext) {
             // XQuery 3.1 Section 2.5.5.3 - Element Test
             // ElementTest ::= "element" "(" (ElementNameOrWildcard ("," TypeName "?"?)?)? ")"
             // element() and element(*) match any single element node.
@@ -3458,7 +3456,6 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
             // element(N, T) matches an element node whose name is N and whose type annotation is T.
             // element(*, T) matches any element node whose type annotation is T.
             // element(N, T?) also matches nillable elements (validation-related, unsupported).
-            XQueryParser.ElementTestContext elementContext = (XQueryParser.ElementTestContext) kindTest;
             // Reject the nillable marker "?" (validation-related feature)
             if (elementContext.optional != null) {
                 throw new UnsupportedFeatureException(
@@ -3491,15 +3488,13 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
                 return new ElementTest(true);
             }
             return new ElementTest();
-        } else if (kindTest instanceof XQueryParser.AttributeTestContext) {
+        } else if (kindTest instanceof XQueryParser.AttributeTestContext attributeTestContext) {
             // XQuery 3.1 Section 2.5.5.5 - Attribute Test
             // AttributeTest ::= "attribute" "(" (AttribNameOrWildcard ("," TypeName)?)? ")"
             // attribute() and attribute(*) match any single attribute node.
             // attribute(N) matches any attribute node whose name is N.
             // attribute(N, T) matches an attribute node whose name is N and whose type annotation is T.
             // attribute(*, T) matches any attribute node whose type annotation is T.
-            XQueryParser.AttributeTestContext attributeTestContext =
-                (XQueryParser.AttributeTestContext) kindTest;
             Name attributeName;
             if (attributeTestContext.attributeNameOrWildcard() != null) {
                 boolean hasWildcard = attributeTestContext.attributeNameOrWildcard().attributeName() == null;
@@ -3549,13 +3544,12 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
             // CommentTest ::= "comment" "(" ")"
             // A CommentTest matches any comment node.
             return new CommentTest();
-        } else if (kindTest instanceof XQueryParser.PiTestContext) {
+        } else if (kindTest instanceof XQueryParser.PiTestContext piContext) {
             // XQuery 3.1 Section 2.5.5
             // PITest ::= "processing-instruction" "(" (NCName | StringLiteral)? ")"
             // processing-instruction() matches any processing-instruction node.
             // processing-instruction(N) matches any processing-instruction node whose target
             // name equals fn:normalize-space(N).
-            XQueryParser.PiTestContext piContext = (XQueryParser.PiTestContext) kindTest;
             if (piContext.ncName() != null) {
                 return new PITest(piContext.ncName().getText());
             }
@@ -3782,14 +3776,14 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
             boolean allowEnclosedExpressions
     ) {
         ParseTree child = ctx.children.get(0);
-        if (child instanceof XQueryParser.DirAttributeValueAposContext) {
+        if (child instanceof XQueryParser.DirAttributeValueAposContext dirAttributeValueAposContext) {
             return this.getDirAttributeValueAposExpressions(
-                (XQueryParser.DirAttributeValueAposContext) child,
+                dirAttributeValueAposContext,
                 allowEnclosedExpressions
             );
-        } else if (child instanceof XQueryParser.DirAttributeValueQuotContext) {
+        } else if (child instanceof XQueryParser.DirAttributeValueQuotContext dirAttributeValueQuotContext) {
             return this.getDirAttributeValueQuotExpressions(
-                (XQueryParser.DirAttributeValueQuotContext) child,
+                dirAttributeValueQuotContext,
                 allowEnclosedExpressions
             );
         }
@@ -3862,9 +3856,9 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
 
             // Process each expression returned from the child
             for (Expression childExpression : childExpressions) {
-                if (childExpression instanceof AttributeNodeContentExpression) {
+                if (childExpression instanceof AttributeNodeContentExpression attributeNodeContentExpression) {
                     // Text content - accumulate it
-                    String content = ((AttributeNodeContentExpression) childExpression).getContent();
+                    String content = (attributeNodeContentExpression).getContent();
 
                     if (textAccumulator == null) {
                         // Start accumulating text content
@@ -3916,14 +3910,14 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         ParseTree child = ctx.children.get(0);
         List<Expression> expressions = new ArrayList<>();
 
-        if (ctx instanceof XQueryParser.DirAttributeValueAposContext) {
+        if (ctx instanceof XQueryParser.DirAttributeValueAposContext dirAttributeValueAposContext) {
             return this.getDirAttributeValueAposExpressions(
-                (XQueryParser.DirAttributeValueAposContext) ctx,
+                dirAttributeValueAposContext,
                 allowEnclosedExpressions
             );
-        } else if (ctx instanceof XQueryParser.DirAttributeValueQuotContext) {
+        } else if (ctx instanceof XQueryParser.DirAttributeValueQuotContext dirAttributeValueQuotContext) {
             return this.getDirAttributeValueQuotExpressions(
-                (XQueryParser.DirAttributeValueQuotContext) ctx,
+                dirAttributeValueQuotContext,
                 allowEnclosedExpressions
             );
         } else if (

--- a/src/main/java/org/rumbledb/exceptions/RumbleException.java
+++ b/src/main/java/org/rumbledb/exceptions/RumbleException.java
@@ -134,8 +134,8 @@ public class RumbleException extends RuntimeException {
         if (ex instanceof SparkException) {
             Throwable sparkExceptionCause = ex.getCause();
             return unnestException(sparkExceptionCause);
-        } else if (ex instanceof RumbleException) {
-            return (RumbleException) ex;
+        } else if (ex instanceof RumbleException rumbleException) {
+            return rumbleException;
         } else {
             RumbleException e2 = new OurBadException("Unanticipated exception!");
             e2.initCause(ex);

--- a/src/main/java/org/rumbledb/expressions/xml/DirPIConstructorExpression.java
+++ b/src/main/java/org/rumbledb/expressions/xml/DirPIConstructorExpression.java
@@ -84,8 +84,8 @@ public class DirPIConstructorExpression extends Expression {
         sb.append(this.target);
         if (this.contentExpression != null) {
             sb.append(" ");
-            if (this.contentExpression instanceof StringLiteralExpression) {
-                sb.append(((StringLiteralExpression) this.contentExpression).getValue());
+            if (this.contentExpression instanceof StringLiteralExpression stringLiteralExpression) {
+                sb.append(stringLiteralExpression.getValue());
             } else {
                 this.contentExpression.serializeToJSONiq(sb, 0);
             }

--- a/src/main/java/org/rumbledb/items/AnnotatedItem.java
+++ b/src/main/java/org/rumbledb/items/AnnotatedItem.java
@@ -60,11 +60,11 @@ public class AnnotatedItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
-            if (((Item) otherItem).isAtomic()) {
+        if (otherItem instanceof Item other) {
+            if (other.isAtomic()) {
                 long c = ComparisonIterator.compareItems(
                     this,
-                    (Item) otherItem,
+                    other,
                     ComparisonOperator.VC_EQ,
                     ExceptionMetadata.EMPTY_METADATA
                 );
@@ -709,8 +709,8 @@ public class AnnotatedItem implements Item {
 
     @Override
     public boolean physicalEquals(Object other) {
-        if (other instanceof AnnotatedItem) {
-            return this.itemToAnnotate.physicalEquals(((AnnotatedItem) other).itemToAnnotate);
+        if (other instanceof AnnotatedItem annotatedItem) {
+            return this.itemToAnnotate.physicalEquals(annotatedItem.itemToAnnotate);
         }
         return this.itemToAnnotate.physicalEquals(other);
     }

--- a/src/main/java/org/rumbledb/items/AnnotatedItem.java
+++ b/src/main/java/org/rumbledb/items/AnnotatedItem.java
@@ -59,12 +59,12 @@ public class AnnotatedItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
-            if (other.isAtomic()) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
+            if (otherItem.isAtomic()) {
                 long c = ComparisonIterator.compareItems(
                     this,
-                    other,
+                    otherItem,
                     ComparisonOperator.VC_EQ,
                     ExceptionMetadata.EMPTY_METADATA
                 );

--- a/src/main/java/org/rumbledb/items/AnyURIItem.java
+++ b/src/main/java/org/rumbledb/items/AnyURIItem.java
@@ -55,11 +55,11 @@ public class AnyURIItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/AnyURIItem.java
+++ b/src/main/java/org/rumbledb/items/AnyURIItem.java
@@ -56,10 +56,10 @@ public class AnyURIItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/ArrayItem.java
+++ b/src/main/java/org/rumbledb/items/ArrayItem.java
@@ -84,10 +84,9 @@ public class ArrayItem implements Item {
     }
 
     public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item)) {
+        if (!(otherItem instanceof Item o)) {
             return false;
         }
-        Item o = (Item) otherItem;
         if (!o.isArray()) {
             return false;
         }

--- a/src/main/java/org/rumbledb/items/ArrayItem.java
+++ b/src/main/java/org/rumbledb/items/ArrayItem.java
@@ -83,18 +83,18 @@ public class ArrayItem implements Item {
         return copy;
     }
 
-    public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item o)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        if (!o.isArray()) {
+        if (!otherItem.isArray()) {
             return false;
         }
-        if (getSize() != o.getSize()) {
+        if (getSize() != otherItem.getSize()) {
             return false;
         }
         for (int i = 0; i < getSize(); ++i) {
-            if (!getItemAt(i).equals(o.getItemAt(i))) {
+            if (!getItemAt(i).equals(otherItem.getItemAt(i))) {
                 return false;
             }
         }

--- a/src/main/java/org/rumbledb/items/Base64BinaryItem.java
+++ b/src/main/java/org/rumbledb/items/Base64BinaryItem.java
@@ -53,10 +53,10 @@ public class Base64BinaryItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/Base64BinaryItem.java
+++ b/src/main/java/org/rumbledb/items/Base64BinaryItem.java
@@ -52,11 +52,11 @@ public class Base64BinaryItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/BooleanItem.java
+++ b/src/main/java/org/rumbledb/items/BooleanItem.java
@@ -88,10 +88,9 @@ public class BooleanItem implements Item {
     }
 
     public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item)) {
+        if (!(otherItem instanceof Item o)) {
             return false;
         }
-        Item o = (Item) otherItem;
         if (!o.isBoolean()) {
             return false;
         }

--- a/src/main/java/org/rumbledb/items/BooleanItem.java
+++ b/src/main/java/org/rumbledb/items/BooleanItem.java
@@ -87,14 +87,14 @@ public class BooleanItem implements Item {
         this.value = input.readBoolean();
     }
 
-    public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item o)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        if (!o.isBoolean()) {
+        if (!otherItem.isBoolean()) {
             return false;
         }
-        return (getBooleanValue() == o.getBooleanValue());
+        return (getBooleanValue() == otherItem.getBooleanValue());
     }
 
     public int hashCode() {

--- a/src/main/java/org/rumbledb/items/DateItem.java
+++ b/src/main/java/org/rumbledb/items/DateItem.java
@@ -93,11 +93,11 @@ public class DateItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DateItem.java
+++ b/src/main/java/org/rumbledb/items/DateItem.java
@@ -94,10 +94,10 @@ public class DateItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DateTimeItem.java
+++ b/src/main/java/org/rumbledb/items/DateTimeItem.java
@@ -99,10 +99,10 @@ public class DateTimeItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DateTimeItem.java
+++ b/src/main/java/org/rumbledb/items/DateTimeItem.java
@@ -98,11 +98,11 @@ public class DateTimeItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DateTimeStampItem.java
+++ b/src/main/java/org/rumbledb/items/DateTimeStampItem.java
@@ -46,11 +46,11 @@ public class DateTimeStampItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DateTimeStampItem.java
+++ b/src/main/java/org/rumbledb/items/DateTimeStampItem.java
@@ -47,10 +47,10 @@ public class DateTimeStampItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DayTimeDurationItem.java
+++ b/src/main/java/org/rumbledb/items/DayTimeDurationItem.java
@@ -96,10 +96,10 @@ public class DayTimeDurationItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DayTimeDurationItem.java
+++ b/src/main/java/org/rumbledb/items/DayTimeDurationItem.java
@@ -95,11 +95,11 @@ public class DayTimeDurationItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DecimalItem.java
+++ b/src/main/java/org/rumbledb/items/DecimalItem.java
@@ -58,11 +58,11 @@ public class DecimalItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DecimalItem.java
+++ b/src/main/java/org/rumbledb/items/DecimalItem.java
@@ -59,10 +59,10 @@ public class DecimalItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DoubleItem.java
+++ b/src/main/java/org/rumbledb/items/DoubleItem.java
@@ -59,10 +59,10 @@ public class DoubleItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DoubleItem.java
+++ b/src/main/java/org/rumbledb/items/DoubleItem.java
@@ -58,11 +58,11 @@ public class DoubleItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DurationItem.java
+++ b/src/main/java/org/rumbledb/items/DurationItem.java
@@ -66,10 +66,10 @@ public class DurationItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/DurationItem.java
+++ b/src/main/java/org/rumbledb/items/DurationItem.java
@@ -65,11 +65,11 @@ public class DurationItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/FloatItem.java
+++ b/src/main/java/org/rumbledb/items/FloatItem.java
@@ -57,10 +57,10 @@ public class FloatItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/FloatItem.java
+++ b/src/main/java/org/rumbledb/items/FloatItem.java
@@ -56,11 +56,11 @@ public class FloatItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/HexBinaryItem.java
+++ b/src/main/java/org/rumbledb/items/HexBinaryItem.java
@@ -41,10 +41,10 @@ public class HexBinaryItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/HexBinaryItem.java
+++ b/src/main/java/org/rumbledb/items/HexBinaryItem.java
@@ -40,11 +40,11 @@ public class HexBinaryItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/IntItem.java
+++ b/src/main/java/org/rumbledb/items/IntItem.java
@@ -57,11 +57,11 @@ public class IntItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/IntItem.java
+++ b/src/main/java/org/rumbledb/items/IntItem.java
@@ -58,10 +58,10 @@ public class IntItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/IntegerItem.java
+++ b/src/main/java/org/rumbledb/items/IntegerItem.java
@@ -57,10 +57,10 @@ public class IntegerItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/IntegerItem.java
+++ b/src/main/java/org/rumbledb/items/IntegerItem.java
@@ -56,11 +56,11 @@ public class IntegerItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/LazyObjectItem.java
+++ b/src/main/java/org/rumbledb/items/LazyObjectItem.java
@@ -105,15 +105,15 @@ public class LazyObjectItem implements Item {
 
     }
 
-    public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item o)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        if (!o.isObject()) {
+        if (!otherItem.isObject()) {
             return false;
         }
         for (String s : getKeys()) {
-            Item v = o.getItemByKey(s);
+            Item v = otherItem.getItemByKey(s);
             if (v == null) {
                 return false;
             }
@@ -121,12 +121,12 @@ public class LazyObjectItem implements Item {
                 return false;
             }
         }
-        for (String s : o.getKeys()) {
+        for (String s : otherItem.getKeys()) {
             Item v = getItemByKey(s);
             if (v == null) {
                 return false;
             }
-            if (!o.getItemByKey(s).equals(v)) {
+            if (!otherItem.getItemByKey(s).equals(v)) {
                 return false;
             }
         }

--- a/src/main/java/org/rumbledb/items/LazyObjectItem.java
+++ b/src/main/java/org/rumbledb/items/LazyObjectItem.java
@@ -106,10 +106,9 @@ public class LazyObjectItem implements Item {
     }
 
     public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item)) {
+        if (!(otherItem instanceof Item o)) {
             return false;
         }
-        Item o = (Item) otherItem;
         if (!o.isObject()) {
             return false;
         }

--- a/src/main/java/org/rumbledb/items/MapEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapEntryItem.java
@@ -353,14 +353,14 @@ public class MapEntryItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item other)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        if (!other.isObject()) {
+        if (!otherItem.isObject()) {
             return false;
         }
-        List<Item> otherSequence = other.getSequenceByKey(this.key);
+        List<Item> otherSequence = otherItem.getSequenceByKey(this.key);
         if (otherSequence == null || this.value.size() != otherSequence.size()) {
             return false;
         }
@@ -369,7 +369,7 @@ public class MapEntryItem implements Item {
                 return false;
             }
         }
-        for (Item key : other.getItemKeys()) {
+        for (Item key : otherItem.getItemKeys()) {
             if (getSequenceByKey(key) == null) {
                 return false;
             }

--- a/src/main/java/org/rumbledb/items/MapEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapEntryItem.java
@@ -354,10 +354,9 @@ public class MapEntryItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item)) {
+        if (!(otherItem instanceof Item other)) {
             return false;
         }
-        Item other = (Item) otherItem;
         if (!other.isObject()) {
             return false;
         }

--- a/src/main/java/org/rumbledb/items/MapItem.java
+++ b/src/main/java/org/rumbledb/items/MapItem.java
@@ -556,16 +556,16 @@ public class MapItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item other)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        if (!other.isObject()) {
+        if (!otherItem.isObject()) {
             return false;
         }
         for (Item key : this.keys) {
             List<Item> thisSequence = getSequenceByKey(key);
-            List<Item> otherSequence = other.getSequenceByKey(key);
+            List<Item> otherSequence = otherItem.getSequenceByKey(key);
             if (otherSequence == null || thisSequence.size() != otherSequence.size()) {
                 return false;
             }
@@ -575,7 +575,7 @@ public class MapItem implements Item {
                 }
             }
         }
-        for (Item key : other.getItemKeys()) {
+        for (Item key : otherItem.getItemKeys()) {
             if (getSequenceByKey(key) == null) {
                 return false;
             }

--- a/src/main/java/org/rumbledb/items/MapItem.java
+++ b/src/main/java/org/rumbledb/items/MapItem.java
@@ -557,10 +557,9 @@ public class MapItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item)) {
+        if (!(otherItem instanceof Item other)) {
             return false;
         }
-        Item other = (Item) otherItem;
         if (!other.isObject()) {
             return false;
         }

--- a/src/main/java/org/rumbledb/items/MapSameKeyWrapper.java
+++ b/src/main/java/org/rumbledb/items/MapSameKeyWrapper.java
@@ -82,10 +82,9 @@ public final class MapSameKeyWrapper {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof MapSameKeyWrapper)) {
+        if (!(o instanceof MapSameKeyWrapper other)) {
             return false;
         }
-        MapSameKeyWrapper other = (MapSameKeyWrapper) o;
         return MapAtomicSameKey.sameKey(this.key, other.key);
     }
 

--- a/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
@@ -373,10 +373,9 @@ public class MapWithAdditionalEntryItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item)) {
+        if (!(otherItem instanceof Item other)) {
             return false;
         }
-        Item other = (Item) otherItem;
         if (!other.isObject()) {
             return false;
         }

--- a/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
@@ -372,11 +372,11 @@ public class MapWithAdditionalEntryItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item other)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        if (!other.isObject()) {
+        if (!otherItem.isObject()) {
             return false;
         }
         for (Item key : this.original.getItemKeys()) {
@@ -384,7 +384,7 @@ public class MapWithAdditionalEntryItem implements Item {
             if (this.itemSameKeyComparator.compare(key, this.additionalKey) == 0) {
                 thisSequence = this.additionalValue;
             }
-            List<Item> otherSequence = other.getSequenceByKey(key);
+            List<Item> otherSequence = otherItem.getSequenceByKey(key);
             if (otherSequence == null || thisSequence.size() != otherSequence.size()) {
                 return false;
             }
@@ -394,9 +394,9 @@ public class MapWithAdditionalEntryItem implements Item {
                 }
             }
         }
-        for (Item key : other.getItemKeys()) {
+        for (Item key : otherItem.getItemKeys()) {
             if (this.itemSameKeyComparator.compare(key, this.additionalKey) == 0) {
-                List<Item> otherSequence = other.getSequenceByKey(key);
+                List<Item> otherSequence = otherItem.getSequenceByKey(key);
                 if (otherSequence == null || this.additionalValue.size() != otherSequence.size()) {
                     return false;
                 }

--- a/src/main/java/org/rumbledb/items/MapWithRemovedEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithRemovedEntryItem.java
@@ -367,11 +367,11 @@ public class MapWithRemovedEntryItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item other)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        if (!other.isObject()) {
+        if (!otherItem.isObject()) {
             return false;
         }
         for (Item key : this.original.getItemKeys()) {
@@ -379,7 +379,7 @@ public class MapWithRemovedEntryItem implements Item {
                 continue;
             }
             List<Item> thisSequence = this.original.getSequenceByKey(key);
-            List<Item> otherSequence = other.getSequenceByKey(key);
+            List<Item> otherSequence = otherItem.getSequenceByKey(key);
             if (otherSequence == null || thisSequence.size() != otherSequence.size()) {
                 return false;
             }
@@ -389,7 +389,7 @@ public class MapWithRemovedEntryItem implements Item {
                 }
             }
         }
-        for (Item key : other.getItemKeys()) {
+        for (Item key : otherItem.getItemKeys()) {
             if (this.removedKeys.contains(key)) {
                 return false;
             }

--- a/src/main/java/org/rumbledb/items/MapWithRemovedEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithRemovedEntryItem.java
@@ -368,10 +368,9 @@ public class MapWithRemovedEntryItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item)) {
+        if (!(otherItem instanceof Item other)) {
             return false;
         }
-        Item other = (Item) otherItem;
         if (!other.isObject()) {
             return false;
         }

--- a/src/main/java/org/rumbledb/items/NullItem.java
+++ b/src/main/java/org/rumbledb/items/NullItem.java
@@ -41,11 +41,11 @@ public class NullItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/NullItem.java
+++ b/src/main/java/org/rumbledb/items/NullItem.java
@@ -42,10 +42,10 @@ public class NullItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/ObjectItem.java
+++ b/src/main/java/org/rumbledb/items/ObjectItem.java
@@ -98,15 +98,15 @@ public class ObjectItem implements Item {
         return result;
     }
 
-    public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item o)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        if (!o.isObject()) {
+        if (!otherItem.isObject()) {
             return false;
         }
         for (String s : getKeys()) {
-            Item v = o.getItemByKey(s);
+            Item v = otherItem.getItemByKey(s);
             if (v == null) {
                 return false;
             }
@@ -114,12 +114,12 @@ public class ObjectItem implements Item {
                 return false;
             }
         }
-        for (String s : o.getKeys()) {
+        for (String s : otherItem.getKeys()) {
             Item v = getItemByKey(s);
             if (v == null) {
                 return false;
             }
-            if (!o.getItemByKey(s).equals(v)) {
+            if (!otherItem.getItemByKey(s).equals(v)) {
                 return false;
             }
         }

--- a/src/main/java/org/rumbledb/items/ObjectItem.java
+++ b/src/main/java/org/rumbledb/items/ObjectItem.java
@@ -99,10 +99,9 @@ public class ObjectItem implements Item {
     }
 
     public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item)) {
+        if (!(otherItem instanceof Item o)) {
             return false;
         }
-        Item o = (Item) otherItem;
         if (!o.isObject()) {
             return false;
         }
@@ -160,8 +159,7 @@ public class ObjectItem implements Item {
                     } else {
                         throw new RuntimeException("Unexpected list size found.");
                     }
-                } else if (keyValuePairs.get(key) instanceof Item) {
-                    Item value = (Item) keyValuePairs.get(key);
+                } else if (keyValuePairs.get(key) instanceof Item value) {
                     valueList.add(value);
                 } else {
                     throw new RuntimeException("Unexpected value type found.");

--- a/src/main/java/org/rumbledb/items/QNameItem.java
+++ b/src/main/java/org/rumbledb/items/QNameItem.java
@@ -54,10 +54,9 @@ public class QNameItem implements Item {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof Item)) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        Item otherItem = (Item) other;
         if (!otherItem.isQName()) {
             return false;
         }

--- a/src/main/java/org/rumbledb/items/SequenceArrayItem.java
+++ b/src/main/java/org/rumbledb/items/SequenceArrayItem.java
@@ -72,19 +72,19 @@ public class SequenceArrayItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item o)) {
+    public boolean equals(Object other) {
+        if (!(other instanceof Item otherItem)) {
             return false;
         }
-        if (!o.isArray()) {
+        if (!otherItem.isArray()) {
             return false;
         }
-        if (getSize() != o.getSize()) {
+        if (getSize() != otherItem.getSize()) {
             return false;
         }
         for (int i = 0; i < getSize(); ++i) {
             List<Item> thisMember = this.getSequenceAt(i);
-            List<Item> otherMember = o.getSequenceAt(i);
+            List<Item> otherMember = otherItem.getSequenceAt(i);
             if (thisMember.size() != otherMember.size()) {
                 return false;
             }

--- a/src/main/java/org/rumbledb/items/SequenceArrayItem.java
+++ b/src/main/java/org/rumbledb/items/SequenceArrayItem.java
@@ -73,10 +73,9 @@ public class SequenceArrayItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (!(otherItem instanceof Item)) {
+        if (!(otherItem instanceof Item o)) {
             return false;
         }
-        Item o = (Item) otherItem;
         if (!o.isArray()) {
             return false;
         }

--- a/src/main/java/org/rumbledb/items/StringItem.java
+++ b/src/main/java/org/rumbledb/items/StringItem.java
@@ -57,11 +57,11 @@ public class StringItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/StringItem.java
+++ b/src/main/java/org/rumbledb/items/StringItem.java
@@ -58,10 +58,10 @@ public class StringItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/TimeItem.java
+++ b/src/main/java/org/rumbledb/items/TimeItem.java
@@ -70,11 +70,11 @@ public class TimeItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/TimeItem.java
+++ b/src/main/java/org/rumbledb/items/TimeItem.java
@@ -71,10 +71,10 @@ public class TimeItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/UntypedAtomicItem.java
+++ b/src/main/java/org/rumbledb/items/UntypedAtomicItem.java
@@ -106,10 +106,10 @@ public class UntypedAtomicItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/UntypedAtomicItem.java
+++ b/src/main/java/org/rumbledb/items/UntypedAtomicItem.java
@@ -105,11 +105,11 @@ public class UntypedAtomicItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/YearMonthDurationItem.java
+++ b/src/main/java/org/rumbledb/items/YearMonthDurationItem.java
@@ -91,10 +91,10 @@ public class YearMonthDurationItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/YearMonthDurationItem.java
+++ b/src/main/java/org/rumbledb/items/YearMonthDurationItem.java
@@ -90,11 +90,11 @@ public class YearMonthDurationItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gDayItem.java
+++ b/src/main/java/org/rumbledb/items/gDayItem.java
@@ -70,10 +70,10 @@ public class gDayItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gDayItem.java
+++ b/src/main/java/org/rumbledb/items/gDayItem.java
@@ -69,11 +69,11 @@ public class gDayItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gMonthDayItem.java
+++ b/src/main/java/org/rumbledb/items/gMonthDayItem.java
@@ -79,11 +79,11 @@ public class gMonthDayItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gMonthDayItem.java
+++ b/src/main/java/org/rumbledb/items/gMonthDayItem.java
@@ -80,10 +80,10 @@ public class gMonthDayItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gMonthItem.java
+++ b/src/main/java/org/rumbledb/items/gMonthItem.java
@@ -70,11 +70,11 @@ public class gMonthItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gMonthItem.java
+++ b/src/main/java/org/rumbledb/items/gMonthItem.java
@@ -71,10 +71,10 @@ public class gMonthItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gYearItem.java
+++ b/src/main/java/org/rumbledb/items/gYearItem.java
@@ -73,11 +73,11 @@ public class gYearItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gYearItem.java
+++ b/src/main/java/org/rumbledb/items/gYearItem.java
@@ -74,10 +74,10 @@ public class gYearItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gYearMonthItem.java
+++ b/src/main/java/org/rumbledb/items/gYearMonthItem.java
@@ -76,10 +76,10 @@ public class gYearMonthItem implements Item {
 
     @Override
     public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item) {
+        if (otherItem instanceof Item other) {
             long c = ComparisonIterator.compareItems(
                 this,
-                (Item) otherItem,
+                other,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/gYearMonthItem.java
+++ b/src/main/java/org/rumbledb/items/gYearMonthItem.java
@@ -75,11 +75,11 @@ public class gYearMonthItem implements Item {
     }
 
     @Override
-    public boolean equals(Object otherItem) {
-        if (otherItem instanceof Item other) {
+    public boolean equals(Object other) {
+        if (other instanceof Item otherItem) {
             long c = ComparisonIterator.compareItems(
                 this,
-                other,
+                otherItem,
                 ComparisonExpression.ComparisonOperator.VC_EQ,
                 ExceptionMetadata.EMPTY_METADATA
             );

--- a/src/main/java/org/rumbledb/items/parsing/ItemParser.java
+++ b/src/main/java/org/rumbledb/items/parsing/ItemParser.java
@@ -684,7 +684,7 @@ public class ItemParser implements Serializable {
             } else {
                 return ItemFactory.getInstance().createAnnotatedItem(item, itemType);
             }
-        } else if (fieldType instanceof DecimalType && ((DecimalType) fieldType).scale() == 0) {
+        } else if (fieldType instanceof DecimalType decimalType && decimalType.scale() == 0) {
             BigDecimal value;
             if (row != null) {
                 value = row.getDecimal(i);
@@ -800,8 +800,7 @@ public class ItemParser implements Serializable {
             } else {
                 return ItemFactory.getInstance().createAnnotatedItem(item, itemType);
             }
-        } else if (fieldType instanceof ArrayType) {
-            ArrayType arrayType = (ArrayType) fieldType;
+        } else if (fieldType instanceof ArrayType arrayType) {
             DataType dataType = arrayType.elementType();
             ItemType memberType = null;
             if (itemType != null && itemType.isArrayItemType() && !itemType.equals(BuiltinTypesCatalogue.item)) {
@@ -815,8 +814,8 @@ public class ItemParser implements Serializable {
                 }
             } else {
                 Iterator<Object> iterator = null;
-                if (o instanceof scala.collection.mutable.ArraySeq) {
-                    iterator = ((scala.collection.mutable.ArraySeq<Object>) o).iterator();
+                if (o instanceof scala.collection.mutable.ArraySeq<?> arraySeq) {
+                    iterator = ((scala.collection.mutable.ArraySeq<Object>) arraySeq).iterator();
                 } else {
                     iterator = ((ArraySeq<Object>) o).iterator();
                 }
@@ -838,9 +837,8 @@ public class ItemParser implements Serializable {
             } else {
                 vector = (Vector) o;
             }
-            if (vector instanceof DenseVector) {
+            if (vector instanceof DenseVector denseVector) {
                 // a dense vector is mapped to a rumble array
-                DenseVector denseVector = (DenseVector) vector;
                 List<Item> members = new ArrayList<>(vector.size());
                 for (double value : denseVector.values()) {
                     members.add(ItemFactory.getInstance().createDoubleItem(value));
@@ -851,9 +849,8 @@ public class ItemParser implements Serializable {
                 } else {
                     return ItemFactory.getInstance().createAnnotatedItem(item, itemType);
                 }
-            } else if (vector instanceof SparseVector) {
+            } else if (vector instanceof SparseVector sparseVector) {
                 // a sparse vector is mapped to a Rumble object where keys are indices of the non-0 values in the vector
-                SparseVector sparseVector = (SparseVector) vector;
                 List<String> objectKeyList = new ArrayList<>();
                 List<Item> objectValueList = new ArrayList<>();
                 int[] vectorIndices = sparseVector.indices();

--- a/src/main/java/org/rumbledb/items/structured/JSoundDataFrame.java
+++ b/src/main/java/org/rumbledb/items/structured/JSoundDataFrame.java
@@ -243,12 +243,10 @@ public class JSoundDataFrame implements Serializable {
         if (dataType instanceof VariantType) {
             return true;
         }
-        if (dataType instanceof ArrayType) {
-            ArrayType arrayType = (ArrayType) dataType;
+        if (dataType instanceof ArrayType arrayType) {
             return containsVariantTypeInSchema(arrayType.elementType());
         }
-        if (dataType instanceof StructType) {
-            StructType structType = (StructType) dataType;
+        if (dataType instanceof StructType structType) {
             for (StructField field : structType.fields()) {
                 if (containsVariantTypeInSchema(field.dataType())) {
                     return true;

--- a/src/main/java/org/rumbledb/items/xml/AttributeItem.java
+++ b/src/main/java/org/rumbledb/items/xml/AttributeItem.java
@@ -155,10 +155,9 @@ public class AttributeItem implements Item {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof AttributeItem)) {
+        if (!(other instanceof AttributeItem otherAttributeItem)) {
             return false;
         }
-        AttributeItem otherAttributeItem = (AttributeItem) other;
         return this.getXmlDocumentPosition().equals(otherAttributeItem.getXmlDocumentPosition());
     }
 

--- a/src/main/java/org/rumbledb/items/xml/CommentItem.java
+++ b/src/main/java/org/rumbledb/items/xml/CommentItem.java
@@ -104,10 +104,9 @@ public class CommentItem implements Item {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof CommentItem)) {
+        if (!(other instanceof CommentItem otherComment)) {
             return false;
         }
-        CommentItem otherComment = (CommentItem) other;
         return this.getXmlDocumentPosition() != null
             && this.getXmlDocumentPosition().equals(otherComment.getXmlDocumentPosition());
     }
@@ -221,4 +220,3 @@ public class CommentItem implements Item {
         return Collections.emptyList();
     }
 }
-

--- a/src/main/java/org/rumbledb/items/xml/DocumentItem.java
+++ b/src/main/java/org/rumbledb/items/xml/DocumentItem.java
@@ -140,10 +140,9 @@ public class DocumentItem implements Item {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof DocumentItem)) {
+        if (!(other instanceof DocumentItem otherDocumentItem)) {
             return false;
         }
-        DocumentItem otherDocumentItem = (DocumentItem) other;
         return this.getXmlDocumentPosition().equals(otherDocumentItem.getXmlDocumentPosition());
     }
 

--- a/src/main/java/org/rumbledb/items/xml/ElementItem.java
+++ b/src/main/java/org/rumbledb/items/xml/ElementItem.java
@@ -143,10 +143,9 @@ public class ElementItem implements Item {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ElementItem)) {
+        if (!(other instanceof ElementItem otherElementItem)) {
             return false;
         }
-        ElementItem otherElementItem = (ElementItem) other;
         return this.getXmlDocumentPosition().equals(otherElementItem.getXmlDocumentPosition());
     }
 
@@ -346,10 +345,9 @@ public class ElementItem implements Item {
     }
 
     public void addOrReplaceNamespace(Item namespaceItem) {
-        if (!(namespaceItem instanceof NamespaceItem)) {
+        if (!(namespaceItem instanceof NamespaceItem namespace)) {
             return;
         }
-        NamespaceItem namespace = (NamespaceItem) namespaceItem;
         if (this.namespaces == null) {
             this.namespaces = new HashMap<>();
         }
@@ -382,5 +380,4 @@ public class ElementItem implements Item {
         return true;
     }
 }
-
 

--- a/src/main/java/org/rumbledb/items/xml/NamespaceItem.java
+++ b/src/main/java/org/rumbledb/items/xml/NamespaceItem.java
@@ -149,10 +149,9 @@ public class NamespaceItem implements Item {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof NamespaceItem)) {
+        if (!(other instanceof NamespaceItem otherNamespaceItem)) {
             return false;
         }
-        NamespaceItem otherNamespaceItem = (NamespaceItem) other;
         return this.getXmlDocumentPosition().equals(otherNamespaceItem.getXmlDocumentPosition());
     }
 
@@ -266,4 +265,3 @@ public class NamespaceItem implements Item {
         return Collections.emptyList();
     }
 }
-

--- a/src/main/java/org/rumbledb/items/xml/ProcessingInstructionItem.java
+++ b/src/main/java/org/rumbledb/items/xml/ProcessingInstructionItem.java
@@ -99,10 +99,9 @@ public class ProcessingInstructionItem implements Item {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ProcessingInstructionItem)) {
+        if (!(other instanceof ProcessingInstructionItem otherItem)) {
             return false;
         }
-        ProcessingInstructionItem otherItem = (ProcessingInstructionItem) other;
         return this.getXmlDocumentPosition().equals(otherItem.getXmlDocumentPosition());
     }
 
@@ -236,4 +235,3 @@ public class ProcessingInstructionItem implements Item {
         return Collections.emptyList();
     }
 }
-

--- a/src/main/java/org/rumbledb/items/xml/TextItem.java
+++ b/src/main/java/org/rumbledb/items/xml/TextItem.java
@@ -59,10 +59,9 @@ public class TextItem implements Item {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof TextItem)) {
+        if (!(other instanceof TextItem otherTextItem)) {
             return false;
         }
-        TextItem otherTextItem = (TextItem) other;
         return this.getXmlDocumentPosition().equals(otherTextItem.getXmlDocumentPosition());
     }
 

--- a/src/main/java/org/rumbledb/runtime/flwor/FlworDataFrameUtils.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/FlworDataFrameUtils.java
@@ -862,8 +862,8 @@ public class FlworDataFrameUtils {
 
     public static long getCountOfField(Row row, int columnIndex) {
         Object o = row.get(columnIndex);
-        if (o instanceof Long) {
-            return ((Long) o).longValue();
+        if (o instanceof Long longValue) {
+            return longValue.longValue();
         } else {
             throw new OurBadException("Count is not available. Items should have been deserialized and counted.");
         }

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/JoinClauseSparkIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/JoinClauseSparkIterator.java
@@ -375,12 +375,11 @@ public class JoinClauseSparkIterator extends RuntimeTupleIterator {
         candidateIterators.push(predicateIterator);
         while (!candidateIterators.isEmpty()) {
             RuntimeIterator iterator = candidateIterators.pop();
-            if (iterator instanceof AndOperationIterator) {
-                AndOperationIterator andIterator = ((AndOperationIterator) iterator);
+            if (iterator instanceof AndOperationIterator andOperationIterator) {
+                AndOperationIterator andIterator = andOperationIterator;
                 candidateIterators.push(andIterator.getLeftIterator());
                 candidateIterators.push(andIterator.getRightIterator());
-            } else if (iterator instanceof ComparisonIterator) {
-                ComparisonIterator comparisonIterator = (ComparisonIterator) iterator;
+            } else if (iterator instanceof ComparisonIterator comparisonIterator) {
                 if (comparisonIterator.isValueEquality()) {
                     RuntimeIterator lhs = comparisonIterator.getLeftIterator();
                     RuntimeIterator rhs = comparisonIterator.getRightIterator();

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/LetClauseSparkIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/LetClauseSparkIterator.java
@@ -476,8 +476,7 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
         candidateIterators.push(predicateIterator);
         while (!candidateIterators.isEmpty()) {
             RuntimeIterator iterator = candidateIterators.pop();
-            if (iterator instanceof AndOperationIterator) {
-                AndOperationIterator andIterator = (AndOperationIterator) iterator;
+            if (iterator instanceof AndOperationIterator andIterator) {
                 candidateIterators.push(andIterator.getLeftIterator());
                 candidateIterators.push(andIterator.getRightIterator());
                 continue;

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/DataFrameContext.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/DataFrameContext.java
@@ -219,8 +219,7 @@ public class DataFrameContext implements Serializable {
                 throw ex;
             }
         }
-        if (dt instanceof ArrayType) {
-            ArrayType arrayType = (ArrayType) dt;
+        if (dt instanceof ArrayType arrayType) {
             if (arrayType.elementType().equals(DataTypes.BinaryType)) {
                 List<Object> objects = row.getList(columnIndex);
                 List<Item> items = new ArrayList<>();
@@ -243,7 +242,7 @@ public class DataFrameContext implements Serializable {
                 for (Object object : objects) {
                     Item item = ItemParser.convertValueToItem(
                         object,
-                        ((ArrayType) dt).elementType(),
+                        (arrayType).elementType(),
                         ExceptionMetadata.EMPTY_METADATA,
                         itemType == null ? null : itemType.getArrayContentFacet()
                     );

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/GroupClauseArrayMergeAggregateResultsUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/GroupClauseArrayMergeAggregateResultsUDF.java
@@ -52,8 +52,7 @@ public class GroupClauseArrayMergeAggregateResultsUDF implements UDF1<ArraySeq<O
         Iterator<Object> iterator = wrappedParameters.iterator();
         while (iterator.hasNext()) {
             Object o = iterator.next();
-            if (o instanceof Row) {
-                Row row = (Row) o;
+            if (o instanceof Row row) {
                 result.add(row);
             }
             if (o instanceof ArraySeq) {

--- a/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
@@ -318,8 +318,8 @@ public class FileSystemUtil {
             rumbleException.initCause(e);
             throw rumbleException;
         }
-        if (e instanceof RumbleException) {
-            throw (RumbleException) e;
+        if (e instanceof RumbleException rumbleException) {
+            throw rumbleException;
         }
         if (e instanceof RuntimeException) {
             Throwable cause = e.getCause();

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/CountFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/CountFunctionIterator.java
@@ -59,8 +59,7 @@ public class CountFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         // the count($x) case is treated separately because we can short-circuit the
         // count, e.g., if it comes from the group-by aggregation of a non-grouping
         // key.
-        if (iterator instanceof VariableReferenceIterator) {
-            VariableReferenceIterator expr = (VariableReferenceIterator) iterator;
+        if (iterator instanceof VariableReferenceIterator expr) {
             // this.hasNext = false;
             return context.getVariableValues()
                 .getVariableCount(expr.getVariableName(), getMetadata());

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupIterator.java
@@ -199,8 +199,8 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
             // we use nativeClauseContext that contains the top level schema
             DataType schema = nativeClauseContext.getSchema();
             StructType structSchema;
-            if (schema instanceof StructType) {
-                structSchema = (StructType) schema;
+            if (schema instanceof StructType structType) {
+                structSchema = structType;
                 if (
                     Arrays.stream(structSchema.fieldNames())
                         .anyMatch(field -> keyDependencies.containsKey(Name.createVariableInNoNamespace(field)))

--- a/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupIterator.java
@@ -237,8 +237,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
         // we use nativeClauseContext that contains the top level schema
         DataType outerContextSchema = nativeClauseContext.getSchema();
         // if the right hand side depends on the tuple stream, we cannot turn this into a native SQL query.
-        if (outerContextSchema instanceof StructType) {
-            StructType structSchema = (StructType) outerContextSchema;
+        if (outerContextSchema instanceof StructType structSchema) {
             for (Name n : keyDependencies.keySet()) {
                 if (FlworDataFrameUtils.hasColumnForVariable(structSchema, n)) {
                     return NativeClauseContext.NoNativeQuery;
@@ -270,8 +269,8 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
                         nativeClauseContext.getResultingType()
                 );
             } else {
-                if (leftSchema instanceof ArrayType) {
-                    leftSchema = ((ArrayType) leftSchema).elementType();
+                if (leftSchema instanceof ArrayType arrayType) {
+                    leftSchema = arrayType.elementType();
                 }
                 newContext = new NativeClauseContext(
                         nativeClauseContext,

--- a/src/main/java/org/rumbledb/runtime/typing/ValidateTypeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/ValidateTypeIterator.java
@@ -373,10 +373,10 @@ public class ValidateTypeIterator extends HybridRuntimeIterator {
             }
         }
         try {
-            if (dataType instanceof ArrayType) {
+            if (dataType instanceof ArrayType arrayType) {
                 List<Item> arrayItems = item.getItems();
                 Object[] arrayItemsForRow = new Object[arrayItems.size()];
-                DataType elementType = ((ArrayType) dataType).elementType();
+                DataType elementType = arrayType.elementType();
                 for (int i = 0; i < arrayItems.size(); i++) {
                     Item arrayItem = item.getItemAt(i);
                     arrayItemsForRow[i] = getRowColumnFromItemUsingDataType(
@@ -388,8 +388,8 @@ public class ValidateTypeIterator extends HybridRuntimeIterator {
                 return arrayItemsForRow;
             }
 
-            if (dataType instanceof StructType) {
-                return ValidateTypeIterator.convertLocalItemToRow(item, (StructType) dataType, context);
+            if (dataType instanceof StructType structType) {
+                return ValidateTypeIterator.convertLocalItemToRow(item, structType, context);
             }
 
             if (dataType.equals(DataTypes.BooleanType)) {

--- a/src/main/java/org/rumbledb/runtime/xml/StepExprIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/StepExprIterator.java
@@ -111,8 +111,8 @@ public class StepExprIterator extends LocalRuntimeIterator {
             return elementKindTest(node);
         } else if (this.nodeTest instanceof NameTest) {
             return nameKindTest(node);
-        } else if (this.nodeTest instanceof DocumentTest) {
-            return documentKindTest(node);
+        } else if (this.nodeTest instanceof DocumentTest documentTest) {
+            return documentKindTest(node, documentTest);
         } else {
             throw new UnsupportedFeatureException(
                     "Unsupported node test: " + this.nodeTest,
@@ -131,8 +131,7 @@ public class StepExprIterator extends LocalRuntimeIterator {
         }
     }
 
-    private Item documentKindTest(Item node) {
-        DocumentTest documentTest = (DocumentTest) this.nodeTest;
+    private Item documentKindTest(Item node, DocumentTest documentTest) {
         if (!node.isDocumentNode()) {
             return null;
         }

--- a/src/main/java/org/rumbledb/types/ArrayItemType.java
+++ b/src/main/java/org/rumbledb/types/ArrayItemType.java
@@ -75,14 +75,14 @@ public class ArrayItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        if (((ItemType) other).isXQueryArrayItemType()) {
+        if (itemType.isXQueryArrayItemType()) {
             // delegate to the XQuery array item type equality check
             return other.equals(this);
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -179,13 +179,12 @@ public class ArrayItemType implements ItemType {
 
     @Override
     public ItemType findLeastCommonSuperTypeLax(ItemType other) {
-        if (!(other instanceof ArrayItemType)) {
+        if (!(other instanceof ArrayItemType otherArray)) {
             if (other.isArrayItemType()) {
                 return other.findLeastCommonSuperTypeLax(this);
             }
             return this.findLeastCommonSuperTypeWith(other);
         }
-        ArrayItemType otherArray = (ArrayItemType) other;
         if (!this.isResolved() || !otherArray.isResolved()) {
             return this.findLeastCommonSuperTypeWith(other);
         }

--- a/src/main/java/org/rumbledb/types/AtomicItemType.java
+++ b/src/main/java/org/rumbledb/types/AtomicItemType.java
@@ -129,10 +129,10 @@ public class AtomicItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/types/AttributeNodeItemType.java
+++ b/src/main/java/org/rumbledb/types/AttributeNodeItemType.java
@@ -50,10 +50,10 @@ public class AttributeNodeItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType) || !((ItemType) other).isNodeItemType()) {
+        if (!(other instanceof ItemType itemType) || !itemType.isNodeItemType()) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -63,10 +63,9 @@ public class AttributeNodeItemType implements ItemType {
 
     @Override
     public boolean isEqualTo(ItemType otherType) {
-        if (!(otherType instanceof AttributeNodeItemType)) {
+        if (!(otherType instanceof AttributeNodeItemType other)) {
             return false;
         }
-        AttributeNodeItemType other = (AttributeNodeItemType) otherType;
         return Objects.equals(this.catalogueName, other.catalogueName)
             && Objects.equals(this.nodeName, other.nodeName);
     }
@@ -109,10 +108,9 @@ public class AttributeNodeItemType implements ItemType {
         ) {
             return true;
         }
-        if (!(superType instanceof AttributeNodeItemType)) {
+        if (!(superType instanceof AttributeNodeItemType other)) {
             return false;
         }
-        AttributeNodeItemType other = (AttributeNodeItemType) superType;
         if (other.isWildcardAttribute()) {
             return true;
         }

--- a/src/main/java/org/rumbledb/types/DerivedAtomicItemType.java
+++ b/src/main/java/org/rumbledb/types/DerivedAtomicItemType.java
@@ -199,10 +199,10 @@ public class DerivedAtomicItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/types/DocumentNodeItemType.java
+++ b/src/main/java/org/rumbledb/types/DocumentNodeItemType.java
@@ -54,10 +54,10 @@ public class DocumentNodeItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType) || !((ItemType) other).isNodeItemType()) {
+        if (!(other instanceof ItemType itemType) || !itemType.isNodeItemType()) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -67,10 +67,9 @@ public class DocumentNodeItemType implements ItemType {
 
     @Override
     public boolean isEqualTo(ItemType otherType) {
-        if (!(otherType instanceof DocumentNodeItemType)) {
+        if (!(otherType instanceof DocumentNodeItemType other)) {
             return false;
         }
-        DocumentNodeItemType other = (DocumentNodeItemType) otherType;
         return Objects.equals(this.catalogueName, other.catalogueName)
             && Objects.equals(this.elementTestType, other.elementTestType);
     }
@@ -109,10 +108,9 @@ public class DocumentNodeItemType implements ItemType {
         ) {
             return true;
         }
-        if (!(superType instanceof DocumentNodeItemType)) {
+        if (!(superType instanceof DocumentNodeItemType other)) {
             return false;
         }
-        DocumentNodeItemType other = (DocumentNodeItemType) superType;
         if (other.isWildcardDocument()) {
             return true;
         }
@@ -124,8 +122,7 @@ public class DocumentNodeItemType implements ItemType {
         if (this.equals(other)) {
             return this;
         }
-        if (other instanceof DocumentNodeItemType) {
-            DocumentNodeItemType otherDocument = (DocumentNodeItemType) other;
+        if (other instanceof DocumentNodeItemType otherDocument) {
             if (this.isWildcardDocument() || otherDocument.isWildcardDocument()) {
                 return BuiltinTypesCatalogue.documentNode;
             }

--- a/src/main/java/org/rumbledb/types/ElementNodeItemType.java
+++ b/src/main/java/org/rumbledb/types/ElementNodeItemType.java
@@ -50,10 +50,10 @@ public class ElementNodeItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType) || !((ItemType) other).isNodeItemType()) {
+        if (!(other instanceof ItemType itemType) || !itemType.isNodeItemType()) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -63,10 +63,9 @@ public class ElementNodeItemType implements ItemType {
 
     @Override
     public boolean isEqualTo(ItemType otherType) {
-        if (!(otherType instanceof ElementNodeItemType)) {
+        if (!(otherType instanceof ElementNodeItemType other)) {
             return false;
         }
-        ElementNodeItemType other = (ElementNodeItemType) otherType;
         return Objects.equals(this.catalogueName, other.catalogueName)
             && Objects.equals(this.nodeName, other.nodeName);
     }
@@ -109,10 +108,9 @@ public class ElementNodeItemType implements ItemType {
         ) {
             return true;
         }
-        if (!(superType instanceof ElementNodeItemType)) {
+        if (!(superType instanceof ElementNodeItemType other)) {
             return false;
         }
-        ElementNodeItemType other = (ElementNodeItemType) superType;
         if (other.isWildcardElement()) {
             return true;
         }

--- a/src/main/java/org/rumbledb/types/FunctionItemType.java
+++ b/src/main/java/org/rumbledb/types/FunctionItemType.java
@@ -48,10 +48,10 @@ public class FunctionItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/types/ItemItemType.java
+++ b/src/main/java/org/rumbledb/types/ItemItemType.java
@@ -37,10 +37,10 @@ public class ItemItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/types/ItemTypeFactory.java
+++ b/src/main/java/org/rumbledb/types/ItemTypeFactory.java
@@ -788,12 +788,12 @@ public class ItemTypeFactory {
     }
 
     public static ItemType createItemType(DataType dt) {
-        if (dt instanceof StructType) {
-            return createItemTypeFromSparkStructType((StructType) dt);
+        if (dt instanceof StructType structType) {
+            return createItemTypeFromSparkStructType(structType);
         }
-        if (dt instanceof ArrayType) {
+        if (dt instanceof ArrayType arrayType) {
             return createArrayTypeWithSparkDataTypeContent(
-                ((ArrayType) dt).elementType()
+                arrayType.elementType()
             );
         }
         if (dt.equals(DataTypes.StringType)) {
@@ -810,7 +810,7 @@ public class ItemTypeFactory {
             return BuiltinTypesCatalogue.integerItem;
         } else if (dt.equals(DataTypes.FloatType)) {
             return BuiltinTypesCatalogue.floatItem;
-        } else if (dt instanceof DecimalType && ((DecimalType) dt).scale() == 0) {
+        } else if (dt instanceof DecimalType decimalType && decimalType.scale() == 0) {
             return BuiltinTypesCatalogue.integerItem;
         } else if (dt instanceof DecimalType) {
             return BuiltinTypesCatalogue.decimalItem;

--- a/src/main/java/org/rumbledb/types/JsonItemType.java
+++ b/src/main/java/org/rumbledb/types/JsonItemType.java
@@ -29,10 +29,10 @@ public class JsonItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/types/MapItemType.java
+++ b/src/main/java/org/rumbledb/types/MapItemType.java
@@ -74,13 +74,13 @@ public class MapItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        if (((ItemType) other).isMapItemType()) {
-            return this.structurallyEqual((MapItemType) other);
+        if (itemType instanceof MapItemType mapItemType) {
+            return this.structurallyEqual(mapItemType);
         }
-        if (((ItemType) other).isObjectItemType() && other.equals(BuiltinTypesCatalogue.objectItem)) {
+        if (itemType.isObjectItemType() && other.equals(BuiltinTypesCatalogue.objectItem)) {
             // a js:object = map(xs:string, item)
             ItemType objectAsMap = ItemTypeFactory.mapOf(
                 BuiltinTypesCatalogue.stringItem,
@@ -88,7 +88,7 @@ public class MapItemType implements ItemType {
             );
             return this.equals(objectAsMap);
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -124,8 +124,7 @@ public class MapItemType implements ItemType {
             // an object type (js:object) WITHOUT a JSound schema attached is a subtype of a map(*)
             return superType.equals(BuiltinTypesCatalogue.objectItem) && this.isSubtypeOf(objectAsMap);
         }
-        if (superType.isMapItemType()) {
-            MapItemType sup = (MapItemType) superType;
+        if (superType instanceof MapItemType sup) {
             return this.keyType.isSubtypeOf(sup.keyType)
                 && this.valueSequenceType.isSubtypeOf(sup.valueSequenceType);
         }
@@ -183,8 +182,7 @@ public class MapItemType implements ItemType {
             }
             return BuiltinTypesCatalogue.anyFunctionItem;
         }
-        if (other.isMapItemType()) {
-            MapItemType otherMap = (MapItemType) other;
+        if (other instanceof MapItemType otherMap) {
             ItemType keySuperType = this.keyType.findLeastCommonSuperTypeWith(otherMap.keyType);
             SequenceType valueSuperType = this.valueSequenceType.leastCommonSupertypeWith(otherMap.valueSequenceType);
             if (

--- a/src/main/java/org/rumbledb/types/NodeItemType.java
+++ b/src/main/java/org/rumbledb/types/NodeItemType.java
@@ -34,10 +34,10 @@ public class NodeItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -98,5 +98,4 @@ public class NodeItemType implements ItemType {
         return false;
     }
 }
-
 

--- a/src/main/java/org/rumbledb/types/ObjectItemType.java
+++ b/src/main/java/org/rumbledb/types/ObjectItemType.java
@@ -191,14 +191,14 @@ public class ObjectItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        if (((ItemType) other).isMapItemType()) {
+        if (itemType.isMapItemType()) {
             // delegate to the map item type equality check
             return other.equals(this);
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -335,13 +335,12 @@ public class ObjectItemType implements ItemType {
 
     @Override
     public ItemType findLeastCommonSuperTypeLax(ItemType other) {
-        if (!(other instanceof ObjectItemType)) {
+        if (!(other instanceof ObjectItemType otherObject)) {
             if (other.isObjectItemType()) {
                 return other.findLeastCommonSuperTypeLax(this);
             }
             return this.findLeastCommonSuperTypeWith(other);
         }
-        ObjectItemType otherObject = (ObjectItemType) other;
         if (!this.isResolved() || !otherObject.isResolved()) {
             return this.findLeastCommonSuperTypeWith(other);
         }

--- a/src/main/java/org/rumbledb/types/PINodeItemType.java
+++ b/src/main/java/org/rumbledb/types/PINodeItemType.java
@@ -55,10 +55,10 @@ public class PINodeItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType) || !((ItemType) other).isNodeItemType()) {
+        if (!(other instanceof ItemType itemType) || !itemType.isNodeItemType()) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -68,10 +68,9 @@ public class PINodeItemType implements ItemType {
 
     @Override
     public boolean isEqualTo(ItemType otherType) {
-        if (!(otherType instanceof PINodeItemType)) {
+        if (!(otherType instanceof PINodeItemType other)) {
             return false;
         }
-        PINodeItemType other = (PINodeItemType) otherType;
         return Objects.equals(this.catalogueName, other.catalogueName)
             && Objects.equals(this.normalizedTarget, other.normalizedTarget);
     }
@@ -110,10 +109,9 @@ public class PINodeItemType implements ItemType {
         ) {
             return true;
         }
-        if (!(superType instanceof PINodeItemType)) {
+        if (!(superType instanceof PINodeItemType other)) {
             return false;
         }
-        PINodeItemType other = (PINodeItemType) superType;
         if (other.isWildcardPI()) {
             return true;
         }

--- a/src/main/java/org/rumbledb/types/SequenceType.java
+++ b/src/main/java/org/rumbledb/types/SequenceType.java
@@ -240,10 +240,9 @@ public class SequenceType implements Serializable {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof SequenceType)) {
+        if (!(other instanceof SequenceType sequenceType)) {
             return false;
         }
-        SequenceType sequenceType = (SequenceType) other;
         if (isEmptySequence()) {
             return sequenceType.isEmptySequence();
         }

--- a/src/main/java/org/rumbledb/types/TypeMappings.java
+++ b/src/main/java/org/rumbledb/types/TypeMappings.java
@@ -167,7 +167,7 @@ public class TypeMappings {
         if (DataTypes.FloatType.equals(dataType)) {
             return BuiltinTypesCatalogue.floatItem;
         }
-        if (dataType instanceof DecimalType && ((DecimalType) dataType).scale() == 0) {
+        if (dataType instanceof DecimalType decimalType && decimalType.scale() == 0) {
             return BuiltinTypesCatalogue.integerItem;
         }
         if (dataType instanceof DecimalType) {

--- a/src/main/java/org/rumbledb/types/UnionItemType.java
+++ b/src/main/java/org/rumbledb/types/UnionItemType.java
@@ -71,10 +71,10 @@ public class UnionItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/types/XQueryArrayItemType.java
+++ b/src/main/java/org/rumbledb/types/XQueryArrayItemType.java
@@ -72,21 +72,21 @@ public class XQueryArrayItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        if (((ItemType) other).isXQueryArrayItemType()) {
+        if (itemType instanceof XQueryArrayItemType arrayItemType) {
             // structural equality check
-            return this.structurallyEqual((XQueryArrayItemType) other);
+            return this.structurallyEqual(arrayItemType);
         }
-        if (((ItemType) other).isArrayItemType() && other.equals(BuiltinTypesCatalogue.arrayItem)) {
+        if (itemType.isArrayItemType() && other.equals(BuiltinTypesCatalogue.arrayItem)) {
             // js:array() = array(item)
             ItemType arrayItemType = ItemTypeFactory.xqueryArrayOf(
                 SequenceType.createSequenceType("item")
             );
             return this.equals(arrayItemType);
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -348,4 +348,3 @@ public class XQueryArrayItemType implements ItemType {
         throw new UnsupportedOperationException("array item type is not mapped to Spark SQL");
     }
 }
-

--- a/src/main/java/org/rumbledb/types/XmlNodeItemType.java
+++ b/src/main/java/org/rumbledb/types/XmlNodeItemType.java
@@ -33,10 +33,10 @@ public class XmlNodeItemType implements ItemType {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof ItemType)) {
+        if (!(other instanceof ItemType itemType)) {
             return false;
         }
-        return isEqualTo((ItemType) other);
+        return isEqualTo(itemType);
     }
 
     @Override
@@ -84,5 +84,4 @@ public class XmlNodeItemType implements ItemType {
         return false;
     }
 }
-
 

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
@@ -61,8 +61,8 @@ public class FlworKey implements KryoSerializable {
 
     @Override
     public boolean equals(Object otherKey) {
-        if (otherKey instanceof FlworKey) {
-            return this.equalFlworKey((FlworKey) otherKey);
+        if (otherKey instanceof FlworKey flworKey) {
+            return this.equalFlworKey(flworKey);
         } else {
             return false;
         }


### PR DESCRIPTION
In the codebase we have many usage of `instanceof` followed by a manual casting. Java 14 introduced pattern matching for instanceof that simplified this (https://www.baeldung.com/java-pattern-matching-instanceof)

For example:

```java
if (node instanceof InlineFunctionExpression) {
      ((InlineFunctionExpression) node).setExpressionClassification(expressionClassification);
      return expressionClassification;
}
```

Becomes:

```java
if (node instanceof InlineFunctionExpression inlineFunctionExpression) {
    inlineFunctionExpression.setExpressionClassification(expressionClassification);
    return expressionClassification;
}
```