### PR TITLE
Remove `Spark` keyword from the names of `runtime.flwors.clauses` iterators

### DIFF
--- a/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
@@ -165,13 +165,13 @@ import org.rumbledb.runtime.control.SwitchRuntimeIterator;
 import org.rumbledb.runtime.control.TryCatchRuntimeIterator;
 import org.rumbledb.runtime.control.TypeswitchRuntimeIterator;
 import org.rumbledb.runtime.control.TypeswitchRuntimeIteratorCase;
-import org.rumbledb.runtime.flwor.clauses.CountClauseSparkIterator;
-import org.rumbledb.runtime.flwor.clauses.ForClauseSparkIterator;
-import org.rumbledb.runtime.flwor.clauses.GroupByClauseSparkIterator;
-import org.rumbledb.runtime.flwor.clauses.LetClauseSparkIterator;
-import org.rumbledb.runtime.flwor.clauses.OrderByClauseSparkIterator;
-import org.rumbledb.runtime.flwor.clauses.ReturnClauseSparkIterator;
-import org.rumbledb.runtime.flwor.clauses.WhereClauseSparkIterator;
+import org.rumbledb.runtime.flwor.clauses.CountClauseIterator;
+import org.rumbledb.runtime.flwor.clauses.ForClauseIterator;
+import org.rumbledb.runtime.flwor.clauses.GroupByClauseIterator;
+import org.rumbledb.runtime.flwor.clauses.LetClauseIterator;
+import org.rumbledb.runtime.flwor.clauses.OrderByClauseIterator;
+import org.rumbledb.runtime.flwor.clauses.ReturnClauseIterator;
+import org.rumbledb.runtime.flwor.clauses.WhereClauseIterator;
 import org.rumbledb.runtime.flwor.expression.GroupByClauseSparkIteratorExpression;
 import org.rumbledb.runtime.flwor.expression.OrderByClauseAnnotatedChildIterator;
 import org.rumbledb.runtime.flwor.expression.SimpleMapExpressionIterator;
@@ -323,7 +323,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
             argument
         );
         ReturnClause returnClause = expression.getReturnClause();
