### PR TITLE
Use different iterators for `jn:text-file` and `fn:unparsed-text-line` and fix URI parsing

### DIFF
--- a/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
+++ b/src/main/java/org/rumbledb/context/BuiltinFunctionCatalogue.java
@@ -84,6 +84,7 @@ import org.rumbledb.runtime.functions.input.PostgreSQLTableFunctionIterator;
 import org.rumbledb.runtime.functions.input.RepartitionFunctionIterator;
 import org.rumbledb.runtime.functions.input.RootFileFunctionIterator;
 import org.rumbledb.runtime.functions.input.StructuredJsonLinesFunctionIterator;
+import org.rumbledb.runtime.functions.input.TextFileFunctionIterator;
 import org.rumbledb.runtime.functions.input.UnparsedTextLinesFunctionIterator;
 import org.rumbledb.runtime.functions.input.XmlFilesFunctionIterator;
 import org.rumbledb.runtime.functions.io.CollectionFunctionIterator;
@@ -803,14 +804,14 @@ public class BuiltinFunctionCatalogue {
         new Name(Name.JN_NS, "jn", "text-file"),
         List.of("string"),
         "item*",
-        UnparsedTextLinesFunctionIterator.class,
+        TextFileFunctionIterator.class,
         BuiltinFunction.BuiltinFunctionExecutionMode.RDD
     );
     static final BuiltinFunction text_file2 = createBuiltinFunction(
         new Name(Name.JN_NS, "jn", "text-file"),
         List.of("string", "integer?"),
         "item*",
-        UnparsedTextLinesFunctionIterator.class,
+        TextFileFunctionIterator.class,
         BuiltinFunction.BuiltinFunctionExecutionMode.RDD
     );
     /**

--- a/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
+++ b/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
@@ -119,6 +119,7 @@ public final class ErrorCode implements Serializable {
     public static final ErrorCode InvalidXMLRepresentationOfJSON = registerBuiltIn("FOJS0006");
     public static final ErrorCode InvalidEscapeSequenceJSON = registerBuiltIn("FOJS0007");
     public static final ErrorCode UnavailableResourceErrorCode = registerBuiltIn("FOUT1170");
+    public static final ErrorCode InvalidEncodingErrorCode = registerBuiltIn("FOUT1190");
     public static final ErrorCode CannotInferEncodingErrorCode = registerBuiltIn("FOUT1200");
 
     public static final ErrorCode StringOfJSONiqItemsErrorCode = registerBuiltIn("JNTY0024");

--- a/src/main/java/org/rumbledb/exceptions/InvalidEncodingException.java
+++ b/src/main/java/org/rumbledb/exceptions/InvalidEncodingException.java
@@ -1,0 +1,12 @@
+package org.rumbledb.exceptions;
+
+import org.rumbledb.errorcodes.ErrorCode;
+
+public class InvalidEncodingException extends RumbleException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidEncodingException(String message, ExceptionMetadata metadata) {
+        super(message, ErrorCode.InvalidEncodingErrorCode, metadata);
+    }
+}

--- a/src/main/java/org/rumbledb/runtime/functions/URIUtils.java
+++ b/src/main/java/org/rumbledb/runtime/functions/URIUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rumbledb.runtime.functions;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public final class URIUtils {
+
+    private URIUtils() {
+    }
+
+    /**
+     * Parses a URI reference and, when it is relative, resolves it against an absolute base URI.
+     *
+     * @param baseURI the base URI; it may be {@code null} when {@code reference} is absolute
+     * @param reference a URI reference
+     * @return an absolute URI
+     * @throws URISyntaxException if the reference is malformed or cannot be resolved to an absolute URI
+     */
+    public static URI resolveURIReference(URI baseURI, String reference) throws URISyntaxException {
+        if (reference == null) {
+            throw new URISyntaxException("null", "The URI reference cannot be null");
+        }
+
+        URI referenceURI = new URI(reference);
+        if (referenceURI.isAbsolute()) {
+            return referenceURI;
+        }
+
+        if (baseURI == null || !baseURI.isAbsolute()) {
+            throw new URISyntaxException(
+                    reference,
+                    "A relative URI reference requires an absolute base URI"
+            );
+        }
+
+        URI resolvedURI = baseURI.resolve(referenceURI);
+        if (!resolvedURI.isAbsolute()) {
+            throw new URISyntaxException(reference, "The URI reference could not be resolved to an absolute URI");
+        }
+        return resolvedURI;
+    }
+}

