### PR TITLE
Replace triple slash `///` comments with double slash `//`

### DIFF
--- a/src/main/java/org/rumbledb/compiler/BuiltinPartialApplicationRewriteVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/BuiltinPartialApplicationRewriteVisitor.java
@@ -42,7 +42,7 @@ public class BuiltinPartialApplicationRewriteVisitor extends CloneVisitor {
         for (int i = 0; i < arguments.size(); i++) {
             Expression currentArgument = arguments.get(i);
             if (currentArgument != null) {
-                /// It was not a ?
+                // It was not a ?
                 fullArguments.add(currentArgument);
                 continue;
             }

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -3400,20 +3400,20 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     private CatchPattern parseWildcardPattern(JsoniqParser.WildcardContext wildcardContext) {
         if (wildcardContext instanceof JsoniqParser.AllNamesContext) {
-            /// Only * is provided
+            // Only * is provided
             return CatchPattern.catchAll();
         }
         if (wildcardContext instanceof JsoniqParser.AllWithLocalContext) {
-            /// Namespace is the wildcard
+            // Namespace is the wildcard
             String wildcardText = wildcardContext.getText();
-            /// First two characters *: are stripped to keep only the local name
+            // First two characters *: are stripped to keep only the local name
             return CatchPattern.namespaceWildcard(wildcardText.substring(2), wildcardText);
         }
         if (wildcardContext instanceof JsoniqParser.AllWithNSContext) {
-            /// Local name is the wildcard
+            // Local name is the wildcard
             String wildcardText = wildcardContext.getText();
 
-            /// Strip the last two characters :*
+            // Strip the last two characters :*
             String prefix = wildcardText.substring(0, wildcardText.length() - 2);
             String namespace = resolvePrefixForDirConstructor(prefix);
             if (namespace == null) {

--- a/src/main/java/org/rumbledb/runtime/update/PendingUpdateList.java
+++ b/src/main/java/org/rumbledb/runtime/update/PendingUpdateList.java
@@ -164,7 +164,7 @@ public class PendingUpdateList {
         Map<Item, List<Item>> tempSelSrcListMap;
         Item tempSrc;
 
-        ////// OBJECTS
+        // OBJECTS
 
         // DELETES & REPLACES
         for (Item target : this.delReplaceObjMap.keySet()) {
@@ -200,7 +200,7 @@ public class PendingUpdateList {
             }
         }
 
-        ////// ARRAYS
+        // ARRAYS
 
         // DELETES & REPLACES
 
@@ -242,13 +242,13 @@ public class PendingUpdateList {
             targetArrayPULs.put(target, tempSelPULsMap);
         }
 
-        ////// APPLY OBJECTS
+        // APPLY OBJECTS
 
         for (UpdatePrimitive updatePrimitive : objectPUL) {
             updatePrimitive.apply();
         }
 
-        ////// APPLY ARRAYS
+        // APPLY ARRAYS
         for (Item target : targetArrayPULs.keySet()) {
             tempSelPULsMap = targetArrayPULs.get(target);
             for (Item selector : tempSelPULsMap.keySet()) {
@@ -259,26 +259,26 @@ public class PendingUpdateList {
             }
         }
 
-        ////// APPLY INSERT TUPLE
+        // APPLY INSERT TUPLE
         this.insertBeforeList.forEach(UpdatePrimitive::apply);
         this.insertAfterList.forEach(UpdatePrimitive::apply);
         this.insertFirstList.forEach(UpdatePrimitive::apply);
         this.insertLastList.forEach(UpdatePrimitive::apply);
 
-        ////// APPLY EDIT TUPLE
+        // APPLY EDIT TUPLE
         for (Map<Double, UpdatePrimitive> tables : this.editTupleMap.values()) {
             tables.values().forEach(UpdatePrimitive::apply);
         }
 
-        ////// APPLY DELETE TUPLE
+        // APPLY DELETE TUPLE
         for (Map<Double, UpdatePrimitive> tables : this.deleteTupleMap.values()) {
             tables.values().forEach(UpdatePrimitive::apply);
         }
 
-        ////// APPLY CREATE COLLECTION
+        // APPLY CREATE COLLECTION
         this.createCollectionMap.values().forEach(UpdatePrimitive::apply);
 
-        ////// APPLY TRUNCATE COLLECTION
+        // APPLY TRUNCATE COLLECTION
         this.truncateCollectionMap.values().forEach(UpdatePrimitive::apply);
 
     }
@@ -292,7 +292,7 @@ public class PendingUpdateList {
         Item tempSrcRes;
         List<Item> tempSrcList;
 
-        ////// OBJECTS
+        // OBJECTS
 
         // DELETES & REPLACES
         for (Item target : otherPul.delReplaceObjMap.keySet()) {
@@ -354,7 +354,7 @@ public class PendingUpdateList {
             this.renameObjMap.put(target, tempSelSrcResMap);
         }
 
-        ////// ARRAYS
+        // ARRAYS
 
         // DELETES & REPLACES
         for (Item target : otherPul.delReplaceArrayMap.keySet()) {

--- a/src/test/java/iq/UpdatesForRumbleBenchmark.java
+++ b/src/test/java/iq/UpdatesForRumbleBenchmark.java
@@ -87,7 +87,7 @@ public class UpdatesForRumbleBenchmark {
         powersOf2.add(64);
         powersOf2.add(128);
 
-        ////// GH_Q1
+        // GH_Q1
         // RUMBLE
         // for (Integer power : powersOf2) {
         // benchmarkFiles.add(new FileTuple(
@@ -121,7 +121,7 @@ public class UpdatesForRumbleBenchmark {
         // ));
         // }
 
-        ////// GH_Q2
+        // GH_Q2
         // RUMBLE
         // for (Integer power : powersOf2) {
         // benchmarkFiles.add(new FileTuple(
@@ -157,7 +157,7 @@ public class UpdatesForRumbleBenchmark {
         // ));
         // }
 
-        ////// GH_Q3
+        // GH_Q3
         // RUMBLE
         // for (Integer power : powersOf2) {
         // benchmarkFiles.add(new FileTuple(
@@ -193,7 +193,7 @@ public class UpdatesForRumbleBenchmark {
         // ));
         // }
 
-        ////// NEW ORDER TRANSACTION
+        // NEW ORDER TRANSACTION
         // RUMBLE
         for (Integer power : powersOf2) {
             this.benchmarkFiles.add(
@@ -264,7 +264,7 @@ public class UpdatesForRumbleBenchmark {
         // true
         // ));
 
-        ////// PAYMENT TRANSACTION
+        // PAYMENT TRANSACTION
         // RUMBLE
         // for (Integer power : powersOf2) {
         // benchmarkFiles.add(new FileTuple(
@@ -299,7 +299,7 @@ public class UpdatesForRumbleBenchmark {
         // ));
         // }
 
-        ////// DELIVERY TRANSACTION
+        // DELIVERY TRANSACTION
         // RUMBLE
         // for (Integer power : powersOf2) {
         // benchmarkFiles.add(new FileTuple(


### PR DESCRIPTION
In Java 23, `///` triple slash comments are rendered as Markdown: https://docs.oracle.com/en/java/javase/25/javadoc/using-markdown-documentation-comments.html

As we are currently using Java versions 17–21, this pull request removes the triple slash to prevent any potential confusion in the future.