### PR TITLE
Fix unparsed-text tests

### DIFF
--- a/src/main/java/org/rumbledb/compiler/VisitorHelpers.java
+++ b/src/main/java/org/rumbledb/compiler/VisitorHelpers.java
@@ -136,16 +136,24 @@ public class VisitorHelpers {
         System.err.println(node.getStaticContext());
     }
 
+    private static URI resolveStaticBaseUri(String url, RumbleRuntimeConfiguration configuration) {
+        URI resolved = FileSystemUtil.resolveURIAgainstWorkingDirectory(
+            url,
+            configuration,
+            ExceptionMetadata.EMPTY_METADATA
+        );
+        if (url != null && url.endsWith("/") && !resolved.toString().endsWith("/")) {
+            resolved = URI.create(resolved + "/");
+        }
+        return resolved;
+    }
+
     public static MainModule parseMainModuleFromLocation(URI location, RumbleRuntimeConfiguration configuration)
             throws IOException {
         InputStream in = FileSystemUtil.getDataInputStream(location, configuration, ExceptionMetadata.EMPTY_METADATA);
         String query = IOUtils.toString(in, StandardCharsets.UTF_8.name());
         if (configuration.getStaticBaseUri() != null) {
-            location = FileSystemUtil.resolveURIAgainstWorkingDirectory(
-                configuration.getStaticBaseUri(),
-                configuration,
-                ExceptionMetadata.EMPTY_METADATA
-            );
+            location = resolveStaticBaseUri(configuration.getStaticBaseUri(), configuration);
         }
         return parseMainModule(query, location, configuration);
     }
@@ -160,11 +168,7 @@ public class VisitorHelpers {
         InputStream in = FileSystemUtil.getDataInputStream(location, configuration, metadata);
         String query = IOUtils.toString(in, StandardCharsets.UTF_8.name());
         if (configuration.getStaticBaseUri() != null) {
-            location = FileSystemUtil.resolveURIAgainstWorkingDirectory(
-                configuration.getStaticBaseUri(),
-                configuration,
-                ExceptionMetadata.EMPTY_METADATA
-            );
+            location = resolveStaticBaseUri(configuration.getStaticBaseUri(), configuration);
         }
         return parseLibraryModule(query, location, importingModuleContext, configuration);
     }
@@ -174,11 +178,7 @@ public class VisitorHelpers {
         if (configuration.getStaticBaseUri() != null) {
             url = configuration.getStaticBaseUri();
         }
-        URI location = FileSystemUtil.resolveURIAgainstWorkingDirectory(
-            url,
-            configuration,
-            ExceptionMetadata.EMPTY_METADATA
-        );
+        URI location = resolveStaticBaseUri(url, configuration);
         return parseMainModule(query, location, configuration);
     }
 