-        RuntimeIterator runtimeIterator = new ReturnClauseSparkIterator(
+        RuntimeIterator runtimeIterator = new ReturnClauseIterator(
                 previous,
                 this.visit(
                     returnClause.getReturnExpr(),
@@ -352,7 +352,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
         }
         if (clause instanceof ForClause forClause) {
             RuntimeIterator assignmentIterator = this.visit(forClause.getExpression(), argument);
-            return new ForClauseSparkIterator(
+            return new ForClauseIterator(
                     previousIterator,
                     forClause.getVariableName(),
                     forClause.getPositionalVariableName(),
@@ -362,7 +362,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
             );
         } else if (clause instanceof LetClause letClause) {
             RuntimeIterator assignmentIterator = this.visit(letClause.getExpression(), argument);
-            return new LetClauseSparkIterator(
+            return new LetClauseIterator(
                     previousIterator,
                     letClause.getVariableName(),
                     letClause.getStaticType(),
@@ -388,7 +388,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     )
                 );
             }
-            return new GroupByClauseSparkIterator(
+            return new GroupByClauseIterator(
                     previousIterator,
                     groupingExpressions,
                     clause.getStaticContextForRuntime(this.config, this.visitorConfig)
@@ -413,20 +413,20 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     )
                 );
             }
-            return new OrderByClauseSparkIterator(
+            return new OrderByClauseIterator(
                     previousIterator,
                     expressionsWithIterator,
                     orderByClause.isStable(),
                     clause.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         } else if (clause instanceof WhereClause whereClause) {
-            return new WhereClauseSparkIterator(
+            return new WhereClauseIterator(
                     previousIterator,
                     this.visit(whereClause.getWhereExpression(), argument),
                     clause.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         } else if (clause instanceof CountClause countClause) {
-            return new CountClauseSparkIterator(
+            return new CountClauseIterator(
                     previousIterator,
                     countClause.getCountVariableName(),
                     clause.getStaticContextForRuntime(this.config, this.visitorConfig)

--- a/src/main/java/org/rumbledb/runtime/RuntimeTupleIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeTupleIterator.java
@@ -36,8 +36,8 @@ import org.rumbledb.expressions.ExecutionMode;
 import org.rumbledb.expressions.flowr.FLWOR_CLAUSES;
 import org.rumbledb.runtime.flwor.NativeClauseContext;
 import org.rumbledb.runtime.flwor.FlworDataFrame;
-import org.rumbledb.runtime.flwor.clauses.ForClauseSparkIterator;
-import org.rumbledb.runtime.flwor.clauses.LetClauseSparkIterator;
+import org.rumbledb.runtime.flwor.clauses.ForClauseIterator;
+import org.rumbledb.runtime.flwor.clauses.LetClauseIterator;
 
 import sparksoniq.jsoniq.tuple.FlworTuple;
 
@@ -240,7 +240,7 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
     public void setEvaluationDepthLimit(int limit) {
         this.evaluationDepthLimit = limit;
         if (limit == 0) {
-            if (!(this instanceof ForClauseSparkIterator || this instanceof LetClauseSparkIterator)) {
+            if (!(this instanceof ForClauseIterator || this instanceof LetClauseIterator)) {
                 throw new OurBadException(
                         "We cannot stop the evaluation of FLWOR clauses at any other place than a let or a for clause."
                 );
@@ -273,7 +273,7 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
      */
     public boolean canSetEvaluationDepthLimit(int limit) {
         if (limit == 0) {
-            return this instanceof ForClauseSparkIterator || this instanceof LetClauseSparkIterator;
+            return this instanceof ForClauseIterator || this instanceof LetClauseIterator;
         }
         if (limit == -1) {
             return true;

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/CountClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/CountClauseIterator.java
@@ -50,14 +50,14 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-public class CountClauseSparkIterator extends RuntimeTupleIterator {
+public class CountClauseIterator extends RuntimeTupleIterator {
 
     private static final long serialVersionUID = 1L;
     private Name variableName;
     private FlworTuple nextLocalTupleResult;
     private int currentCountIndex;
 
-    public CountClauseSparkIterator(
+    public CountClauseIterator(
             RuntimeTupleIterator child,
             Name variableName,
             RuntimeStaticContext staticContext

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/ForClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/ForClauseIterator.java
@@ -73,7 +73,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 
-public class ForClauseSparkIterator extends RuntimeTupleIterator {
+public class ForClauseIterator extends RuntimeTupleIterator {
 
 
     private static final long serialVersionUID = 1L;
@@ -92,7 +92,7 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
     private transient FlworTuple inputTuple; // tuple received from child, used for tuple creation
     private transient boolean isFirstItem;
 
-    public ForClauseSparkIterator(
+    public ForClauseIterator(
             RuntimeTupleIterator child,
             Name variableName,
             Name positionalVariableName,
@@ -302,7 +302,7 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
             DynamicContext context
     ) {
         // If the expression depends on this input tuple, we might still recognize an join.
-        if (!LetClauseSparkIterator.isExpressionIndependentFromInputTuple(this.assignmentIterator, this.child)) {
+        if (!LetClauseIterator.isExpressionIndependentFromInputTuple(this.assignmentIterator, this.child)) {
             return getDataFrameFromJoin(context);
         }
 
@@ -403,7 +403,7 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
         RuntimeIterator predicateIterator = predicateAssignmentIterator.predicateIterator();
 
         // If the left hand side depends on the input tuple, we do not how to handle it.
-        if (!LetClauseSparkIterator.isExpressionIndependentFromInputTuple(sequenceIterator, this.child)) {
+        if (!LetClauseIterator.isExpressionIndependentFromInputTuple(sequenceIterator, this.child)) {
             throw new JobWithinAJobException(
                     "A for clause expression cannot produce a big sequence of items for a big number of tuples, as this would lead to a data flow explosion. In our efforts to detect a join, we did recognize a predicate expression in the for clause, but the left-hand-side of the predicate expression depends on the previous variables of this FLWOR expression. You can fix this by making sure it does not.",
                     getMetadata()
@@ -489,7 +489,7 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
             variablesInRightInputTuple.add(Name.CONTEXT_COUNT);
         }
 
-        return JoinClauseSparkIterator.joinInputTupleWithSequenceOnPredicate(
+        return JoinClauseIterator.joinInputTupleWithSequenceOnPredicate(
             context,
             this.child.getDataFrame(context).getDataFrame(),
             expressionDF,
@@ -844,7 +844,7 @@ public class ForClauseSparkIterator extends RuntimeTupleIterator {
             return result;
         }
         // Add column for positional variable, similar to count clause.
-        Dataset<Row> dfWithIndex = CountClauseSparkIterator.addSerializedCountColumn(
+        Dataset<Row> dfWithIndex = CountClauseIterator.addSerializedCountColumn(
             df,
             outputDependencies,
             positionalVariableName

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/GroupByClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/GroupByClauseIterator.java
@@ -68,7 +68,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
+public class GroupByClauseIterator extends RuntimeTupleIterator {
 
     private static final long serialVersionUID = 1L;
     private final List<GroupByClauseSparkIteratorExpression> groupingExpressions;
@@ -76,7 +76,7 @@ public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
     private int resultIndex;
     private Map<Name, DynamicContext.VariableDependency> dependencies;
 
-    public GroupByClauseSparkIterator(
+    public GroupByClauseIterator(
             RuntimeTupleIterator child,
             List<GroupByClauseSparkIteratorExpression> groupingExpressions,
             RuntimeStaticContext staticContext
@@ -347,7 +347,7 @@ public class GroupByClauseSparkIterator extends RuntimeTupleIterator {
             if (expression.getExpression() != null) {
                 // if a variable is defined in-place with groupby, execute a let on the variable
                 variableAccessNames.add(expression.getVariableName());
-                df = LetClauseSparkIterator.bindLetVariableInDataFrame(
+                df = LetClauseIterator.bindLetVariableInDataFrame(
                     df,
                     expression.getVariableName(),
                     null,

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/JoinClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/JoinClauseIterator.java
@@ -58,7 +58,7 @@ import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.spark.SparkSessionManager;
 
 
-public class JoinClauseSparkIterator extends RuntimeTupleIterator {
+public class JoinClauseIterator extends RuntimeTupleIterator {
 
     private static final long serialVersionUID = 1L;
 
@@ -80,7 +80,7 @@ public class JoinClauseSparkIterator extends RuntimeTupleIterator {
     @SuppressWarnings("unused")
     private transient boolean isFirstItem;
 
-    public JoinClauseSparkIterator(
+    public JoinClauseIterator(
             RuntimeTupleIterator leftChild,
             RuntimeTupleIterator rightChild,
             boolean isLeftOuterJoin,
@@ -238,7 +238,7 @@ public class JoinClauseSparkIterator extends RuntimeTupleIterator {
 
         // And we extend the expression and input tuple views with the hashes.
         if (optimizableJoin) {
-            rightInputTuple = LetClauseSparkIterator.bindLetVariableInDataFrame(
+            rightInputTuple = LetClauseIterator.bindLetVariableInDataFrame(
                 rightInputTuple,
                 Name.createVariableInNoNamespace(SparkSessionManager.rightHandSideHashColumnName),
                 null,
@@ -249,7 +249,7 @@ public class JoinClauseSparkIterator extends RuntimeTupleIterator {
                 true,
                 staticContext.getConfiguration()
             );
-            leftInputTuple = LetClauseSparkIterator.bindLetVariableInDataFrame(
+            leftInputTuple = LetClauseIterator.bindLetVariableInDataFrame(
                 leftInputTuple,
                 Name.createVariableInNoNamespace(SparkSessionManager.leftHandSideHashColumnName),
                 null,

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/LetClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/LetClauseIterator.java
@@ -69,7 +69,7 @@ import sparksoniq.spark.SparkSessionManager;
 import java.math.BigDecimal;
 import java.util.*;
 
-public class LetClauseSparkIterator extends RuntimeTupleIterator {
+public class LetClauseIterator extends RuntimeTupleIterator {
 
 
     private static final long serialVersionUID = 1L;
@@ -79,7 +79,7 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
     private DynamicContext tupleContext; // re-use same DynamicContext object for efficiency
     private FlworTuple nextLocalTupleResult;
 
-    public LetClauseSparkIterator(
+    public LetClauseIterator(
             RuntimeTupleIterator child,
             Name variableName,
             SequenceType sequenceType,
@@ -286,7 +286,7 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
         // We need to manually adjust the context item with the dependency mode the parent projection.
         Map<Name, VariableDependency> sequenceDependencies = new HashMap<>();
         sequenceDependencies.put(Name.CONTEXT_ITEM, DynamicContext.VariableDependency.FULL);
-        Dataset<Row> expressionDF = ForClauseSparkIterator.getDataFrameStartingClause(
+        Dataset<Row> expressionDF = ForClauseIterator.getDataFrameStartingClause(
             sequenceIterator,
             Name.CONTEXT_ITEM,
             null,
@@ -300,7 +300,7 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
             contextItemEqualityCriteria,
             getMetadata()
         );
-        expressionDF = LetClauseSparkIterator.bindLetVariableInDataFrame(
+        expressionDF = LetClauseIterator.bindLetVariableInDataFrame(
             expressionDF,
             Name.createVariableInNoNamespace(SparkSessionManager.rightHandSideHashColumnName),
             this.sequenceType,
@@ -316,7 +316,7 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
             inputTupleEqualityCriteria,
             getMetadata()
         );
-        inputDF = LetClauseSparkIterator.bindLetVariableInDataFrame(
+        inputDF = LetClauseIterator.bindLetVariableInDataFrame(
             inputDF,
             Name.createVariableInNoNamespace(SparkSessionManager.leftHandSideHashColumnName),
             this.sequenceType,
@@ -429,7 +429,7 @@ public class LetClauseSparkIterator extends RuntimeTupleIterator {
                     .withExecutionMode(ExecutionMode.LOCAL)
                     .withMetadata(getMetadata())
         );
-        inputDF = LetClauseSparkIterator.bindLetVariableInDataFrame(
+        inputDF = LetClauseIterator.bindLetVariableInDataFrame(
             inputDF,
             this.variableName,
             this.sequenceType,

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/OrderByClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/OrderByClauseIterator.java
@@ -58,7 +58,7 @@ import sparksoniq.jsoniq.tuple.FlworTuple;
 
 import java.util.*;
 
-public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
+public class OrderByClauseIterator extends RuntimeTupleIterator {
 
     public static final String StringFlagForEmptySequence = "empty-sequence";
     private static final long serialVersionUID = 1L;
@@ -68,7 +68,7 @@ public class OrderByClauseSparkIterator extends RuntimeTupleIterator {
     private List<FlworTuple> localTupleResults;
     private int resultIndex;
 
-    public OrderByClauseSparkIterator(
+    public OrderByClauseIterator(
             RuntimeTupleIterator child,
             List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator,
             boolean stable,

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/ReturnClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/ReturnClauseIterator.java
@@ -64,7 +64,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
+public class ReturnClauseIterator extends HybridRuntimeIterator {
 
     private static final long serialVersionUID = 1L;
     private RuntimeTupleIterator child;
@@ -72,7 +72,7 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
     private RuntimeIterator expression;
     private Item nextResult;
 
-    public ReturnClauseSparkIterator(
+    public ReturnClauseIterator(
             RuntimeTupleIterator child,
             RuntimeIterator expression,
             boolean isUpdating,
@@ -85,7 +85,7 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
         setInputAndOutputTupleVariableDependencies();
     }
 
-    public ReturnClauseSparkIterator(
+    public ReturnClauseIterator(
             RuntimeTupleIterator child,
             RuntimeIterator expression,
             RuntimeStaticContext staticContext

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/WhereClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/WhereClauseIterator.java
@@ -50,7 +50,7 @@ import sparksoniq.jsoniq.tuple.FlworTuple;
 
 import java.util.*;
 
-public class WhereClauseSparkIterator extends RuntimeTupleIterator {
+public class WhereClauseIterator extends RuntimeTupleIterator {
 
 
     private static final long serialVersionUID = 1L;
@@ -58,7 +58,7 @@ public class WhereClauseSparkIterator extends RuntimeTupleIterator {
     private DynamicContext tupleContext; // re-use same DynamicContext object for efficiency
     private FlworTuple nextLocalTupleResult;
 
-    public WhereClauseSparkIterator(
+    public WhereClauseIterator(
             RuntimeTupleIterator child,
             RuntimeIterator whereExpression,
             RuntimeStaticContext staticContext
@@ -211,7 +211,7 @@ public class WhereClauseSparkIterator extends RuntimeTupleIterator {
     }
 
     private FlworDataFrame getDataFrameIfLimit(DynamicContext context) {
-        if (!(this.child instanceof CountClauseSparkIterator countClauseIterator)) {
+        if (!(this.child instanceof CountClauseIterator countClauseIterator)) {
             return null;
         }
         Name countVariable = countClauseIterator.getVariableName();
@@ -337,7 +337,7 @@ public class WhereClauseSparkIterator extends RuntimeTupleIterator {
             Set<Name> rightVariables = this.child.getOutputTupleVariableNames();
             this.setEvaluationDepthLimit(-1);
 
-            FlworDataFrame result = JoinClauseSparkIterator.joinInputTupleWithSequenceOnPredicate(
+            FlworDataFrame result = JoinClauseIterator.joinInputTupleWithSequenceOnPredicate(
                 context,
                 leftTuples.getDataFrame(),
                 rightTuples.getDataFrame(),

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/OrderClauseDetermineTypeUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/OrderClauseDetermineTypeUDF.java
@@ -28,7 +28,7 @@ import org.rumbledb.exceptions.MoreThanOneItemException;
 import org.rumbledb.exceptions.UnexpectedTypeException;
 import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.runtime.flwor.FlworDataFrameColumn;
-import org.rumbledb.runtime.flwor.clauses.OrderByClauseSparkIterator;
+import org.rumbledb.runtime.flwor.clauses.OrderByClauseIterator;
 import org.rumbledb.runtime.flwor.expression.OrderByClauseAnnotatedChildIterator;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,7 +76,7 @@ public class OrderClauseDetermineTypeUDF implements UDF1<Row, List<String>> {
         }
 
         if (this.nextItem == null) {
-            this.result.add(OrderByClauseSparkIterator.StringFlagForEmptySequence);
+            this.result.add(OrderByClauseIterator.StringFlagForEmptySequence);
             return;
         }
         if (this.nextItem.isArray() || this.nextItem.isObject()) {


### PR DESCRIPTION
Avoids confusion.