### PR TITLE
Add ConsoleOutput class for centralized command-line output

### DIFF
--- a/src/main/java/org/rumbledb/cli/ConsoleOutput.java
+++ b/src/main/java/org/rumbledb/cli/ConsoleOutput.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rumbledb.cli;
+
+/**
+ * Centralizes user-facing command-line output.
+ *
+ * Debug logging should be done through the logging framework, not through this class.
+ */
+public final class ConsoleOutput {
+
+    private ConsoleOutput() {
+    }
+
+    /**
+     * Prints user-facing text to standard output.
+     *
+     * @param message the text to print.
+     */
+    public static void out(String message) {
+        System.out.println(message);
+    }
+
+    /**
+     * Prints a user-facing warning to standard error.
+     *
+     * @param message the warning text to print.
+     */
+    public static void warn(String message) {
+        System.err.println(message);
+    }
+
+    /**
+     * Prints a user-facing error to standard error.
+     *
+     * @param message the error text to print.
+     */
+    public static void error(String message) {
+        System.err.println(message);
+    }
+
+    /**
+     * Prints a stack trace to standard error when the user explicitly requested debug error details.
+     *
+     * @param throwable the throwable whose stack trace should be printed.
+     */
+    public static void stackTrace(Throwable throwable) {
+        throwable.printStackTrace(System.err);
+    }
+}