--- a/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
+++ b/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
@@ -789,14 +789,14 @@ public class BuiltinFunctionCatalogue {
         new Name(Name.FN_NS, "fn", "unparsed-text-lines"),
         List.of("string?"),
         "string*",
-        org.rumbledb.runtime.functions.io.UnparsedTextLinesFunctionIterator.class,
+        UnparsedTextLinesFunctionIterator.class,
         BuiltinFunction.BuiltinFunctionExecutionMode.RDD
     );
     static final BuiltinFunction unparsed_text_lines2 = createBuiltinFunction(
         new Name(Name.FN_NS, "fn", "unparsed-text-lines"),
         List.of("string?", "string"),
         "string*",
-        org.rumbledb.runtime.functions.io.UnparsedTextLinesFunctionIterator.class,
+        UnparsedTextLinesFunctionIterator.class,
         BuiltinFunction.BuiltinFunctionExecutionMode.RDD
     );
     static final BuiltinFunction text_file1 = createBuiltinFunction(

--- a/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
+++ b/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
@@ -789,14 +789,14 @@ public class BuiltinFunctionCatalogue {
         new Name(Name.FN_NS, "fn", "unparsed-text-lines"),
         List.of("string?"),
         "string*",
-        UnparsedTextLinesFunctionIterator.class,
+        org.rumbledb.runtime.functions.io.UnparsedTextLinesFunctionIterator.class,
         BuiltinFunction.BuiltinFunctionExecutionMode.RDD
     );
     static final BuiltinFunction unparsed_text_lines2 = createBuiltinFunction(
         new Name(Name.FN_NS, "fn", "unparsed-text-lines"),
         List.of("string?", "string"),
         "string*",
-        UnparsedTextLinesFunctionIterator.class,
+        org.rumbledb.runtime.functions.io.UnparsedTextLinesFunctionIterator.class,
         BuiltinFunction.BuiltinFunctionExecutionMode.RDD
     );
     static final BuiltinFunction text_file1 = createBuiltinFunction(
@@ -4087,16 +4087,16 @@ public class BuiltinFunctionCatalogue {
 
     static final BuiltinFunction innermost = createBuiltinFunction(
         new Name(Name.FN_NS, "fn", "innermost"),
-        List.of("item*"),
-        "item*",
+        List.of("node()*"),
+        "node()*",
         InnermostFunctionIterator.class,
         BuiltinFunction.BuiltinFunctionExecutionMode.LOCAL
     );
 
     static final BuiltinFunction outermost = createBuiltinFunction(
         new Name(Name.FN_NS, "fn", "outermost"),
-        List.of("item*"),
-        "item*",
+        List.of("node()*"),
+        "node()*",
         OutermostFunctionIterator.class,
         BuiltinFunction.BuiltinFunctionExecutionMode.LOCAL
     );

--- a/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
+++ b/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
@@ -119,6 +119,7 @@ public final class ErrorCode implements Serializable {
     public static final ErrorCode InvalidXMLRepresentationOfJSON = registerBuiltIn("FOJS0006");
     public static final ErrorCode InvalidEscapeSequenceJSON = registerBuiltIn("FOJS0007");
     public static final ErrorCode UnavailableResourceErrorCode = registerBuiltIn("FOUT1170");
+    public static final ErrorCode InvalidEncodingErrorCode = registerBuiltIn("FOUT1190");
     public static final ErrorCode CannotInferEncodingErrorCode = registerBuiltIn("FOUT1200");
 
     public static final ErrorCode StringOfJSONiqItemsErrorCode = registerBuiltIn("JNTY0024");

--- a/src/main/java/org/rumbledb/exceptions/InvalidEncodingException.java
+++ b/src/main/java/org/rumbledb/exceptions/InvalidEncodingException.java
@@ -1,0 +1,12 @@
+package org.rumbledb.exceptions;
+
+import org.rumbledb.errorcodes.ErrorCode;
+
+public class InvalidEncodingException extends RumbleException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidEncodingException(String message, ExceptionMetadata metadata) {
+        super(message, ErrorCode.InvalidEncodingErrorCode, metadata);
+    }
+}

--- a/src/main/java/org/rumbledb/runtime/functions/io/TextResourceUtil.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/TextResourceUtil.java
@@ -1,0 +1,88 @@
+package org.rumbledb.runtime.functions.io;
+
+import org.rumbledb.config.RumbleRuntimeConfiguration;
+import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.runtime.functions.input.FileSystemUtil;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+
+public final class TextResourceUtil {
+
+    private TextResourceUtil() {
+    }
+
+    public static byte[] fetchBytes(URI uri, RumbleRuntimeConfiguration conf, ExceptionMetadata metadata)
+            throws IOException {
+        try (InputStream is = FileSystemUtil.getDataInputStream(uri, conf, metadata)) {
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            byte[] data = new byte[8192];
+            int nRead;
+            while ((nRead = is.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+            return buffer.toByteArray();
+        }
+    }
+
+    public static CharsetDecoder strictDecoder(Charset charset) {
+        return charset.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT);
+    }
+
+    public static String decodeStrict(byte[] bytes, Charset charset) throws CharacterCodingException {
+        return strictDecoder(charset).decode(ByteBuffer.wrap(bytes)).toString();
+    }
+
+    /**
+     * Detects the resource encoding as required by fn:json-doc and fn:unparsed-text: UTF-8, UTF-16, or UTF-32,
+     * from a leading byte-order mark or from the NUL pattern of the first
+     * bytes.
+     */
+    public static Charset detectEncoding(byte[] b) {
+        int b0 = b.length > 0 ? b[0] & 0xFF : -1;
+        int b1 = b.length > 1 ? b[1] & 0xFF : -1;
+        int b2 = b.length > 2 ? b[2] & 0xFF : -1;
+        int b3 = b.length > 3 ? b[3] & 0xFF : -1;
+
+        if (b0 == 0x00 && b1 == 0x00 && b2 == 0xFE && b3 == 0xFF) {
+            return Charset.forName("UTF-32BE");
+        }
+        if (b0 == 0xFF && b1 == 0xFE && b2 == 0x00 && b3 == 0x00) {
+            return Charset.forName("UTF-32LE");
+        }
+        if (b0 == 0xFE && b1 == 0xFF) {
+            return StandardCharsets.UTF_16BE;
+        }
+        if (b0 == 0xFF && b1 == 0xFE) {
+            return StandardCharsets.UTF_16LE;
+        }
+        if (b0 == 0xEF && b1 == 0xBB && b2 == 0xBF) {
+            return StandardCharsets.UTF_8;
+        }
+
+        if (b0 == 0x00 && b1 == 0x00 && b2 == 0x00 && b3 > 0x00) {
+            return Charset.forName("UTF-32BE");
+        }
+        if (b0 > 0x00 && b1 == 0x00 && b2 == 0x00 && b3 == 0x00) {
+            return Charset.forName("UTF-32LE");
+        }
+        if (b0 == 0x00 && b1 > 0x00) {
+            return StandardCharsets.UTF_16BE;
+        }
+        if (b0 > 0x00 && b1 == 0x00) {
+            return StandardCharsets.UTF_16LE;
+        }
+
+        return StandardCharsets.UTF_8;
+    }
+}

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextAvailableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextAvailableFunctionIterator.java
@@ -6,11 +6,8 @@ import org.rumbledb.context.RuntimeStaticContext;
 import org.rumbledb.items.ItemFactory;
 import org.rumbledb.runtime.AtMostOneItemLocalRuntimeIterator;
 import org.rumbledb.runtime.RuntimeIterator;
-import org.rumbledb.runtime.functions.input.FileSystemUtil;
 
 import java.io.Serial;
-import java.net.URI;
-import java.nio.charset.Charset;
 import java.util.List;
 
 public class UnparsedTextAvailableFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
@@ -30,18 +27,20 @@ public class UnparsedTextAvailableFunctionIterator extends AtMostOneItemLocalRun
         if (hrefItem == null) {
             return ItemFactory.getInstance().createBooleanItem(false);
         }
+        String encoding = null;
         if (this.children.size() == 2) {
             Item encodingItem = this.children.get(1).materializeFirstItemOrNull(context);
-            try {
-                Charset.forName(encodingItem.getStringValue());
-            } catch (Exception e) {
-                return ItemFactory.getInstance().createBooleanItem(false);
-            }
+            encoding = encodingItem.getStringValue();
         }
         try {
-            String href = hrefItem.getStringValue();
-            URI uri = href.isEmpty() ? this.staticURI : FileSystemUtil.resolveURI(this.staticURI, href, getMetadata());
-            FileSystemUtil.readContent(uri, getConfiguration(), getMetadata());
+            UnparsedTextReader.read(
+                this.staticURI,
+                hrefItem.getStringValue(),
+                encoding,
+                context.getRumbleRuntimeConfiguration(),
+                getConfiguration().getXmlVersion(),
+                getMetadata()
+            );
             return ItemFactory.getInstance().createBooleanItem(true);
         } catch (Exception e) {
             return ItemFactory.getInstance().createBooleanItem(false);

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextFunctionIterator.java
@@ -24,21 +24,15 @@ package org.rumbledb.runtime.functions.io;
 import org.rumbledb.api.Item;
 import org.rumbledb.context.DynamicContext;
 import org.rumbledb.context.RuntimeStaticContext;
-import org.rumbledb.exceptions.IteratorFlowException;
 import org.rumbledb.items.ItemFactory;
+import org.rumbledb.runtime.AtMostOneItemLocalRuntimeIterator;
 import org.rumbledb.runtime.RuntimeIterator;
-import org.rumbledb.runtime.functions.base.LocalFunctionCallIterator;
-import org.rumbledb.runtime.functions.input.FileSystemUtil;
 
-import java.net.URI;
 import java.util.List;
 
-public class UnparsedTextFunctionIterator extends LocalFunctionCallIterator {
+public class UnparsedTextFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
-
-    private transient Item path;
 
     public UnparsedTextFunctionIterator(
             List<RuntimeIterator> arguments,
@@ -48,48 +42,25 @@ public class UnparsedTextFunctionIterator extends LocalFunctionCallIterator {
     }
 
     @Override
-    public void open(DynamicContext context) {
-        super.open(context);
-        this.iterator = this.children.get(0);
-        this.path = this.iterator.materializeFirstItemOrNull(context);
-        this.hasNext = this.path != null;
-    }
-
-    @Override
-    public void reset(DynamicContext context) {
-        super.reset(context);
-        this.iterator = this.children.get(0);
-        this.path = this.iterator.materializeFirstItemOrNull(context);
-        this.hasNext = this.path != null;
-    }
-
-    @Override
-    public void close() {
-        super.close();
-        this.path = null;
-    }
-
-    @Override
-    public Item next() {
-        if (this.hasNext) {
-            URI uri = FileSystemUtil.resolveURI(
-                this.staticURI,
-                this.path.getStringValue(),
-                getMetadata()
-            );
-            String result = FileSystemUtil.readContent(
-                uri,
-                this.currentDynamicContextForLocalExecution.getRumbleRuntimeConfiguration(),
-                getMetadata()
-            );
-            this.hasNext = false;
-            return ItemFactory.getInstance().createStringItem(result);
+    public Item materializeFirstItemOrNull(DynamicContext context) {
+        Item hrefItem = this.children.get(0).materializeFirstItemOrNull(context);
+        if (hrefItem == null) {
+            return null;
         }
-        throw new IteratorFlowException(
-                RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " unparsed-text function",
-                getMetadata()
+        String encoding = null;
+        if (this.children.size() == 2) {
+            Item encodingItem = this.children.get(1).materializeFirstItemOrNull(context);
+            encoding = encodingItem.getStringValue();
+        }
+
+        String result = UnparsedTextReader.read(
+            this.staticURI,
+            hrefItem.getStringValue(),
+            encoding,
+            context.getRumbleRuntimeConfiguration(),
+            getConfiguration().getXmlVersion(),
+            getMetadata()
         );
+        return ItemFactory.getInstance().createStringItem(result);
     }
-
-
 }

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextLinesFunctionIterator.java
@@ -1,0 +1,68 @@
+package org.rumbledb.runtime.functions.io;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.rumbledb.api.Item;
+import org.rumbledb.context.DynamicContext;
+import org.rumbledb.context.RuntimeStaticContext;
+import org.rumbledb.items.parsing.StringToStringItemMapper;
+import org.rumbledb.runtime.RDDRuntimeIterator;
+import org.rumbledb.runtime.RuntimeIterator;
+
+import sparksoniq.spark.SparkSessionManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class UnparsedTextLinesFunctionIterator extends RDDRuntimeIterator {
+
+    private static final long serialVersionUID = 1L;
+    private static final Pattern LINE_SPLIT_PATTERN = Pattern.compile("\r\n|\r|\n");
+
+    public UnparsedTextLinesFunctionIterator(
+            List<RuntimeIterator> arguments,
+            RuntimeStaticContext staticContext
+    ) {
+        super(arguments, staticContext);
+    }
+
+    @Override
+    public JavaRDD<Item> getRDDAux(DynamicContext context) {
+        RuntimeIterator hrefIterator = this.children.get(0);
+        Item hrefItem = hrefIterator.materializeFirstItemOrNull(context);
+        if (hrefItem == null) {
+            return SparkSessionManager.getInstance()
+                .getJavaSparkContext()
+                .emptyRDD();
+        }
+        String encoding = null;
+        if (this.children.size() == 2) {
+            Item encodingItem = this.children.get(1).materializeFirstItemOrNull(context);
+            encoding = encodingItem.getStringValue();
+        }
+
+        String text = UnparsedTextReader.read(
+            this.staticURI,
+            hrefItem.getStringValue(),
+            encoding,
+            context.getRumbleRuntimeConfiguration(),
+            getConfiguration().getXmlVersion(),
+            getMetadata()
+        );
+
+        String[] split = LINE_SPLIT_PATTERN.split(text, -1);
+        List<String> lines = new ArrayList<>(split.length);
+        int last = split.length - 1;
+        for (int i = 0; i < split.length; i++) {
+            if (i == last && split[i].isEmpty()) {
+                continue;
+            }
+            lines.add(split[i]);
+        }
+
+        return SparkSessionManager.getInstance()
+            .getJavaSparkContext()
+            .parallelize(lines)
+            .mapPartitions(new StringToStringItemMapper());
+    }
+}

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextReader.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextReader.java
@@ -1,0 +1,131 @@
+package org.rumbledb.runtime.functions.io;
+
+import org.rumbledb.config.RumbleRuntimeConfiguration;
+import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.exceptions.InvalidEncodingException;
+import org.rumbledb.exceptions.RumbleException;
+import org.rumbledb.exceptions.UnavailableResourceException;
+import org.rumbledb.runtime.functions.input.FileSystemUtil;
+import org.rumbledb.runtime.xml.XMLUtils;
+
+import java.net.URI;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
+
+public final class UnparsedTextReader {
+
+    private UnparsedTextReader() {
+    }
+
+
+    private static URI resolveHref(URI staticBaseUri, String href, ExceptionMetadata metadata) {
+        if (href.isEmpty()) {
+            return staticBaseUri;
+        }
+        return FileSystemUtil.resolveURI(staticBaseUri, href, metadata);
+    }
+
+    public static String read(
+            URI staticBaseUri,
+            String href,
+            String encoding,
+            RumbleRuntimeConfiguration conf,
+            String xmlVersion,
+            ExceptionMetadata metadata
+    ) {
+        URI uri;
+        try {
+            uri = resolveHref(staticBaseUri, href, metadata);
+        } catch (UnavailableResourceException e) {
+            throw e;
+        } catch (RumbleException e) {
+            UnavailableResourceException ex = new UnavailableResourceException(e.getMessage(), metadata);
+            ex.initCause(e);
+            throw ex;
+        } catch (Exception e) {
+            UnavailableResourceException ex = new UnavailableResourceException(
+                    "The URI supplied to fn:unparsed-text() is invalid or cannot be resolved: " + href,
+                    metadata
+            );
+            ex.initCause(e);
+            throw ex;
+        }
+
+        if (uri.getFragment() != null) {
+            throw new UnavailableResourceException(
+                    "A URI containing a fragment identifier is not valid for fn:unparsed-text().",
+                    metadata
+            );
+        }
+
+        byte[] bytes;
+        try {
+            bytes = TextResourceUtil.fetchBytes(uri, conf, metadata);
+        } catch (UnavailableResourceException e) {
+            throw e;
+        } catch (RumbleException e) {
+            UnavailableResourceException ex = new UnavailableResourceException(e.getMessage(), metadata);
+            ex.initCause(e);
+            throw ex;
+        } catch (Exception e) {
+            UnavailableResourceException ex = new UnavailableResourceException(
+                    "Unable to retrieve the resource supplied to fn:unparsed-text(): " + uri,
+                    metadata
+            );
+            ex.initCause(e);
+            throw ex;
+        }
+
+        Charset charset;
+        if (encoding != null) {
+            try {
+                charset = Charset.forName(encoding);
+            } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+                InvalidEncodingException ex = new InvalidEncodingException(
+                        "Invalid or unsupported encoding supplied to fn:unparsed-text(): " + encoding,
+                        metadata
+                );
+                ex.initCause(e);
+                throw ex;
+            }
+        } else {
+            charset = TextResourceUtil.detectEncoding(bytes);
+        }
+
+        String decoded;
+        try {
+            decoded = TextResourceUtil.decodeStrict(bytes, charset);
+        } catch (CharacterCodingException e) {
+            InvalidEncodingException ex = new InvalidEncodingException(
+                    "Unable to decode the resource supplied to fn:unparsed-text() using encoding "
+                        + charset.name()
+                        + ".",
+                    metadata
+            );
+            ex.initCause(e);
+            throw ex;
+        }
+
+        if (!decoded.isEmpty() && decoded.charAt(0) == '\uFEFF') {
+            decoded = decoded.substring(1);
+        }
+
+        int i = 0;
+        while (i < decoded.length()) {
+            int codepoint = decoded.codePointAt(i);
+            if (!XMLUtils.isValidXmlCharacter(codepoint, xmlVersion)) {
+                throw new InvalidEncodingException(
+                        "The resource supplied to fn:unparsed-text() contains a character "
+                            + "that is not permitted in XML: U+"
+                            + Integer.toHexString(codepoint).toUpperCase(),
+                        metadata
+                );
+            }
+            i += Character.charCount(codepoint);
+        }
+
+        return decoded;
+    }
+}


### PR DESCRIPTION
Makes `fn:unparsed-text`, `fn:unparsed-text-lines`, and `fn:unparsed-text-available` more compliant with F&O 3.1 (§14.6.5–14.6.7). Also introduces a dedicated `unparsed-text-lines` class instead of reusing the shared `jn:text-file` class (which crashed on string encoding). Encoding detection/decoding is now shared between `fn:json-doc` and the `unparsed-text*` family via `TextResourceUtil` instead of being duplicated. Additionally includes a trailing-slash fix in `VisitorHelpers` for base-URI resolution of relative hrefs.