### PR TITLE
New CLI parser powered by PicoCLI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,11 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.7.7</version>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/org/rumbledb/cli/CLIArgumentParser.java
+++ b/src/main/java/org/rumbledb/cli/CLIArgumentParser.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.rumbledb.cli;
+
+import org.rumbledb.cli.commands.Repl;
+import org.rumbledb.cli.commands.Run;
+import org.rumbledb.cli.commands.Serve;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParseResult;
+
+@Command(
+    name = "rumbledb",
+    description = "RumbleDB command line interface.",
+    subcommands = {
+        Run.class,
+        Serve.class,
+        Repl.class
+    }
+)
+public final class CLIArgumentParser {
+    public static ParseResult parse(String... args) {
+        CommandLine commandLine = new CommandLine(new CLIArgumentParser());
+        return commandLine.parseArgs(args);
+    }
+}

--- a/src/main/java/org/rumbledb/cli/arguments/AccessArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/AccessArguments.java
@@ -1,0 +1,14 @@
+package org.rumbledb.cli.arguments;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import picocli.CommandLine.Option;
+
+public final class AccessArguments {
+    @Option(
+        names = { "--allowed-uri-prefixes" },
+        description = "Allowed URI prefixes for read/write (with I/O functions to read data)"
+    )
+    private List<String> allowedPrefixes = new ArrayList<>();
+}