--- a/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rumbledb.runtime.functions.input;
+
+import org.apache.spark.api.java.JavaRDD;
+import org.rumbledb.api.Item;
+import org.rumbledb.context.DynamicContext;
+import org.rumbledb.context.RuntimeStaticContext;
+import org.rumbledb.exceptions.CannotRetrieveResourceException;
+import org.rumbledb.items.parsing.StringToStringItemMapper;
+import org.rumbledb.runtime.RDDRuntimeIterator;
+import org.rumbledb.runtime.RuntimeIterator;
+
+import sparksoniq.spark.SparkSessionManager;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Implements the Rumble-specific jn:text-file() function. */
+public class TextFileFunctionIterator extends RDDRuntimeIterator {
+
+    private static final long serialVersionUID = 1L;
+    public static final int MIN_PARTITIONS = 10;
+
+    public TextFileFunctionIterator(
+            List<RuntimeIterator> arguments,
+            RuntimeStaticContext staticContext
+    ) {
+        super(arguments, staticContext);
+    }
+
+    @Override
+    public JavaRDD<Item> getRDDAux(DynamicContext context) {
+        RuntimeIterator urlIterator = this.children.get(0);
+        Item url = urlIterator.materializeFirstItemOrNull(context);
+        if (url == null) {
+            return SparkSessionManager.getInstance()
+                .getJavaSparkContext()
+                .emptyRDD();
+        }
+        URI uri = FileSystemUtil.resolveURI(this.staticURI, url.getStringValue(), getMetadata());
+        int partitions = -1;
+        if (this.children.size() > 1) {
+            Item partitionsItem = this.children.get(1).materializeFirstItemOrNull(context);
+            if (partitionsItem != null) {
+                partitions = partitionsItem.getIntValue();
+            }
+        }
+
+        JavaRDD<String> strings;
+        if ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme())) {
+            InputStream is = FileSystemUtil.getDataInputStream(
+                uri,
+                context.getRumbleRuntimeConfiguration(),
+                getMetadata()
+            );
+            BufferedReader br = new BufferedReader(new InputStreamReader(is));
+            List<String> lines = new ArrayList<>();
+            String line;
+            try {
+                while ((line = br.readLine()) != null) {
+                    lines.add(line);
+                }
+            } catch (IOException e) {
+                throw new CannotRetrieveResourceException("Cannot read " + uri, getMetadata());
+            }
+            if (partitions == -1) {
+                strings = SparkSessionManager.getInstance()
+                    .getJavaSparkContext()
+                    .parallelize(lines);
+            } else {
+                strings = SparkSessionManager.getInstance()
+                    .getJavaSparkContext()
+                    .parallelize(lines, partitions);
+            }
+        } else {
+            if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
+                throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
+            }
+
+            int effectivePartitions = partitions == -1 ? MIN_PARTITIONS : partitions;
+            strings = SparkSessionManager.getInstance()
+                .getJavaSparkContext()
+                .textFile(FileSystemUtil.convertURIToStringForSpark(uri), effectivePartitions);
+        }
+        return strings.mapPartitions(new StringToStringItemMapper());
+    }
+}

--- a/src/main/java/org/rumbledb/runtime/functions/input/UnparsedTextLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/UnparsedTextLinesFunctionIterator.java
@@ -30,6 +30,7 @@ import org.rumbledb.exceptions.UnavailableResourceException;
 import org.rumbledb.items.parsing.StringToStringItemMapper;
 import org.rumbledb.runtime.RDDRuntimeIterator;
 import org.rumbledb.runtime.RuntimeIterator;
+import org.rumbledb.runtime.functions.URIUtils;
 
 import sparksoniq.spark.SparkSessionManager;
 
