### PR TITLE
Display failed test case file name in Java Maven test

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
-      checks: write
       contents: read
     steps:
       - name: Checkout the repository

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,8 +14,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v5
@@ -108,6 +106,8 @@ jobs:
         uses: ScalableCapital/action-surefire-report@v2
         with:
           report_paths: target/surefire-reports/TEST-*.xml
+          create_check: false
+          skip_publishing: true
           fail_on_test_failures: false
           fail_if_no_tests: false
           report_mode: workflow

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -109,6 +109,6 @@ jobs:
         uses: ScalableCapital/action-surefire-report@v2
         with:
           report_paths: target/surefire-reports/TEST-*.xml
-          check_name: Test Report - ${{ matrix.test_class }}
           fail_on_test_failures: false
           fail_if_no_tests: false
+          report_mode: workflow

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      checks: write
+      contents: read
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v5
@@ -101,3 +104,11 @@ jobs:
           path: target
       - name: Run Test ${{ matrix.test_class }}
         run: mvn -Dtest=${{ matrix.test_class }} test
+      - name: Publish Surefire Report ${{ matrix.test_class }}
+        if: always()
+        uses: ScalableCapital/action-surefire-report@v2
+        with:
+          report_paths: target/surefire-reports/TEST-*.xml
+          check_name: Test Report - ${{ matrix.test_class }}
+          fail_on_test_failures: false
+          fail_if_no_tests: false

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -107,7 +107,6 @@ jobs:
         with:
           report_paths: target/surefire-reports/TEST-*.xml
           create_check: false
-          skip_publishing: true
           fail_on_test_failures: false
           fail_if_no_tests: false
           report_mode: workflow

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-            <version>3.5.5</version>
+                <version>3.5.6</version>
                 <configuration>
                     <enableOutErrElements>${surefire.enableOutErrElements}</enableOutErrElements>
                     <!-- arguments needed for unit tests to work with Java 17
@@ -330,6 +330,28 @@
                         --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
                         --add-opens java.base/java.net=ALL-UNNAMED
                     </argLine>