--- a/src/main/java/org/rumbledb/cli/arguments/AccessArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/AccessArguments.java
@@ -8,6 +8,7 @@ import picocli.CommandLine.Option;
 public final class AccessArguments {
     @Option(
         names = { "--allowed-uri-prefixes" },
+        split = ";",
         description = "Allowed URI prefixes for read/write (with I/O functions to read data)"
     )
     private List<String> allowedPrefixes = new ArrayList<>();

--- a/src/main/java/org/rumbledb/cli/arguments/AnalysisArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/AnalysisArguments.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.rumbledb.cli.arguments;
+
+import picocli.CommandLine.Option;
+
+public final class AnalysisArguments {
+    @Option(
+        names = { "-t", "--static-typing" },
+        negatable = true,
+        description = {
+            "Activates static type analysis, which annotates the expression tree with inferred types at compile time.",
+            "Enables more optimizations (experimental). Deactivated by default."
+        }
+    )
+    private Boolean enableStaticTyping;
+
+    @Option(
+        names = "--print-inferred-types",
+        negatable = true,
+        description = "Prints inferred types."
+    )
+    private Boolean printInferredTypes;
+
+    @Option(
+        names = "--check-return-types-of-builtin-functions",
+        negatable = true,
+        description = "Checks return types of built-in functions."
+    )
+    private Boolean checkReturnTypesOfBuiltinFunctions;
+}

--- a/src/main/java/org/rumbledb/cli/arguments/BindingsArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/BindingsArguments.java
@@ -1,0 +1,69 @@
+package org.rumbledb.cli.arguments;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Option;
+
+public final class BindingsArguments {
+    private static final String DEFAULT_CONTEXT_ITEM_INPUT_FORMAT = "json";
+
+    @ArgGroup(exclusive = true, multiplicity = "0..1")
+    private ContextItemSource contextItemSource = new ContextItemSource();
+
+    private static final class ContextItemSource {
+        @ArgGroup(exclusive = true, multiplicity = "1")
+        private ContextItemValue contextItemValue = new ContextItemValue();
+
+        @ArgGroup(exclusive = true, multiplicity = "1")
+        private ContextItemInput contextItemInput = new ContextItemInput();
+    }
+
+    private static final class ContextItemValue {
+        @Option(
+            names = { "-I", "--context-item" },
+            paramLabel = "value",
+            description = {
+                "Initializes the global context item $$ to the supplied value.",
+                "The query must contain the corresponding global variable declaration, e.g. "
+                    + "\"declare context item external;\""
+            }
+        )
+        private String value;
+    }
+
+    private static final class ContextItemInput {
+        @Option(
+            names = { "-i", "--context-item-input" },
+            paramLabel = "path",
+            description = "Reads the context item value from the standard input."
+        )
+        private String value;
+    }
+
+    @Option(
+        names = "--context-item-input-format",
+        paramLabel = "format",
+        description = "Sets the input format to use for parsing the standard input (as text or as a serialized json value)."
+    )
+    private String contextItemInputFormat;
+
+    @Option(
+        names = "--variable",
+        paramLabel = "name=value",
+        description = {
+            "Initializes a global variable to the supplied value.",
+            "The query must contain the corresponding global variable declaration, e.g. "
+                + "\"declare variable $foo external;\""
+        }
+    )
+    private Map<String, String> variables = new HashMap<>();
+
+    @Option(
+        names = "--variable-from-file",
+        paramLabel = "name=path",
+        description = "Initializes a global variable with a value read from the supplied file."
+    )
+    private Map<String, String> variablesFromFiles = new HashMap<>();
+}

--- a/src/main/java/org/rumbledb/cli/arguments/DebugArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/DebugArguments.java
@@ -1,0 +1,29 @@
+package org.rumbledb.cli.arguments;
+
+import picocli.CommandLine.Option;
+
+public final class DebugArguments {
+    @Option(
+        names = "--print-iterator-tree",
+        negatable = true,
+        description = "For debugging purposes, prints out the expression tree and runtime interator tree."
+    )
+    private Boolean printIteratorTree;
+
+    @Option(
+        names = { "-v", "--show-error-info" },
+        negatable = true,
+        description = {
+            "For debugging purposes.",
+            "If you want to report a bug, you can use this to get the full exception stack."
+        }
+    )
+    private Boolean showErrorInfo;
+
+    @Option(
+        names = "--debug",
+        negatable = true,
+        description = "Enables debug output."
+    )
+    private Boolean logging;
+}

--- a/src/main/java/org/rumbledb/cli/arguments/FormattingArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/FormattingArguments.java
@@ -1,0 +1,28 @@
+package org.rumbledb.cli.arguments;
+
+import java.time.ZoneId;
+
+import picocli.CommandLine.Option;
+
+public final class FormattingArguments {
+    @Option(
+        names = "--default-formatting-place",
+        paramLabel = "timezone",
+        description = "Sets the default place used for formatting date and time values."
+    )
+    private ZoneId defaultFormattingPlace;
+
+    @Option(
+        names = "--default-formatting-calendar",
+        paramLabel = "calendar",
+        description = "Sets the default calendar used for formatting date and time values."
+    )
+    private String defaultFormattingCalendar;
+
+    @Option(
+        names = "--default-formatting-language",
+        paramLabel = "language",
+        description = "Sets the default language used for formatting date and time values."
+    )
+    private String defaultFormattingLanguage;
+}

--- a/src/main/java/org/rumbledb/cli/arguments/InputArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/InputArguments.java
@@ -1,0 +1,19 @@
+package org.rumbledb.cli.arguments;
+
+import picocli.CommandLine.Option;
+
+public final class InputArguments {
+    @Option(
+        names = { "-q", "--query" },
+        paramLabel = "query",
+        description = "A JSONiq query directly provided as a string."
+    )
+    private String query;
+
+    @Option(
+        names = "--query-path",
+        paramLabel = "path",
+        description = "A JSONiq query file to read from (from any file system, even the Web!)."
+    )
+    private String queryPath;
+}

--- a/src/main/java/org/rumbledb/cli/arguments/OptimizationArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/OptimizationArguments.java
@@ -1,0 +1,47 @@
+package org.rumbledb.cli.arguments;
+
+import picocli.CommandLine.Option;
+
+public final class OptimizationArguments {
+    @Option(
+        names = "--function-inlining",
+        negatable = true,
+        description = "Activates function inlining for non-recursive functions (activated by default)."
+    )
+    private Boolean functionInlining;
+
+    @Option(
+        names = "--tail-call-optimization",
+        negatable = true,
+        description = "Activates tail call optimization."
+    )
+    private Boolean tailCallOptimization;
+
+    @Option(
+        names = "--optimize-general-comparison-to-value-comparison",
+        negatable = true,
+        description = "Activates automatic conversion of general comparisons to value comparisons when applicable (activated by default)."
+    )
+    private Boolean optimizeGeneralComparisonToValueComparison;
+
+    @Option(
+        names = "--optimize-steps",
+        negatable = true,
+        description = "Allows RumbleDB to optimize steps, might violate stability of document order (activated by default)."
+    )
+    private Boolean optimizeSteps;
+
+    @Option(
+        names = "--optimize-steps-experimental",
+        negatable = true,
+        description = "Experimentally optimizes steps more by skipping uniqueness and sorting in some cases. Correctness is not yet verified (disabled by default)."
+    )
+    private Boolean optimizeStepsExperimental;
+
+    @Option(
+        names = "--optimize-parent-pointers",
+        negatable = true,
+        description = "Allows RumbleDB to remove parent pointers from items if no steps requiring parent pointers are detected statically (activated by default)."
+    )
+    private Boolean optimizeParentPointers;
+}

--- a/src/main/java/org/rumbledb/cli/arguments/OptionConversion.java
+++ b/src/main/java/org/rumbledb/cli/arguments/OptionConversion.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.rumbledb.cli.arguments;
+
+import java.util.function.IntConsumer;
+import java.util.function.Consumer;
+
+final class OptionConversion {
+    @FunctionalInterface
+    interface BooleanConsumer {
+        void accept(boolean value);
+    }
+
+    static void applyBooleanIfPresent(Boolean value, BooleanConsumer setter) {
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+
+    static void applyIntIfPresent(Integer value, IntConsumer setter) {
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+
+    static <T> void applyIfPresent(T value, Consumer<? super T> setter) {
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+}

--- a/src/main/java/org/rumbledb/cli/arguments/OutputArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/OutputArguments.java
@@ -1,0 +1,59 @@
+package org.rumbledb.cli.arguments;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import picocli.CommandLine.Option;
+
+public final class OutputArguments {
+    @Option(
+        names = { "-o", "--output-path" },
+        paramLabel = "path",
+        description = {
+            "Where to output to.",
+            "If the output is large, it will create a sharded directory, otherwise it will create a file."
+        }
+    )
+    private String outputPath;
+
+    @Option(
+        names = { "-f", "--output-format" },
+        paramLabel = "format",
+        description = {
+            "An output format to use for the output.",
+            "Formats other than json can only be output if the query outputs a highly structured sequence of objects."
+        }
+    )
+    private String outputFormat;
+
+    @Option(names = "--log-path", paramLabel = "path", description = "Where to output log information.")
+    private String logPath;
+
+    @Option(
+        names = { "-O", "--overwrite" },
+        negatable = true,
+        description = "Whether to overwrite to --output-path. No throws an error if the output file/folder exists."
+    )
+    private Boolean overwrite;
+
+    @Option(
+        names = { "-P", "--number-of-output-partitions" },
+        paramLabel = "count",
+        description = "How many partitions to create in the output, i.e., the number of files that will be created in the output path directory."
+    )
+    private Integer numberOfOutputPartitions;
+
+    @Option(
+        names = "--shell-filter",
+        paramLabel = "command",
+        description = "Post-processes the output of JSONiq queries on the shell with the specified command."
+    )
+    private String shellFilter;
+
+    @Option(
+        names = "--output-format-option",
+        paramLabel = "name=value",
+        description = "Options to further specify the output format, for example a separator character for CSV or a compression format."
+    )
+    private Map<String, String> outputFormatOptions = new HashMap<>();
+}

--- a/src/main/java/org/rumbledb/cli/arguments/RuntimeArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/RuntimeArguments.java
@@ -1,0 +1,61 @@
+package org.rumbledb.cli.arguments;
+
+import picocli.CommandLine.Option;
+
+public final class RuntimeArguments {
+    @Option(
+        names = "--result-size",
+        paramLabel = "count",
+        description = "A cap on the maximum number of items to output on the screen or to a local list."
+    )
+    private Integer resultSize;
+
+    @Option(
+        names = { "-c", "--materialization-cap" },
+        paramLabel = "count",
+        description = "A cap on the maximum number of items to materialize during the query execution for large sequences within a query."
+    )
+    private Integer materializationCap;
+
+    @Option(
+        names = "--native-sql-predicates",
+        negatable = true,
+        description = "Activates native SQL predicates when possible."
+    )
+    private Boolean nativeSQLPredicates;
+
+    @Option(
+        names = "--data-frame-execution-mode-detection",
+        negatable = true,
+        description = "Activates DataFrame execution mode detection for higher-order functions."
+    )
+    private Boolean dataFrameExecutionModeDetection;
+
+    @Option(
+        names = "--parallel-execution",
+        negatable = true,
+        description = "Activates parallel execution when possible (activated by default)."
+    )
+    private Boolean parallelExecution;
+
+    @Option(
+        names = "--data-frame-execution",
+        negatable = true,
+        description = "Activates DataFrame execution when possible."
+    )
+    private Boolean dataFrameExecution;
+
+    @Option(
+        names = "--native-execution",
+        negatable = true,
+        description = "Activates native (Spark SQL) execution when possible (activated by default)."
+    )
+    private Boolean nativeExecution;
+
+    @Option(
+        names = "--apply-updates",
+        negatable = true,
+        description = "Applies the pending update list returned by the query."
+    )
+    private Boolean applyUpdates;
+}

--- a/src/main/java/org/rumbledb/cli/arguments/SemanticsArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/SemanticsArguments.java
@@ -1,0 +1,40 @@
+package org.rumbledb.cli.arguments;
+
+import picocli.CommandLine.Option;
+
+public final class SemanticsArguments {
+    @Option(
+        names = "--default-language",
+        paramLabel = "language",
+        description = "Specifies the query language to be used."
+    )
+    private String defaultLanguage;
+
+    @Option(
+        names = "--xml-version",
+        paramLabel = "version",
+        description = "Sets the XML version to use."
+    )
+    private String xmlVersion;
+
+    @Option(
+        names = "--dates-with-timezone",
+        negatable = true,
+        description = "Activates timezone support for the type xs:date (deactivated by default)."
+    )
+    private Boolean datesWithTimezone;
+
+    @Option(
+        names = { "--lax-json-null-validation", "--lax-json-null-valication" },
+        negatable = true,
+        description = "Allows conflating JSON nulls with absent values when validating nillable object fields for more flexibility (activated by default)."
+    )
+    private Boolean laxJSONNullValidation;
+
+    @Option(
+        names = "--static-base-uri",
+        paramLabel = "uri",
+        description = "Sets the static base uri for the execution. This option overwrites module location but is overwritten by declaration inside query."
+    )
+    private String staticBaseUri;
+}

--- a/src/main/java/org/rumbledb/cli/arguments/ServerArguments.java
+++ b/src/main/java/org/rumbledb/cli/arguments/ServerArguments.java
@@ -1,0 +1,19 @@
+package org.rumbledb.cli.arguments;
+
+import picocli.CommandLine.Option;
+
+public final class ServerArguments {
+    @Option(
+        names = { "-h", "--host" },
+        paramLabel = "host",
+        description = "Changes the host of the RumbleDB HTTP server to any of your liking."
+    )
+    private String host;
+
+    @Option(
+        names = { "-p", "--port" },
+        paramLabel = "port",
+        description = "Changes the port of the RumbleDB HTTP server to any of your liking."
+    )
+    private Integer port;
+}

--- a/src/main/java/org/rumbledb/cli/commands/BaseCommand.java
+++ b/src/main/java/org/rumbledb/cli/commands/BaseCommand.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.rumbledb.cli.commands;
+
+import org.rumbledb.cli.arguments.AccessArguments;
+import org.rumbledb.cli.arguments.AnalysisArguments;
+import org.rumbledb.cli.arguments.BindingsArguments;
+import org.rumbledb.cli.arguments.DebugArguments;
+import org.rumbledb.cli.arguments.FormattingArguments;
+import org.rumbledb.cli.arguments.OptimizationArguments;
+import org.rumbledb.cli.arguments.RuntimeArguments;
+import org.rumbledb.cli.arguments.SemanticsArguments;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+
+@Command
+public abstract class BaseCommand {
+    @Mixin
+    AccessArguments access;
+
+    @Mixin
+    RuntimeArguments runtime;
+
+    @Mixin
+    DebugArguments debug;
+
+    @Mixin
+    AnalysisArguments analysis;
+
+    @Mixin
+    OptimizationArguments optimization;
+
+    @Mixin
+    SemanticsArguments semantics;
+
+    @Mixin
+    FormattingArguments formatting;
+
+    @Mixin
+    BindingsArguments bindings;
+}

--- a/src/main/java/org/rumbledb/cli/commands/Repl.java
+++ b/src/main/java/org/rumbledb/cli/commands/Repl.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.rumbledb.cli.commands;
+
+import org.rumbledb.cli.arguments.OutputArguments;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+@Command(name = "repl", description = "Runs the interactive shell.", mixinStandardHelpOptions = false)
+public final class Repl extends BaseCommand {
+    @Mixin
+    OutputArguments output;
+}

--- a/src/main/java/org/rumbledb/cli/commands/Run.java
+++ b/src/main/java/org/rumbledb/cli/commands/Run.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.rumbledb.cli.commands;
+
+import org.rumbledb.cli.arguments.InputArguments;
+import org.rumbledb.cli.arguments.OutputArguments;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "run", description = "Executes a query.", mixinStandardHelpOptions = false)
+public final class Run extends BaseCommand {
+    @Mixin
+    InputArguments input;
+
+    @Mixin
+    OutputArguments output;
+
+    @Parameters(
+        index = "0",
+        arity = "0..1",
+        paramLabel = "query-file",
+        description = "A JSONiq query file to read from (from any file system, even the Web!)."
+    )
+    String queryPath;
+}

--- a/src/main/java/org/rumbledb/cli/commands/Serve.java
+++ b/src/main/java/org/rumbledb/cli/commands/Serve.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.rumbledb.cli.commands;
+
+import org.rumbledb.cli.arguments.ServerArguments;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+@Command(name = "serve", description = "Runs RumbleDB as a server on port 8001.", mixinStandardHelpOptions = false)
+public final class Serve extends BaseCommand {
+    @Mixin
+    ServerArguments server;
+}


### PR DESCRIPTION
## Summary

This pull request only **adds** code for new CLI argument parser based on PicoCLI, it does not replace the old one in  `RumbleRuntimeConfiguration`. The migration will happen in future pull requests along with the Configuration class refactor.

The new parser introduces explicit `run`, `repl`, and `serve` **subcommands**, organizes options into shared mixins, and makes argument validation stricter and more predictable. It also replaces several legacy parsing conventions that were previously handled manually, including mode inference, `yes`/`no` boolean parsing, and dynamic option-name prefixes.

## What Changed

The new CLI is now structured around explicit subcommands:

```bash
spark-submit rumbledb.jar run ...
spark-submit rumbledb.jar repl ...
spark-submit rumbledb.jar serve ...
```

Compared to the legacy parser, this changes the CLI in a few important ways:

- The parser is no longer a permissive flat `String[] args` scan.
- Command-specific options are now **scoped** to the relevant subcommand (for example, `--port` is no longer accepted in `repl` mode)
- Unknown or unsupported options are rejected instead of being silently accepted.
- Dynamic options such as variable bindings and output-format options now use structured Picocli map syntax.
- Boolean flags now follow Picocli conventions instead of requiring `yes` or `no` values.

## User-Visible Behavior Changes

### Explicit subcommands

The old parser accepted several legacy mode-selection patterns, including:
- `serve`
- `repl`
- `run`
- deprecated long flags such as `--serve`, `--repl`, and `--run`
- verb-less execution where the first positional argument was treated as `query-path`

The new parser standardizes on **explicit subcommands only**.

### Boolean flags now use Picocli style

Boolean options now follow Picocli conventions:

- `--flag` enables the option
- `--no-flag` disables the option

Examples:

```bash
# old style
rumbledb run --overwrite yes
rumbledb run --show-error-info no
rumbledb run --static-typing yes

# new style
rumbledb run --overwrite
rumbledb run --no-show-error-info
rumbledb run --static-typing
```

### Dynamic option syntax has changed

Legacy dynamic option-name forms such as these:

```bash
--variable:foo bar
--variable-from-file:foo /tmp/foo.json
-o:separator ,
```

are replaced with Picocli-style key/value forms:

```bash
--variable foo=bar
--variable-from-file foo=/tmp/foo.json
--output-format-option separator=,
```

### Stricter validation

The legacy parser stored arbitrary `--name value` pairs and ignored any entries it did not later consume. The Picocli parser exposes a closed set of supported options, so unsupported or misspelled options now fail fast.

## Breaking Changes

- Explicit subcommands are now required: `run`, `repl`, or `serve`.
- Legacy mode flags such as `--shell yes` and `--server yes` are no longer supported.
- Verb-less invocation that relied on the first positional argument being treated as `query-path` is no longer supported.
- Long boolean options no longer accept `yes` / `no` as separate values.
- Variable binding syntax changes from `--variable:name value` to `--variable name=value`.
- File-based variable binding syntax changes from `--variable-from-file:name path` to `--variable-from-file name=path`.
- Output serialization overrides change from `-o:<name> <value>` to `--output-format-option name=value`.
- Unknown options are now rejected instead of being silently accepted.
- Options are now subcommand-scoped, so flags such as `--host` and `--port` only apply to `serve`.
- `--input-format` flag is removed because it was read in the code but not used anywhere

## Classification of arguments (will be used also for configuration refactor)

Category | Flags
-- | --
Input | --query, --query-path, positional query-file on run
Bindings | --context-item, --context-item-input, --context-item-input-format, --variable, --variable-from-file
Output | --output-path, --output-format, --log-path, --overwrite, --number-of-output-partitions, --shell-filter, --output-format-option
Runtime | --result-size, --materialization-cap, --native-sql-predicates, --data-frame-execution-mode-detection, --parallel-execution, --data-frame-execution, --native-execution, --apply-updates
Optimization | --function-inlining, --tail-call-optimization, --optimize-general-comparison-to-value-comparison, --optimize-steps, --optimize-steps-experimental, --optimize-parent-pointers
Semantics | --default-language, --xml-version, --dates-with-timezone, --lax-json-null-validation, --lax-json-null-valication, --static-base-uri
Analysis | --static-typing, --print-inferred-types, --check-return-types-of-builtin-functions
Formatting | --default-formatting-place, --default-formatting-calendar, --default-formatting-language
Debug | --print-iterator-tree, --show-error-info, --debug
Access | --allowed-uri-prefixes
Server | --host, --port
Subcommands | run, repl, serve