### PR TITLE
Fix element constructor and missing space between atomic elements

### DIFF
--- a/src/main/java/org/rumbledb/expressions/xml/ComputedNamespaceConstructorExpression.java
+++ b/src/main/java/org/rumbledb/expressions/xml/ComputedNamespaceConstructorExpression.java
@@ -101,7 +101,14 @@ public class ComputedNamespaceConstructorExpression extends Expression {
 
     @Override
     public List<Node> getChildren() {
-        return new ArrayList<>();
+        List<Node> result = new ArrayList<>();
+        if (this.prefixExpression != null) {
+            result.add(this.prefixExpression);
+        }
+        if (this.uriExpression != null) {
+            result.add(this.uriExpression);
+        }
+        return result;
     }
 
     @Override
@@ -120,4 +127,3 @@ public class ComputedNamespaceConstructorExpression extends Expression {
         sb.append(" }\n");
     }
 }
-

--- a/src/main/java/org/rumbledb/items/xml/ElementItem.java
+++ b/src/main/java/org/rumbledb/items/xml/ElementItem.java
@@ -408,8 +408,12 @@ public class ElementItem implements Item {
 
     private boolean hasConflictingPrefix(Name name, String prefix, String uri) {
         return name != null
-            && (name.getPrefix() == null ? prefix.isEmpty() : name.getPrefix().equals(prefix))
-            && !uri.equals(name.getNamespace());
+            && normalizeNamespaceComponent(name.getPrefix()).equals(normalizeNamespaceComponent(prefix))
+            && !normalizeNamespaceComponent(uri).equals(normalizeNamespaceComponent(name.getNamespace()));
+    }
+
+    private String normalizeNamespaceComponent(String value) {
+        return value == null ? "" : value;
     }
 
     private String freshPrefix() {

--- a/src/main/java/org/rumbledb/items/xml/ElementItem.java
+++ b/src/main/java/org/rumbledb/items/xml/ElementItem.java
@@ -392,7 +392,33 @@ public class ElementItem implements Item {
         if (this.namespaces == null) {
             this.namespaces = new HashMap<>();
         }
-        this.namespaces.put(namespace.getPrefix(), namespace.getUri());
+        String prefix = namespace.getPrefix();
+        String uri = namespace.getUri();
+
+        // Namespace declarations can conflict with the prefix retained in a
+        // constructed element/attribute QName. Preserve the expanded name by
+        // assigning a fresh prefix and declaring it for the original URI.
+        if (hasConflictingPrefix(this.dmNodeName, prefix, uri)) {
+            String replacement = freshPrefix();
+            this.dmNodeName = new Name(this.dmNodeName.getNamespace(), replacement, this.dmNodeName.getLocalName());
+            this.namespaces.put(replacement, this.dmNodeName.getNamespace());
+        }
+        this.namespaces.put(prefix, uri);
+    }
+
+    private boolean hasConflictingPrefix(Name name, String prefix, String uri) {
+        return name != null
+            && (name.getPrefix() == null ? prefix.isEmpty() : name.getPrefix().equals(prefix))
+            && !uri.equals(name.getNamespace());
+    }
+
+    private String freshPrefix() {
+        int counter = 0;
+        String candidate;
+        do {
+            candidate = "ns" + counter++;
+        } while (this.namespaces.containsKey(candidate));
+        return candidate;
     }
 
 

--- a/src/main/java/org/rumbledb/runtime/xml/DirElemConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/DirElemConstructorRuntimeIterator.java
@@ -82,6 +82,7 @@ public class DirElemConstructorRuntimeIterator extends AtMostOneItemLocalRuntime
         if (this.content != null) {
             StringBuilder textAccumulator = null;
             boolean hasSeenNonAttributeNode = false;
+            boolean previousItemWasAtomic = false;
 
             for (RuntimeIterator iterator : this.content) {
                 iterator.open(contextToUse);
@@ -116,6 +117,7 @@ public class DirElemConstructorRuntimeIterator extends AtMostOneItemLocalRuntime
 
                         // skip empty text content according to XML spec
                         if (textContent.isEmpty()) {
+                            previousItemWasAtomic = item.isAtomic();
                             continue;
                         }
 
@@ -124,9 +126,13 @@ public class DirElemConstructorRuntimeIterator extends AtMostOneItemLocalRuntime
                             textAccumulator = new StringBuilder();
                         }
 
+                        if (item.isAtomic() && previousItemWasAtomic) {
+                            textAccumulator.append(' ');
+                        }
                         // accumulate the text content
                         textAccumulator.append(textContent);
                         hasSeenNonAttributeNode = true;
+                        previousItemWasAtomic = item.isAtomic();
                     } else {
                         hasSeenNonAttributeNode = true;
                         // non-text node encountered
@@ -143,6 +149,7 @@ public class DirElemConstructorRuntimeIterator extends AtMostOneItemLocalRuntime
 
                         // add the non-text node
                         content.add(item);
+                        previousItemWasAtomic = false;
                     }
                 }
                 iterator.close();

--- a/src/main/java/org/rumbledb/runtime/xml/DirElemConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/DirElemConstructorRuntimeIterator.java
@@ -82,9 +82,9 @@ public class DirElemConstructorRuntimeIterator extends AtMostOneItemLocalRuntime
         if (this.content != null) {
             StringBuilder textAccumulator = null;
             boolean hasSeenNonAttributeNode = false;
-            boolean previousItemWasAtomic = false;
 
             for (RuntimeIterator iterator : this.content) {
+                boolean previousItemWasAtomic = false;
                 iterator.open(contextToUse);
                 while (iterator.hasNext()) {
                     Item item = iterator.next();


### PR DESCRIPTION
A space was missing between atomic elements inside a element constructor.

And check is added to prevent prefix collision in element constructor