### PR TITLE
Fix atomic comparison handling in visitComparisonExpr method

### DIFF
--- a/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
@@ -1591,12 +1591,22 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
 
     @Override
     public RuntimeIterator visitComparisonExpr(ComparisonExpression expression, RuntimeIterator argument) {
-        RuntimeIterator left = this.visit(expression.getChildren().get(0), argument);
-        RuntimeIterator right = this.visit(expression.getChildren().get(1), argument);
-        if (left instanceof StepExprIterator) {
-            // We potentially need to atomize
+        Expression leftExpression = (Expression) expression.getChildren().get(0);
+        Expression rightExpression = (Expression) expression.getChildren().get(1);
+
+        RuntimeIterator left = this.visit(leftExpression, argument);
+        RuntimeIterator right = this.visit(rightExpression, argument);
+        if (!(leftExpression.getStaticSequenceType().getItemType().isAtomicItemType())) {
+            // Atomic comparison operators require atomized operands. If the operands are not atomic, we need to wrap
+            // them in a DataFunctionIterator to atomize them.
             left = new DataFunctionIterator(
                     Collections.singletonList(left),
+                    expression.getStaticContextForRuntime(this.config, this.visitorConfig)
+            );
+        }
+        if (!(rightExpression.getStaticSequenceType().getItemType().isAtomicItemType())) {
+            right = new DataFunctionIterator(
+                    Collections.singletonList(right),
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         }

--- a/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
@@ -1440,6 +1440,18 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
             rightExpression,
             argument
         );
+        if (!leftExpression.getStaticSequenceType().getItemType().isAtomicItemType()) {
+            left = new DataFunctionIterator(
+                    Collections.singletonList(left),
+                    expression.getStaticContextForRuntime(this.config, this.visitorConfig)
+            );
+        }
+        if (!rightExpression.getStaticSequenceType().getItemType().isAtomicItemType()) {
+            right = new DataFunctionIterator(
+                    Collections.singletonList(right),
+                    expression.getStaticContextForRuntime(this.config, this.visitorConfig)
+            );
+        }
 
         RuntimeIterator runtimeIterator = new AdditiveOperationIterator(
                 left,
@@ -1463,6 +1475,18 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
             rightExpression,
             argument
         );
+        if (!leftExpression.getStaticSequenceType().getItemType().isAtomicItemType()) {
+            left = new DataFunctionIterator(
+                    Collections.singletonList(left),
+                    expression.getStaticContextForRuntime(this.config, this.visitorConfig)
+            );
+        }
+        if (!rightExpression.getStaticSequenceType().getItemType().isAtomicItemType()) {
+            right = new DataFunctionIterator(
+                    Collections.singletonList(right),
+                    expression.getStaticContextForRuntime(this.config, this.visitorConfig)
+            );
+        }
 
         RuntimeIterator runtimeIterator = new MultiplicativeOperationIterator(
                 left,

--- a/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
+++ b/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
@@ -1090,7 +1090,7 @@ public class BuiltinFunctionCatalogue {
      */
     static final BuiltinFunction avg = createBuiltinFunction(
         new Name(Name.FN_NS, "fn", "avg"),
-        List.of("item*"),
+        List.of("anyAtomicType*"),
         "anyAtomicType?",
         AvgFunctionIterator.class,
         BuiltinFunction.BuiltinFunctionExecutionMode.LOCAL

--- a/src/main/java/org/rumbledb/runtime/arithmetics/AdditiveOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/arithmetics/AdditiveOperationIterator.java
@@ -105,6 +105,12 @@ public class AdditiveOperationIterator extends AtMostOneItemLocalRuntimeIterator
             );
             throw new NonAtomicKeyException(message, getMetadata());
         }
+        if (this.left.isUntypedAtomic()) {
+            this.left = ItemFactory.getInstance().createDoubleItem(this.left.castToDoubleValue());
+        }
+        if (this.right.isUntypedAtomic()) {
+            this.right = ItemFactory.getInstance().createDoubleItem(this.right.castToDoubleValue());
+        }
         Item result = processItem(this.left, this.right, this.isMinus);
         if (result == null) {
             throw new UnexpectedTypeException(

--- a/src/main/java/org/rumbledb/runtime/arithmetics/MultiplicativeOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/arithmetics/MultiplicativeOperationIterator.java
@@ -106,6 +106,12 @@ public class MultiplicativeOperationIterator extends AtMostOneItemLocalRuntimeIt
             );
             throw new NonAtomicKeyException(message, getMetadata());
         }
+        if (this.left.isUntypedAtomic()) {
+            this.left = ItemFactory.getInstance().createDoubleItem(this.left.castToDoubleValue());
+        }
+        if (this.right.isUntypedAtomic()) {
+            this.right = ItemFactory.getInstance().createDoubleItem(this.right.castToDoubleValue());
+        }
         return processItem(this.left, this.right, this.multiplicativeOperator, getMetadata());
     }
 

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/SumFunctionIterator.java
@@ -121,9 +121,15 @@ public class SumFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         Item result = null;
         while (iterator.hasNext()) {
             Item nextValue = iterator.next();
+            if (nextValue.isUntypedAtomic()) {
+                nextValue = ItemFactory.getInstance().createDoubleItem(nextValue.castToDoubleValue());
+            }
             if (result == null) {
                 result = nextValue;
             } else {
+                if (result.isUntypedAtomic()) {
+                    result = ItemFactory.getInstance().createDoubleItem(result.castToDoubleValue());
+                }
                 Item sum = AdditiveOperationIterator.processItem(result, nextValue, false);
                 if (sum == null) {
                     throw new InvalidArgumentTypeException(

--- a/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError5.jq
+++ b/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError5.jq
@@ -1,4 +1,0 @@
-(:JIQS: ShouldCrash; ErrorCode="FORG0006"; ErrorMetadata="LINE:2:COLUMN:0:" :)
-avg((2, 3, [1, 2]))
-
-(: non-numeric error :)

--- a/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError6.jq
+++ b/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError6.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="FORG0006"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:2:COLUMN:0:" :)
 avg((2, 3, {"a": 4}))
 
 (: non-numeric error :)

--- a/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError6.jq
+++ b/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError6.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:2:COLUMN:5:" :)
 avg((2, 3, {"a": 4}))
 
 (: non-numeric error :)

--- a/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError7.jq
+++ b/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError7.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="FORG0006"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:2:COLUMN:0:" :)
 avg((2, 3, {"a": 4}))
 
 (: non-numeric error :)

--- a/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError7.jq
+++ b/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageError7.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:2:COLUMN:5:" :)
 avg((2, 3, {"a": 4}))
 
 (: non-numeric error :)

--- a/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageWithArray.jq
+++ b/src/test/resources/test_files/runtime/FunctionSequence/Aggregate/AggregateAverageWithArray.jq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="2" :)
+avg((2, 3, [1, 2]))
+
+(: items are converted to atomic values, and the average is computed over all atomic values in the sequence :)

--- a/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error10.jq
+++ b/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error10.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="JNTY0004"; ErrorMetadata="LINE:4:COLUMN:0:":)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:4:COLUMN:0:":)
 declare function fn1() {3};
 declare function fn2() {5};
 5 = fn2#0

--- a/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error11.jq
+++ b/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error11.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="JNTY0004"; ErrorMetadata="LINE:4:COLUMN:0:":)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:4:COLUMN:0:":)
 declare function fn1() {3};
 declare function fn2() {5};
 fn1#0 = 3

--- a/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error12.jq
+++ b/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error12.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="JNTY0004"; ErrorMetadata="LINE:4:COLUMN:0:":)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:4:COLUMN:0:":)
 declare function fn1() {3};
 declare function fn2() {5};
 fn1#0 = true

--- a/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error13.jq
+++ b/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error13.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="JNTY0004"; ErrorMetadata="LINE:4:COLUMN:0:":)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:4:COLUMN:0:":)
 declare function fn1() {3};
 declare function fn2() {5};
 fn1#0 = "fn1"

--- a/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error9.jq
+++ b/src/test/resources/test_files/runtime/FunctionUserDefinedDynamic/NamedFunctionRef-Error9.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="JNTY0004"; ErrorMetadata="LINE:4:COLUMN:0:":)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:4:COLUMN:0:":)
 declare function fn1() {3};
 declare function fn2() {5};
 fn1#0 = fn2#0