@@ -115,16 +116,12 @@ public class UnparsedTextLinesFunctionIterator extends RDDRuntimeIterator {
 
     private URI resolveURI(String href) {
         try {
-            URI reference = new URI(href);
-            if (reference.getFragment() != null) {
+            URI uri = URIUtils.resolveURIReference(this.staticURI, href);
+            if (uri.getFragment() != null) {
                 throw new URISyntaxException(href, "Fragment identifiers are not allowed");
             }
-            URI resolvedURI = this.staticURI.resolve(reference);
-            if (!resolvedURI.isAbsolute()) {
-                throw new URISyntaxException(href, "The URI cannot be resolved against an absolute static base URI");
-            }
-            return resolvedURI;
-        } catch (URISyntaxException | IllegalArgumentException | NullPointerException e) {
+            return uri;
+        } catch (URISyntaxException e) {
             UnavailableResourceException ex = new UnavailableResourceException(
                     "Invalid URI supplied to fn:unparsed-text-lines(): " + href,
                     getMetadata()

--- a/src/main/java/org/rumbledb/runtime/functions/input/UnparsedTextLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/UnparsedTextLinesFunctionIterator.java
@@ -24,7 +24,9 @@ import org.apache.spark.api.java.JavaRDD;
 import org.rumbledb.api.Item;
 import org.rumbledb.context.DynamicContext;
 import org.rumbledb.context.RuntimeStaticContext;
-import org.rumbledb.exceptions.CannotRetrieveResourceException;
+import org.rumbledb.exceptions.InvalidEncodingException;
+import org.rumbledb.exceptions.RumbleException;
+import org.rumbledb.exceptions.UnavailableResourceException;
 import org.rumbledb.items.parsing.StringToStringItemMapper;
 import org.rumbledb.runtime.RDDRuntimeIterator;
 import org.rumbledb.runtime.RuntimeIterator;
@@ -36,6 +38,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -60,62 +65,89 @@ public class UnparsedTextLinesFunctionIterator extends RDDRuntimeIterator {
                 .getJavaSparkContext()
                 .emptyRDD();
         }
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url.getStringValue(), getMetadata());
-        int partitions = -1;
-        if (this.children.size() > 1) {
-            partitions = this.children.get(1).materializeFirstItemOrNull(context).getIntValue();
-        }
 
-        JavaRDD<String> strings;
-        if (uri.getScheme().equals("http") || uri.getScheme().equals("https")) {
-            InputStream is = FileSystemUtil.getDataInputStream(
-                uri,
-                context.getRumbleRuntimeConfiguration(),
-                getMetadata()
-            );
-            BufferedReader br = new BufferedReader(new InputStreamReader(is));
-            List<String> lines = new ArrayList<>();
-            String line = null;
-            try {
-                while ((line = br.readLine()) != null) {
-                    lines.add(line);
+        try {
+            URI uri = resolveURI(url.getStringValue());
+            Charset charset = getCharset(context);
+            JavaRDD<String> strings;
+            if (this.children.size() == 2 || "http".equals(uri.getScheme()) || "https".equals(uri.getScheme())) {
+                List<String> lines = new ArrayList<>();
+                try (
+                    InputStream is = FileSystemUtil.getDataInputStream(
+                        uri,
+                        context.getRumbleRuntimeConfiguration(),
+                        getMetadata()
+                    );
+                    BufferedReader br = new BufferedReader(new InputStreamReader(is, charset))
+                ) {
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        lines.add(line);
+                    }
                 }
-            } catch (IOException e) {
-                throw new CannotRetrieveResourceException("Cannot read " + uri, getMetadata());
-            }
-            if (partitions == -1) {
                 strings = SparkSessionManager.getInstance()
                     .getJavaSparkContext()
                     .parallelize(lines);
             } else {
-                strings = SparkSessionManager.getInstance()
-                    .getJavaSparkContext()
-                    .parallelize(
-                        lines,
-                        partitions
-                    );
-            }
-        } else {
-            if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
-                throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
-            }
-
-            if (this.children.size() == 1) {
+                if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
+                    throw new UnavailableResourceException("File " + uri + " not found.", getMetadata());
+                }
                 strings = SparkSessionManager.getInstance()
                     .getJavaSparkContext()
                     .textFile(FileSystemUtil.convertURIToStringForSpark(uri), MIN_PARTITIONS);
-            } else {
-                RuntimeIterator partitionsIterator = this.children.get(1);
-                partitionsIterator.open(context);
-                strings = SparkSessionManager.getInstance()
-                    .getJavaSparkContext()
-                    .textFile(
-                        FileSystemUtil.convertURIToStringForSpark(uri),
-                        partitionsIterator.next().getIntValue()
-                    );
-                partitionsIterator.close();
             }
+            return strings.mapPartitions(new StringToStringItemMapper());
+        } catch (InvalidEncodingException | UnavailableResourceException e) {
+            throw e;
+        } catch (RumbleException e) {
+            UnavailableResourceException ex = new UnavailableResourceException(e.getMessage(), getMetadata());
+            ex.initCause(e);
+            throw ex;
+        } catch (IOException e) {
+            UnavailableResourceException ex = new UnavailableResourceException(
+                    "Unable to read the resource supplied to fn:unparsed-text-lines().",
+                    getMetadata()
+            );
+            ex.initCause(e);
+            throw ex;
         }
-        return strings.mapPartitions(new StringToStringItemMapper());
+    }
+
+    private URI resolveURI(String href) {
+        try {
+            URI reference = new URI(href);
+            if (reference.getFragment() != null) {
+                throw new URISyntaxException(href, "Fragment identifiers are not allowed");
+            }
+            URI resolvedURI = this.staticURI.resolve(reference);
+            if (!resolvedURI.isAbsolute()) {
+                throw new URISyntaxException(href, "The URI cannot be resolved against an absolute static base URI");
+            }
+            return resolvedURI;
+        } catch (URISyntaxException | IllegalArgumentException | NullPointerException e) {
+            UnavailableResourceException ex = new UnavailableResourceException(
+                    "Invalid URI supplied to fn:unparsed-text-lines(): " + href,
+                    getMetadata()
+            );
+            ex.initCause(e);
+            throw ex;
+        }
+    }
+
+    private Charset getCharset(DynamicContext context) {
+        if (this.children.size() == 1) {
+            return StandardCharsets.UTF_8;
+        }
+        Item encoding = this.children.get(1).materializeFirstItemOrNull(context);
+        try {
+            return Charset.forName(encoding.getStringValue());
+        } catch (Exception e) {
+            InvalidEncodingException ex = new InvalidEncodingException(
+                    "Invalid encoding supplied to fn:unparsed-text-lines(): " + encoding.getStringValue(),
+                    getMetadata()
+            );
+            ex.initCause(e);
+            throw ex;
+        }
     }
 }


### PR DESCRIPTION
Previously both uses `UnparsedTextLinesFunctionIterator`. They should not share the same iterator because the second argument has a different meaning (encoding vs num of partitions).

Also, we should probably switch to Java URI implementation instead of Hadoop one, because there are tests failing because Hadoop URI does not support Windows style path.