--- a/src/main/java/org/rumbledb/cli/JsoniqQueryExecutor.java
+++ b/src/main/java/org/rumbledb/cli/JsoniqQueryExecutor.java
@@ -119,10 +119,10 @@ public class JsoniqQueryExecutor {
             List<String> lines = outputList.stream()
                 .map(serializer::serialize)
                 .collect(Collectors.toList());
-            System.out.println(String.join("\n", lines));
+            ConsoleOutput.out(String.join("\n", lines));
             if (materializationCount != -1) {
                 issueMaterializationWarning(materializationCount, this.configuration.getResultSizeCap());
-                System.err.println(
+                ConsoleOutput.warn(
                     "Did you really intend to collect results to the standard input? If you want the complete output, consider using --output-path to select a destination on any file system."
                 );
             }
@@ -149,14 +149,14 @@ public class JsoniqQueryExecutor {
 
     public static void issueMaterializationWarning(long materializationCount, long resultSizeCap) {
         if (materializationCount == Long.MAX_VALUE) {
-            System.err.println(
+            ConsoleOutput.warn(
                 "Warning! The output sequence contains "
                     + "too many items and its materialization was capped at "
                     + resultSizeCap
                     + " items. This value can be configured to something higher with the --materialization-cap parameter (or its deprecated equivalent --result-size) at startup"
             );
         } else {
-            System.err.println(
+            ConsoleOutput.warn(
                 "Warning! The output sequence contains "
                     + materializationCount
                     + " items but its materialization was capped at "

--- a/src/main/java/org/rumbledb/cli/Main.java
+++ b/src/main/java/org/rumbledb/cli/Main.java
@@ -41,11 +41,14 @@ public class Main {
             !javaVersion.startsWith("17")
                 && !javaVersion.startsWith("21")
         ) {
-            System.err.println("[Error] RumbleDB requires Java 17 or 21 (17 being the default Spark 4 version).");
-            System.err.println("Your Java version: " + System.getProperty("java.version"));
-            System.err.println("You can download Java 17 or 21 from https://adoptium.net/");
-            System.err.println(
-                "If you do have Java 17 or 21, but the wrong version appears above, then it means you need to set your JAVA_HOME environment variable properly to point to Java 17 or 21."
+            ConsoleOutput.error(
+                """
+                        [Error] RumbleDB requires Java 17 or 21 (17 being the default Spark 4 version).
+                        Your Java version: %s
+                        You can download Java 17 or 21 from https://adoptium.net/
+                        If you do have Java 17 or 21, but the wrong version appears above, then it means you need to set your JAVA_HOME environment variable properly to point to Java 17 or 21.\
+                        """
+                    .formatted(System.getProperty("java.version"))
             );
             System.exit(43);
         }
@@ -61,10 +64,15 @@ public class Main {
             } else if (sparksoniqConf.getQuery() != null || sparksoniqConf.getQueryPath() != null) {
                 runQueryExecutor(sparksoniqConf);
             } else {
-                System.out.println(IOUtils.toString(Main.class.getResourceAsStream("/assets/banner.txt"), "UTF-8"));
-                System.out.println();
-                System.out.println(
-                    IOUtils.toString(Main.class.getResourceAsStream("/assets/defaultscreen.txt"), "UTF-8")
+                ConsoleOutput.out(
+                    """
+                                %s
+                                %s
+                            """.formatted(
+                        IOUtils.toString(Main.class.getResourceAsStream("/assets/banner.txt"), "UTF-8"),
+                        IOUtils.toString(Main.class.getResourceAsStream("/assets/defaultscreen.txt"), "UTF-8")
+
+                    )
                 );
             }
             System.exit(0);
@@ -91,7 +99,7 @@ public class Main {
                     handleException(sparkExceptionCause, showErrorInfo);
                 } else {
                     if (showErrorInfo) {
-                        ex.printStackTrace();
+                        ConsoleOutput.stackTrace(ex);
                     }
                     handleException(
                         new OurBadException(
@@ -102,75 +110,71 @@ public class Main {
                     );
                 }
             } else if (ex instanceof RumbleException && !(ex instanceof OurBadException)) {
-                System.err.println("⚠️ " + ex.getMessage());
+                ConsoleOutput.error("⚠️ " + ex.getMessage());
                 if (showErrorInfo) {
-                    ex.printStackTrace();
+                    ConsoleOutput.stackTrace(ex);
                 }
                 System.exit(42);
             } else if (ex instanceof OutOfMemoryError) {
-                System.err.println(
-                    "⚠️  Java went out of memory."
-                );
-                System.err.println(
-                    "If running locally, try adding --driver-memory 10G (or any quantity you need) between spark-submit and the RumbleDB jar in the command line to see if it fixes the problem. If running on a cluster, --executor-memory is the way to go."
+                ConsoleOutput.error(
+                    """
+                            ⚠️  Java went out of memory.
+                            If running locally, try adding --driver-memory 10G (or any quantity you need) between spark-submit and the RumbleDB jar in the command line to see if it fixes the problem. If running on a cluster, --executor-memory is the way to go.\
+                            """
                 );
                 if (showErrorInfo) {
-                    ex.printStackTrace();
+                    ConsoleOutput.stackTrace(ex);
                 }
                 System.exit(46);
             } else if (ex instanceof CannotCompileException) {
-                System.err.println("⚠️  There was a CannotCompileException.");
-                System.err.println(
-                    "There is a known issue with this on Docker and on certain versions of OpenJDK due to the JSONiter library."
-                );
-                System.err.println(
-                    "We have a workaround: please try again using --deactivate-jsoniter-streaming yes on your command line. json-doc() will, however, not be available."
-                );
-                System.err.println(
-                    "For more debug info, please try again using --show-error-info yes in your command line."
+                ConsoleOutput.error(
+                    """
+                            ⚠️  There was a CannotCompileException.
+                            There is a known issue with this on Docker and on certain versions of OpenJDK due to the JSONiter library.
+                            We have a workaround: please try again using --deactivate-jsoniter-streaming yes on your command line. json-doc() will, however, not be available.
+                            For more debug info, please try again using --show-error-info yes in your command line.\
+                            """
                 );
                 if (showErrorInfo) {
-                    ex.printStackTrace();
+                    ConsoleOutput.stackTrace(ex);
                 }
                 System.exit(44);
             } else if (ex instanceof ConnectException) {
-                System.err.println("⚠️  There was a problem with the connection to the cluster.");
-                System.err.println(
-                    "For more debug info including the exact exception and a stacktrace, please try again using --show-error-info yes in your command line."
+                ConsoleOutput.error(
+                    """
+                            ⚠️  There was a problem with the connection to the cluster.
+                            For more debug info including the exact exception and a stacktrace, please try again using --show-error-info yes in your command line.\
+                            """
                 );
                 if (showErrorInfo) {
-                    ex.printStackTrace();
+                    ConsoleOutput.stackTrace(ex);
                 }
                 System.exit(45);
             } else if (ex instanceof NullPointerException) {
-                System.err.println(
-                    "Oh my oh my, we are very embarrassed, because there was a null pointer exception. 🙈"
-                );
-                System.err.println(
-                    "We would like to investigate this and make sure to fix it in a subsequent release. We would be very grateful if you could contact us or file an issue on GitHub with your query."
-                );
-                System.err.println("Link: https://github.com/RumbleDB/rumble/issues");
-                System.err.println(
-                    "For more debug info (e.g., so you can communicate it to us), please try again using --show-error-info yes in your command line."
+                ConsoleOutput.error(
+                    """
+                            Oh my oh my, we are very embarrassed, because there was a null pointer exception. 🙈
+                            We would like to investigate this and make sure to fix it in a subsequent release. We would be very grateful if you could contact us or file an issue on GitHub with your query.
+                            Link: https://github.com/RumbleDB/rumble/issues
+                            For more debug info (e.g., so you can communicate it to us), please try again using --show-error-info yes in your command line.\
+                            """
                 );
                 if (showErrorInfo) {
-                    ex.printStackTrace();
+                    ConsoleOutput.stackTrace(ex);
                 }
                 System.exit(-42);
             } else {
-                System.err.println(
-                    "We are very embarrassed, because an error has occured that we did not anticipate 🙈: "
-                        + ex.getMessage()
-                );
-                System.err.println(
-                    "We would like to investigate this and make sure to fix it. We would be very grateful if you could contact us or file an issue on GitHub with your query."
-                );
-                System.err.println("Link: https://github.com/RumbleDB/rumble/issues");
-                System.err.println(
-                    "For more debug info (e.g., so you can communicate it to us), please try again using --show-error-info yes in your command line."
+                ConsoleOutput.error(
+                    """
+                            We are very embarrassed, because an error has occured that we did not anticipate 🙈: %s
+                            We would like to investigate this and make sure to fix it. We would be very grateful if you could contact us or file an issue on GitHub with your query.
+                            Link: https://github.com/RumbleDB/rumble/issues
+                            For more debug info (e.g., so you can communicate it to us), please try again using --show-error-info yes in your command line.\
+                            """
+                        .formatted(ex.getMessage())
                 );
                 if (showErrorInfo) {
-                    ex.printStackTrace();
+                    ConsoleOutput.stackTrace(ex);
                 }
                 System.exit(-42);
             }
@@ -194,7 +198,7 @@ public class Main {
 
     public static void printMessageToLog(String message) {
         if (Main.terminal == null) {
-            System.out.println(message);
+            ConsoleOutput.out(message);
         } else {
             Main.terminal.output(message);
         }


### PR DESCRIPTION
Currently, the codebase mixes user-facing output (e.g. the result of query execution) with debug logs; both use System.out/warn/err.

In the next major version, we will use Log4j2 (or a similar logging framework) for debug logs. This pull request creates a ConsoleOutput utility class in the cli package and redirects all user-facing standard outputs there. Therefore, all remaining std.println() statements should switch to the logging framework in the next major release.

Also, Java multiline string (Java 15+) is used so we no longer need to call println multiple times.