--- a/src/test/resources/test_files/runtime/Operational/AdditiveOpError2.jq
+++ b/src/test/resources/test_files/runtime/Operational/AdditiveOpError2.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="JNTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:2:COLUMN:0:" :)
 {"a":1} + 5
 
 (: non-numeric error :)

--- a/src/test/resources/test_files/runtime/Operational/Comparisons/ErrorValueComparisonArrayType.jq
+++ b/src/test/resources/test_files/runtime/Operational/Comparisons/ErrorValueComparisonArrayType.jq
@@ -1,2 +1,2 @@
-(:JIQS: ShouldCrash; ErrorCode="JNTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
 [4,5] lt 2

--- a/src/test/resources/test_files/runtime/Operational/Comparisons/ErrorValueComparisonObjectType.jq
+++ b/src/test/resources/test_files/runtime/Operational/Comparisons/ErrorValueComparisonObjectType.jq
@@ -1,2 +1,2 @@
-(:JIQS: ShouldCrash; ErrorCode="JNTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:2:COLUMN:0:" :)
 {"a":2} ne 2

--- a/src/test/resources/test_files/runtime/Operational/MultiplicativeOpError2.jq
+++ b/src/test/resources/test_files/runtime/Operational/MultiplicativeOpError2.jq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldCrash; ErrorCode="JNTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(:JIQS: ShouldCrash; ErrorCode="FOTY0013"; ErrorMetadata="LINE:2:COLUMN:0:" :)
 {"a":1} * 5
 
 (: non-numeric error :)


### PR DESCRIPTION
If any of two elements to be compared is not atomic, wrap it with a `data()` function at runtime. 

I had to update the errorcode of some tests because previously they expect JNTY0004, and now it's returning `FOTY0013`.

According to official W3C doc:

> err:FOTY0013, The argument to fn:data() contains a function item.
Raised by [fn:data](https://www.w3.org/TR/xpath-functions-30/#func-data), or by **implicit atomization**, if the sequence to be atomized contains a function item.

So this should be fine.