### PR TITLE
Avoid per-item iterator rebuild in fold-left/fold-right (fixes slow FnTest)

### DIFF
--- a/src/main/java/org/rumbledb/runtime/ConstantRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/ConstantRuntimeIterator.java
@@ -37,6 +37,11 @@ public class ConstantRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
         this.item = item;
     }
 
+    // Only for reuse as a cached argument iterator; call only while closed.
+    public void setItemForReuse(Item item) {
+        this.item = item;
+    }
+
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
         return this.item;

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/FoldLeftFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/FoldLeftFunctionIterator.java
@@ -16,6 +16,7 @@ import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.types.SequenceType;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -54,8 +55,36 @@ public class FoldLeftFunctionIterator extends HybridRuntimeIterator {
         List<Item> accumulator = this.zeroIterator.materialize(context);
         Item functionItem = this.functionIterator.materialize(context).get(0);
 
+        ConstantRuntimeIterator accumulatorArgument = null;
+        ConstantRuntimeIterator currentItemArgument = null;
+        RuntimeIterator reusableFunctionCall = null;
+
         for (Item inputItem : inputItems) {
-            accumulator = applyFunction(functionItem, accumulator, Collections.singletonList(inputItem), context);
+            if (accumulator.size() == 1) {
+                if (reusableFunctionCall == null) {
+                    RuntimeStaticContext localItemStarContext = new RuntimeStaticContext(
+                            getConfiguration(),
+                            SequenceType.createSequenceType("item*"),
+                            ExecutionMode.LOCAL,
+                            getMetadata()
+                    );
+                    accumulatorArgument = new ConstantRuntimeIterator(accumulator.get(0), localItemStarContext);
+                    currentItemArgument = new ConstantRuntimeIterator(inputItem, localItemStarContext);
+                    reusableFunctionCall = NamedFunctions.buildFunctionItemCallIterator(
+                        functionItem,
+                        this.staticContext,
+                        ExecutionMode.LOCAL,
+                        Arrays.asList(accumulatorArgument, currentItemArgument),
+                        false
+                    );
+                } else {
+                    accumulatorArgument.setItemForReuse(accumulator.get(0));
+                    currentItemArgument.setItemForReuse(inputItem);
+                }
+                accumulator = reusableFunctionCall.materialize(context);
+            } else {
+                accumulator = applyFunction(functionItem, accumulator, Collections.singletonList(inputItem), context);
+            }
         }
 
         this.resultSequence = accumulator;

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/FoldRightFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/FoldRightFunctionIterator.java
@@ -16,6 +16,7 @@ import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.types.SequenceType;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -54,13 +55,42 @@ public class FoldRightFunctionIterator extends HybridRuntimeIterator {
         List<Item> accumulator = this.zeroIterator.materialize(context);
         Item functionItem = this.functionIterator.materialize(context).get(0);
 
+        ConstantRuntimeIterator currentItemArgument = null;
+        ConstantRuntimeIterator accumulatorArgument = null;
+        RuntimeIterator reusableFunctionCall = null;
+
         for (int i = inputItems.size() - 1; i >= 0; i--) {
-            accumulator = applyFunction(
-                functionItem,
-                Collections.singletonList(inputItems.get(i)),
-                accumulator,
-                context
-            );
+            Item inputItem = inputItems.get(i);
+            if (accumulator.size() == 1) {
+                if (reusableFunctionCall == null) {
+                    RuntimeStaticContext localItemStarContext = new RuntimeStaticContext(
+                            getConfiguration(),
+                            SequenceType.createSequenceType("item*"),
+                            ExecutionMode.LOCAL,
+                            getMetadata()
+                    );
+                    currentItemArgument = new ConstantRuntimeIterator(inputItem, localItemStarContext);
+                    accumulatorArgument = new ConstantRuntimeIterator(accumulator.get(0), localItemStarContext);
+                    reusableFunctionCall = NamedFunctions.buildFunctionItemCallIterator(
+                        functionItem,
+                        this.staticContext,
+                        ExecutionMode.LOCAL,
+                        Arrays.asList(currentItemArgument, accumulatorArgument),
+                        false
+                    );
+                } else {
+                    currentItemArgument.setItemForReuse(inputItem);
+                    accumulatorArgument.setItemForReuse(accumulator.get(0));
+                }
+                accumulator = reusableFunctionCall.materialize(context);
+            } else {
+                accumulator = applyFunction(
+                    functionItem,
+                    Collections.singletonList(inputItem),
+                    accumulator,
+                    context
+                );
+            }
         }
 
         this.resultSequence = accumulator;


### PR DESCRIPTION
Note that the newly passing tests listed below do not result from this change but from a new version of the rumble-test-suite.