### PR TITLE
Replace Markdown list syntax in javadoc with HTML `<ul>` tags.

### DIFF
--- a/src/main/java/org/rumbledb/api/Item.java
+++ b/src/main/java/org/rumbledb/api/Item.java
@@ -505,8 +505,10 @@ public interface Item extends Serializable, KryoSerializable {
     /**
      * Tests whether the item is an object.
      * Object items are legacy JSONiq objects, that allow only for
-     * - string keys
-     * - singleton values
+     * <ul>
+     * <li>string keys</li>
+     * <li>singleton values</li>
+     * </ul>
      *
      * @return true if it is an object, false otherwise.
      */

--- a/src/main/java/org/rumbledb/api/SequenceWriter.java
+++ b/src/main/java/org/rumbledb/api/SequenceWriter.java
@@ -29,12 +29,15 @@ import org.rumbledb.serialization.Serializers;
  * instead of mutating the current one.
  *
  * There are two mutually exclusive internal modes:
- * - DataFrame mode: {@code dataFrameWriter != null} and {@code mode == null}.
+ * 
+ * <ul>
+ * <li>DataFrame mode: {@code dataFrameWriter != null} and {@code mode == null}.
  * In this case, the sequence can be represented as a Spark {@link Dataset} /
- * {@link DataFrameWriter} and is written using Spark's native writers (json/csv/parquet/...).
- * - RDD mode: {@code dataFrameWriter == null} and {@code mode != null}.
+ * {@link DataFrameWriter} and is written using Spark's native writers (json/csv/parquet/...).</li>
+ * <li>RDD mode: {@code dataFrameWriter == null} and {@code mode != null}.
  * In this case, the sequence is serialized item-by-item via {@link Serializer}
- * and saved as text files.
+ * and saved as text files.</li>
+ * </ul>
  *
  * The serialization method (json, tyson, xml-json-hybrid, yaml, delta, ...) is always taken from
  * {@link SerializationParameters#getMethod()}, which is the single source of truth for the output
@@ -54,10 +57,13 @@ public class SequenceWriter {
      * Internal constructor used by all builder-style methods.
      *
      * Invariants:
-     * - Either DataFrame mode: {@code dataFrameWriter != null} and {@code mode == null}.
-     * - Or RDD mode: {@code dataFrameWriter == null} and {@code mode != null}.
-     * - {@code serializationParameters} is never {@code null}.
-     * - {@code serializationParameters.getMethod()} is never {@code null}; serialization uses a predefined method.
+     * <ul>
+     * <li>Either DataFrame mode: {@code dataFrameWriter != null} and {@code mode == null}.</li>
+     * <li>Or RDD mode: {@code dataFrameWriter == null} and {@code mode != null}.</li>
+     * <li>{@code serializationParameters} is never {@code null}.</li>
+     * <li>{@code serializationParameters.getMethod()} is never {@code null}; serialization uses a predefined
+     * method.</li>
+     * </ul>
      */
     private SequenceWriter(
             SequenceOfItems sequence,
@@ -91,10 +97,12 @@ public class SequenceWriter {
      * Public entry-point constructor used by {@link SequenceOfItems#write()}.
      * TODO: update comment here
      * It determines the initial mode:
-     * - If the method is {@code xml-json-hybrid} or {@code tyson}, or if obtaining a DataFrame
-     * fails, the writer is created in RDD mode.
-     * - Otherwise, the writer is created in DataFrame mode based on the DataFrame returned by
-     * {@link SequenceOfItems#getAsDataFrame()}.
+     * <ul>
+     * <li>If the method is {@code xml-json-hybrid} or {@code tyson}, or if obtaining a DataFrame
+     * fails, the writer is created in RDD mode.</li>
+     * <li>Otherwise, the writer is created in DataFrame mode based on the DataFrame returned by
+     * {@link SequenceOfItems#getAsDataFrame()}.</li>
+     * </ul>
      */
     SequenceWriter(SequenceOfItems sequence) {
         this.sequence = sequence;
@@ -381,10 +389,13 @@ public class SequenceWriter {
      * Parses a string into a Spark SaveMode.
      *
      * Accepted values (case-insensitive):
-     * - overwrite
-     * - append
-     * - ignore
-     * - error, errorifexists, default → ErrorIfExists
+     * 
+     * <ul>
+     * <li>overwrite</li>
+     * <li>append</li>
+     * <li>ignore</li>
+     * <li>error, errorifexists, default → ErrorIfExists</li>
+     * </ul>
      *
      * @param saveMode the string representation of the save mode
      * @return the corresponding SaveMode

--- a/src/main/java/org/rumbledb/compiler/ComparisonVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/ComparisonVisitor.java
@@ -227,12 +227,15 @@ public class ComparisonVisitor extends CloneVisitor {
     /**
      * Implements the XQuery/XPath 3.1 §3.7.2 rules for general comparisons involving xs:untypedAtomic
      * at the expression level using explicit cast expressions:
-     * - Both operands untypedAtomic → both cast to xs:string.
-     * - One operand untypedAtomic, other atomic T:
-     * - If T is numeric → cast untyped to xs:double.
-     * - If T is xs:yearMonthDuration or xs:dayTimeDuration → cast untyped to that duration type.
-     * - Otherwise → cast untyped to the primitive base type of T.
-     *
+     * 
+     * <ul>
+     * <li>Both operands untypedAtomic → both cast to xs:string.</li>
+     * <li>One operand untypedAtomic, other atomic T:</li>
+     * <li>If T is numeric → cast untyped to xs:double.</li>
+     * <li>If T is xs:yearMonthDuration or xs:dayTimeDuration → cast untyped to that duration type.</li>
+     * <li>Otherwise → cast untyped to the primitive base type of T.</li>
+     * </ul>
+     * 
      * The method is purely static-type driven; if static types are insufficiently precise or if
      * operands are not atomic, the original expressions are returned unchanged.
      */

--- a/src/main/java/org/rumbledb/context/StaticContext.java
+++ b/src/main/java/org/rumbledb/context/StaticContext.java
@@ -437,9 +437,13 @@ public class StaticContext implements Serializable, KryoSerializable {
      * Returns the default serialization parameters stored in the static context.
      *
      * Spec references:
-     * - XQuery 3.1 Static Context Components (link: https://www.w3.org/TR/xquery-31/#id-xq-static-context-components)
-     * - Serialization 3.1 — Serialization Parameters (link:
-     * https://www.w3.org/TR/xslt-xquery-serialization-31/#serparam)
+     * 
+     * <ul>
+     * <li>XQuery 3.1 Static Context Components (link:
+     * https://www.w3.org/TR/xquery-31/#id-xq-static-context-components)</li>
+     * <li>Serialization 3.1 — Serialization Parameters (link:
+     * https://www.w3.org/TR/xslt-xquery-serialization-31/#serparam)</li>
+     * </ul>
      */
     public SerializationParameters getSerializationParameters() {
         if (this.serializationParameters != null) {

--- a/src/main/java/org/rumbledb/exceptions/InvalidComputedNamespaceConstructorException.java
+++ b/src/main/java/org/rumbledb/exceptions/InvalidComputedNamespaceConstructorException.java
@@ -25,11 +25,14 @@ import org.rumbledb.errorcodes.ErrorCode;
 /**
  * Exception for XQDY0101: It is a dynamic error if a computed namespace constructor attempts to do any of the
  * following:
- * - Bind the prefix xml to some namespace URI other than http://www.w3.org/XML/1998/namespace
- * - Bind a prefix other than xml to the namespace URI http://www.w3.org/XML/1998/namespace
- * - Bind the prefix xmlns to any namespace URI
- * - Bind a prefix to the namespace URI http://www.w3.org/2000/xmlns/
- * - Bind any prefix (including the empty prefix) to a zero-length namespace URI
+ * 
+ * <ul>
+ * <li>Bind the prefix xml to some namespace URI other than http://www.w3.org/XML/1998/namespace</li>
+ * <li>Bind a prefix other than xml to the namespace URI http://www.w3.org/XML/1998/namespace</li>
+ * <li>Bind the prefix xmlns to any namespace URI</li>
+ * <li>Bind a prefix to the namespace URI http://www.w3.org/2000/xmlns/</li>
+ * <li>Bind any prefix (including the empty prefix) to a zero-length namespace URI</li>
+ * </ul>
  *
  * @see <a href="https://www.w3.org/TR/xquery-31/#ERRXQDY0101">XQuery 3.1, F: XQDY0101</a>
  */

--- a/src/main/java/org/rumbledb/exceptions/PredefinedPrefixInNamespaceDeclarationException.java
+++ b/src/main/java/org/rumbledb/exceptions/PredefinedPrefixInNamespaceDeclarationException.java
@@ -25,9 +25,12 @@ import org.rumbledb.errorcodes.ErrorCode;
 /**
  * Exception for XQST0070: It is a static error if a namespace declaration attribute attempts to do any of the
  * following:
- * - Bind the prefix xml to some namespace URI other than http://www.w3.org/XML/1998/namespace
- * - Bind the prefix xmlns to any namespace URI
- * - Bind a prefix to the namespace URI http://www.w3.org/2000/xmlns/
+ * 
+ * <ul>
+ * <li>Bind the prefix xml to some namespace URI other than http://www.w3.org/XML/1998/namespace</li>
+ * <li>Bind the prefix xmlns to any namespace URI</li>
+ * <li>Bind a prefix to the namespace URI http://www.w3.org/2000/xmlns/</li>
+ * </ul>
  *
  * @see <a href="https://www.w3.org/TR/xquery-31/#ERRXQST0070">XQuery 3.1, F: XQST0070</a>
  */

--- a/src/main/java/org/rumbledb/expressions/Expression.java
+++ b/src/main/java/org/rumbledb/expressions/Expression.java
@@ -160,9 +160,12 @@ public abstract class Expression extends Node {
     /**
      * Sets the sequential property of the expression. An expression can only
      * be one of the following:
-     * - non-updating sequential,
-     * - non-updating non-sequential,
-     * - updating non-sequential.
+     * 
+     * <ul>
+     * <li>non-updating sequential,</li>
+     * <li>non-updating non-sequential,</li>
+     * <li>updating non-sequential.</li>
+     * </ul>
      *
      * @param isSequential a boolean value defining if the expression is
      *        sequential or not.

--- a/src/main/java/org/rumbledb/items/xml/ElementItem.java
+++ b/src/main/java/org/rumbledb/items/xml/ElementItem.java
@@ -233,8 +233,11 @@ public class ElementItem implements Item {
          * Recursion would instantiate namespace node instances for each ancestor element, resulting in a higher memory
          * footprint.
          * A LinkedHashMap is used so that:
-         * - Insertion order is preserved for stable iteration.
-         * - Later puts for the same prefix override earlier values.
+         * 
+         * <ul>
+         * <li>Insertion order is preserved for stable iteration.</li>
+         * <li>Later puts for the same prefix override earlier values.</li>
+         * </ul>
          */
         LinkedHashMap<String, String> inScope = new LinkedHashMap<>();
 

--- a/src/main/java/org/rumbledb/runtime/functions/FunctionItemCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/FunctionItemCallIterator.java
@@ -193,8 +193,11 @@ public class FunctionItemCallIterator extends HybridRuntimeIterator {
 
     /**
      * Partial application generates a new function:
-     * - Supplied parameters are set as NonLocalVariables
-     * - Argument placeholders form the parameters
+     * 
+     * <ul>
+     * <li>Supplied parameters are set as NonLocalVariables</li>
+     * <li>Argument placeholders form the parameters</li>
+     * </ul>
      *
      * @return FunctionRuntimeIterator that contains the newly generated FunctionItem
      */

--- a/src/main/java/org/rumbledb/runtime/functions/xml/BaseUriFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/BaseUriFunctionIterator.java
@@ -42,13 +42,19 @@ import java.util.List;
  * has one; otherwise it returns the empty sequence."
  *
  * Function signatures (Functions and Operators 3.1, {@code fn:base-uri}):
- * - fn:base-uri() as xs:anyURI?
- * - fn:base-uri($arg as node()?) as xs:anyURI?
+ * 
+ * <ul>
+ * <li>fn:base-uri() as xs:anyURI?</li>
+ * <li>fn:base-uri($arg as node()?) as xs:anyURI?</li>
+ * </ul>
  *
  * Rules:
- * - If the argument is omitted, it defaults to the context item (.).
- * - If the argument is supplied and is the empty sequence, the function returns the empty sequence.
- * - Otherwise, the function returns dm:base-uri($arg).
+ * 
+ * <ul>
+ * <li>If the argument is omitted, it defaults to the context item (.).</li>
+ * <li>If the argument is supplied and is the empty sequence, the function returns the empty sequence.</li>
+ * <li>Otherwise, the function returns dm:base-uri($arg).</li>
+ * </ul>
  *
  * @see <a href="https://www.w3.org/TR/xpath-functions-31/#func-base-uri">XPath and XQuery Functions and
  *      Operators 3.1: fn:base-uri</a>

--- a/src/main/java/org/rumbledb/runtime/functions/xml/DocumentUriFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/DocumentUriFunctionIterator.java
@@ -42,12 +42,18 @@ import java.util.List;
  * document node, if it has one; otherwise it returns the empty sequence."
  *
  * Function signature (Functions and Operators 3.1, {@code fn:document-uri}):
- * - fn:document-uri($arg as node()?) as xs:anyURI?
+ * 
+ * <ul>
+ * <li>fn:document-uri($arg as node()?) as xs:anyURI?</li>
+ * </ul>
  *
  * Rules:
- * - If the argument is supplied and is the empty sequence, the function returns the empty sequence.
- * - Otherwise, the function returns dm:document-uri($arg).
- *
+ * 
+ * <ul>
+ * <li>If the argument is supplied and is the empty sequence, the function returns the empty sequence.</li>
+ * <li>Otherwise, the function returns dm:document-uri($arg).</li>
+ * </ul>
+ * 
  * @see <a href="https://www.w3.org/TR/xpath-functions-31/#func-document-uri">XPath and XQuery Functions and
  *      Operators 3.1: fn:document-uri</a>
  */

--- a/src/main/java/org/rumbledb/runtime/functions/xml/NilledFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/NilledFunctionIterator.java
@@ -45,11 +45,16 @@ import java.util.List;
  * returned by Item.nilled().
  *
  * Function signature (Functions and Operators 3.1, {@code fn:nilled}):
- * - fn:nilled($arg as node()?) as xs:boolean?
+ * 
+ * <ul>
+ * <li>fn:nilled($arg as node()?) as xs:boolean?</li>
+ * </ul>
  *
  * Rules:
- * - If the argument is supplied and is the empty sequence, the function returns the empty sequence.
- * - Otherwise, the function returns dm:nilled($arg).
+ * <ul>
+ * <li>If the argument is supplied and is the empty sequence, the function returns the empty sequence.</li>
+ * <li>Otherwise, the function returns dm:nilled($arg).</li>
+ * </ul>
  *
  * @see <a href="https://www.w3.org/TR/xpath-functions-31/#func-nilled">XPath and XQuery Functions and
  *      Operators 3.1: fn:nilled</a>

--- a/src/main/java/org/rumbledb/runtime/functions/xml/NodeNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/NodeNameFunctionIterator.java
@@ -38,15 +38,20 @@ import java.util.List;
  * or has the lexical form of an xs:QName.
  * 
  * Function signatures:
- * - fn:name() as xs:string
- * - fn:name($arg as node()?) as xs:string
+ * 
+ * <ul>
+ * <li>fn:name() as xs:string</li>
+ * <li>fn:name($arg as node()?) as xs:string</li>
+ * </ul>
  * 
  * Rules:
- * - If the argument is omitted, it defaults to the context item (.)
- * - If the argument is supplied and is the empty sequence, the function returns the zero-length string
- * - If the node identified by $arg has no name (that is, if it is a document node, a comment,
- * a text node, or a namespace node having no name), the function returns the zero-length string
- * - Otherwise, the function returns the value of the expression fn:string(fn:node-name($arg))
+ * <ul>
+ * <li>If the argument is omitted, it defaults to the context item (.)</li>
+ * <li>If the argument is supplied and is the empty sequence, the function returns the zero-length string</li>
+ * <li>If the node identified by $arg has no name (that is, if it is a document node, a comment,
+ * a text node, or a namespace node having no name), the function returns the zero-length string</li>
+ * <li>Otherwise, the function returns the value of the expression fn:string(fn:node-name($arg))</li>
+ * </ul>
  * 
  * @see <a href="https://www.w3.org/TR/xpath-functions-31/#func-name">XPath Functions 3.1: fn:name</a>
  */

--- a/src/main/java/org/rumbledb/runtime/functions/xml/NodeQNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/NodeQNameFunctionIterator.java
@@ -43,16 +43,22 @@ import java.util.List;
  * sequence if the node does not have a name."
  *
  * Function signatures (Functions and Operators 3.1, {@code fn:node-name}):
- * - fn:node-name() as xs:QName?
- * - fn:node-name($arg as node()?) as xs:QName?
+ * 
+ * <ul>
+ * <li>fn:node-name() as xs:QName?</li>
+ * <li>fn:node-name($arg as node()?) as xs:QName?</li>
+ * </ul>
  *
  * Rules:
- * - "If the argument is omitted, it defaults to the context item."
- * - "If the argument is supplied and is the empty sequence, the function returns the empty sequence."
- * - "Otherwise, the function returns the result of applying the dm:node-name accessor to the node
+ * 
+ * <ul>
+ * <li>"If the argument is omitted, it defaults to the context item."</li>
+ * <li>"If the argument is supplied and is the empty sequence, the function returns the empty sequence."</li>
+ * <li>"Otherwise, the function returns the result of applying the dm:node-name accessor to the node
  * identified by the argument. If the dm:node-name accessor returns the empty sequence, then the
- * function returns the empty sequence."
- *
+ * function returns the empty sequence."</li>
+ * </ul>
+ * 
  * The optional {@code xs:QName} result wraps the expanded {@link Name} from {@link Item#nodeName()} in a
  * {@link org.rumbledb.items.QNameItem}; otherwise the function returns the empty sequence.
  *

--- a/src/main/java/org/rumbledb/serialization/SerializationParameters.java
+++ b/src/main/java/org/rumbledb/serialization/SerializationParameters.java
@@ -32,10 +32,13 @@ import java.util.Set;
  * Default serialization parameters stored in the XQuery static context.
  *
  * Specification references:
- * - XQuery 3.1 Static Context Components — default serialization parameters (link:
- * https://www.w3.org/TR/xquery-31/#id-xq-static-context-components)
- * - XSLT and XQuery Serialization 3.1 — Serialization Parameters (link:
- * https://www.w3.org/TR/xslt-xquery-serialization-31/#serparam)
+ * 
+ * <ul>
+ * <li>XQuery 3.1 Static Context Components — default serialization parameters (link:
+ * https://www.w3.org/TR/xquery-31/#id-xq-static-context-components)</li>
+ * <li>XSLT and XQuery Serialization 3.1 — Serialization Parameters (link:
+ * https://www.w3.org/TR/xslt-xquery-serialization-31/#serparam)</li>
+ * </ul>
  *
  */
 public class SerializationParameters implements Serializable, KryoSerializable {

--- a/src/test/java/org/rumbledb/types/ObjectItemTypeTest.java
+++ b/src/test/java/org/rumbledb/types/ObjectItemTypeTest.java
@@ -13,9 +13,11 @@ public class ObjectItemTypeTest {
     /**
      * Tests that the lax merge operation includes all fields from both object type operands.
      * Verifies that:
-     * - Fields from both left and right operands are present in the merged result
-     * - Field properties (required, unique) are preserved from their respective sources
-     * - The closed facet is set to false (open) if at least one operand is open
+     * <ul>
+     * <li>Fields from both left and right operands are present in the merged result</li>
+     * <li>Field properties (required, unique) are preserved from their respective sources</li>
+     * <li>The closed facet is set to false (open) if at least one operand is open</li>
+     * </ul>
      */
     @Test
     public void laxMergeIncludesAllFieldsFromBothOperands() {
@@ -44,11 +46,13 @@ public class ObjectItemTypeTest {
     /**
      * Tests that overlapping fields between two object types are merged using lax supertype logic recursively.
      * Verifies that:
-     * - When both operands define a field with the same name but different nested object types, the nested types are
-     * merged recursively using findLeastCommonSuperTypeLax
-     * - The merged nested object contains all fields from both nested types
-     * - The required flag is set to true only if both operands require the field (AND semantics)
-     * - The unique flag is set to true if either operand marks the field as unique (OR semantics)
+     * <ul>
+     * <li>When both operands define a field with the same name but different nested object types, the nested types are
+     * merged recursively using findLeastCommonSuperTypeLax</li>
+     * <li>The merged nested object contains all fields from both nested types</li>
+     * <li>The required flag is set to true only if both operands require the field (AND semantics)</li>
+     * <li>The unique flag is set to true if either operand marks the field as unique (OR semantics)</li>
+     * </ul>
      */
     @Test
     public void overlappingFieldsUseLaxSuperTypesRecursively() {
@@ -87,8 +91,10 @@ public class ObjectItemTypeTest {
     /**
      * Tests that default values are preserved in merged field descriptors only when they are compatible.
      * Verifies that:
-     * - When both operands define the same default value for a field, it is preserved in the merged result
-     * - When operands define conflicting default values, the default is discarded (set to null)
+     * <ul>
+     * <li>When both operands define the same default value for a field, it is preserved in the merged result</li>
+     * <li>When operands define conflicting default values, the default is discarded (set to null)</li>
+     * </ul>
      */
     @Test
     public void defaultValuesArePreservedOnlyWhenCompatible() {


### PR DESCRIPTION
Because support for Markdown in Javadoc is only from JDK 23, and we are supporting 17 - 21 now.

This is to prepare later for a more strict Spotless configuration, which also formats javadoc.