+                    <statelessTestsetReporter
+                        implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                        <disable>false</disable>
+                        <version>3.0.2</version>
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                        <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                        <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                        <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                    </statelessTestsetReporter>
+                    <consoleOutputReporter
+                        implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+                        <disable>false</disable>
+                        <encoding>UTF-8</encoding>
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter
+                        implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+                        <disable>false</disable>
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                        <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
+                        <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+                    </statelessTestsetInfoReporter>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/iq/base/AnnotationTestExecutor.java
+++ b/src/test/java/iq/base/AnnotationTestExecutor.java
@@ -90,16 +90,17 @@ public final class AnnotationTestExecutor {
 
         switch (annotation.expectation()) {
             case UNPARSABLE, UNCOMPILABLE:
-                Assertions.fail(unexpectedSuccessMessage(annotation.expectation().stage()));
+                Assertions.fail(withTestFile(path, unexpectedSuccessMessage(annotation.expectation().stage())));
                 return;
             case PARSABLE, COMPILABLE:
                 return;
             case RUNNABLE:
-                assertOutput(annotation, executionResult.sequence(), checkOutput, applyUpdates, resultSizeCap);
+                assertOutput(path, annotation, executionResult.sequence(), checkOutput, applyUpdates, resultSizeCap);
                 return;
             case UNRUNNABLE:
                 assertExpectedRuntimeFailureDuringMaterialization(
                     annotation,
+                    path,
                     executionResult.sequence(),
                     applyUpdates,
                     resultSizeCap
@@ -180,6 +181,7 @@ public final class AnnotationTestExecutor {
     }
 
     private static void assertOutput(
+            String path,
             AnnotationProcessor.TestAnnotation annotation,
             SequenceOfItems sequence,
             boolean checkOutput,
@@ -187,28 +189,30 @@ public final class AnnotationTestExecutor {
             int resultSizeCap
     ) {
         try {
-            checkExpectedOutput(annotation.output(), sequence, checkOutput, applyUpdates, resultSizeCap);
+            checkExpectedOutput(path, annotation.output(), sequence, checkOutput, applyUpdates, resultSizeCap);
         } catch (RumbleException exception) {
             String errorOutput = exception.getMessage() + "\n" + ExceptionUtils.getStackTrace(exception);
-            Assertions.fail(unexpectedFailureMessage(TestStage.RUNTIME, errorOutput));
+            Assertions.fail(withTestFile(path, unexpectedFailureMessage(TestStage.RUNTIME, errorOutput)));
         }
     }
 
     private static void assertExpectedRuntimeFailureDuringMaterialization(
             AnnotationProcessor.TestAnnotation annotation,
+            String path,
             SequenceOfItems sequence,
             boolean applyUpdates,
             int resultSizeCap
     ) {
         try {
             materializeSequence(sequence, applyUpdates, resultSizeCap);
-            Assertions.fail(unexpectedSuccessMessage(TestStage.RUNTIME));
+            Assertions.fail(withTestFile(path, unexpectedSuccessMessage(TestStage.RUNTIME)));
         } catch (Exception exception) {
             checkErrorCode(exception.getMessage(), annotation.errorCode(), annotation.errorMetadata());
         }
     }
 
     private static void checkExpectedOutput(
+            String path,
             String expectedOutput,
             SequenceOfItems sequence,
             boolean checkOutput,
@@ -217,8 +221,12 @@ public final class AnnotationTestExecutor {
     ) {
         String actualOutput = materializeSequence(sequence, applyUpdates, resultSizeCap);
         if (checkOutput) {
-            Assertions.assertEquals(expectedOutput, actualOutput, "Unexpected query output.");
+            Assertions.assertEquals(expectedOutput, actualOutput, withTestFile(path, "Unexpected query output."));
         }
+    }
+
+    private static String withTestFile(String path, String message) {
+        return "Test file: " + path + "\n" + message;
     }
 
     private static String materializeSequence(

--- a/src/test/java/iq/base/AnnotationsTestsBase.java
+++ b/src/test/java/iq/base/AnnotationsTestsBase.java
@@ -52,7 +52,6 @@ public abstract class AnnotationsTestsBase {
     @MethodSource("testFiles")
     @Timeout(1000)
     final void testAnnotation(File testFile) throws IOException {
-        System.err.println(testFile);
         AnnotationTestExecutor.run(testFile, getConfiguration(), checkOutput());
     }
 }

--- a/src/test/resources/test_files/runtime-native-flwor/where/where4.jq
+++ b/src/test/resources/test_files/runtime-native-flwor/where/where4.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldRun; Output="(1, include spaces)" :)
+(:JIQS: ShouldRun; Output="(2, include spaces)" :)
 for $i in structured-json-lines("../../../queries/difficult-names.json")
 where $i.a[[1]] eq 10
 return $i.keyToUse

--- a/src/test/resources/test_files/runtime-native-flwor/where/where4.jq
+++ b/src/test/resources/test_files/runtime-native-flwor/where/where4.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldRun; Output="(2, include spaces)" :)
+(:JIQS: ShouldRun; Output="(1, include spaces)" :)
 for $i in structured-json-lines("../../../queries/difficult-names.json")
 where $i.a[[1]] eq 10
 return $i.keyToUse


### PR DESCRIPTION
Due to PR #1604, the name of the exact file that caused the test failure is no longer showing in the console report. This is an issue between the JUnit 5+ and Surefire plugins. I configured Surefire to output the file name in the XML report. However, this configuration cannot be applied to the console output. Hence, this commit adds an auxiliary method that adds the file name to the assertion error message.

I also discovered a GitHub action that reads the Surefire XML and displays the results as an action annotation: https://github.com/ScaCap/action-surefire-report

It does not seem very popular, but it works.

<img width="1582" height="250" alt="image" src="https://github.com/user-attachments/assets/00c5ff88-2b53-42c8-8b34-7c3fb6668698" />

So we no longer need to look for the exact fail case in the huge log.

