### PR TITLE
Add ResourceResolver and ModuleImportLoader classes to centralize URI and module import logic

### DIFF
--- a/.github/workflows/run-qt3.yml
+++ b/.github/workflows/run-qt3.yml
@@ -104,7 +104,7 @@ jobs:
 
   qt3-jsoniq:
     needs: [resolve-baseline, build]
-    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@master
+    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@jimmy/resource-resolver
     with:
       tested_parser: jsoniq
       rumble_artifact_name: rumble-build
@@ -112,7 +112,7 @@ jobs:
 
   qt3-xquery:
     needs: [resolve-baseline, build]
-    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@master
+    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@jimmy/resource-resolver
     with:
       tested_parser: xquery
       rumble_artifact_name: rumble-build

--- a/.github/workflows/run-qt3.yml
+++ b/.github/workflows/run-qt3.yml
@@ -104,7 +104,7 @@ jobs:
 
   qt3-jsoniq:
     needs: [resolve-baseline, build]
-    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@jimmy/resource-resolver
+    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@master
     with:
       tested_parser: jsoniq
       rumble_artifact_name: rumble-build
@@ -112,7 +112,7 @@ jobs:
 
   qt3-xquery:
     needs: [resolve-baseline, build]
-    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@jimmy/resource-resolver
+    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@master
     with:
       tested_parser: xquery
       rumble_artifact_name: rumble-build

--- a/src/main/java/org/rumbledb/api/Rumble.java
+++ b/src/main/java/org/rumbledb/api/Rumble.java
@@ -2,9 +2,11 @@ package org.rumbledb.api;
 
 import org.apache.spark.sql.SparkSession;
 import org.rumbledb.compiler.VisitorHelpers;
+import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
 import org.rumbledb.context.DynamicContext;
 import org.rumbledb.expressions.module.MainModule;
+import org.rumbledb.resources.ResourceResolver;
 import org.rumbledb.runtime.RuntimeIterator;
 
 import sparksoniq.spark.SparkSessionManager;
@@ -25,6 +27,7 @@ import java.net.URI;
 public class Rumble {
 
     private RumbleRuntimeConfiguration configuration;
+    private CompilationConfiguration compilationConfiguration;
 
     /**
      * Creates a new Rumble instance. This initializes a brand new Spark session.
@@ -32,7 +35,27 @@ public class Rumble {
      * @param configuration a RumbleRuntimeConfiguration object containing the configuration.
      */
     public Rumble(RumbleRuntimeConfiguration configuration) {
-        this.configuration = configuration;
+        this(new CompilationConfiguration(configuration));
+    }
+
+    /**
+     * Creates a new Rumble instance with a custom resolver for imported resources.
+     *
+     * @param configuration a RumbleRuntimeConfiguration object containing the configuration.
+     * @param resourceResolver the resolver used for imported modules and schemas.
+     */
+    public Rumble(RumbleRuntimeConfiguration configuration, ResourceResolver resourceResolver) {
+        this(new CompilationConfiguration(configuration, resourceResolver));
+    }
+
+    /**
+     * Creates a new Rumble instance with explicit compilation configuration.
+     *
+     * @param compilationConfiguration the configuration used to compile queries.
+     */
+    public Rumble(CompilationConfiguration compilationConfiguration) {
+        this.compilationConfiguration = compilationConfiguration;
+        this.configuration = compilationConfiguration.runtimeConfiguration();
         SparkSessionManager.getInstance().getOrCreateSession();
     }
 
@@ -42,6 +65,7 @@ public class Rumble {
      */
     public Rumble(SparkSession session) {
         this.configuration = new RumbleRuntimeConfiguration();
+        this.compilationConfiguration = new CompilationConfiguration(this.configuration);
         SparkSessionManager.getInstance(session);
     }
 
@@ -63,7 +87,7 @@ public class Rumble {
     public SequenceOfItems runQuery(String query) {
         MainModule mainModule = VisitorHelpers.parseMainModuleFromQuery(
             query,
-            this.configuration
+            this.compilationConfiguration
         );
         DynamicContext dynamicContext = VisitorHelpers.createDynamicContext(mainModule, this.configuration);
         RuntimeIterator iterator = VisitorHelpers.generateRuntimeIterator(
@@ -84,7 +108,7 @@ public class Rumble {
     public SequenceOfItems runQuery(URI location) throws IOException {
         MainModule mainModule = VisitorHelpers.parseMainModuleFromLocation(
             location,
-            this.configuration
+            this.compilationConfiguration
         );
         DynamicContext dynamicContext = VisitorHelpers.createDynamicContext(mainModule, this.configuration);
         RuntimeIterator iterator = VisitorHelpers.generateRuntimeIterator(
@@ -104,7 +128,7 @@ public class Rumble {
     public String serializeToJSONiq(String query) {
         MainModule mainModule = VisitorHelpers.parseMainModuleFromQuery(
             query,
-            this.configuration
+            this.compilationConfiguration
         );
         StringBuilder sb = new StringBuilder();
         mainModule.serializeToJSONiq(sb, 0);

--- a/src/main/java/org/rumbledb/api/Rumble.java
+++ b/src/main/java/org/rumbledb/api/Rumble.java
@@ -1,5 +1,6 @@
 package org.rumbledb.api;
 
+import lombok.Getter;
 import org.apache.spark.sql.SparkSession;
 import org.rumbledb.compiler.VisitorHelpers;
 import org.rumbledb.config.CompilationConfiguration;
@@ -25,6 +26,7 @@ import java.net.URI;
  */
 public class Rumble {
 
+    @Getter
     private RumbleRuntimeConfiguration configuration;
     private CompilationConfiguration compilationConfiguration;
 
@@ -56,15 +58,6 @@ public class Rumble {
         this.configuration = new RumbleRuntimeConfiguration();
         this.compilationConfiguration = new CompilationConfiguration(this.configuration);
         SparkSessionManager.getInstance(session);
-    }
-
-    /**
-     * Gets the configuration
-     * 
-     * @return the configuration
-     */
-    public RumbleRuntimeConfiguration getConfiguration() {
-        return this.configuration;
     }
 
     /**

--- a/src/main/java/org/rumbledb/api/Rumble.java
+++ b/src/main/java/org/rumbledb/api/Rumble.java
@@ -6,7 +6,6 @@ import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
 import org.rumbledb.context.DynamicContext;
 import org.rumbledb.expressions.module.MainModule;
-import org.rumbledb.resources.ResourceResolver;
 import org.rumbledb.runtime.RuntimeIterator;
 
 import sparksoniq.spark.SparkSessionManager;
@@ -36,16 +35,6 @@ public class Rumble {
      */
     public Rumble(RumbleRuntimeConfiguration configuration) {
         this(new CompilationConfiguration(configuration));
-    }
-
-    /**
-     * Creates a new Rumble instance with a custom resolver for imported resources.
-     *
-     * @param configuration a RumbleRuntimeConfiguration object containing the configuration.
-     * @param resourceResolver the resolver used for imported modules and schemas.
-     */
-    public Rumble(RumbleRuntimeConfiguration configuration, ResourceResolver resourceResolver) {
-        this(new CompilationConfiguration(configuration, resourceResolver));
     }
 
     /**

--- a/src/main/java/org/rumbledb/compiler/InferTypeVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/InferTypeVisitor.java
@@ -758,7 +758,11 @@ public class InferTypeVisitor extends AbstractNodeVisitor<StaticContext> {
                 && args.get(0) instanceof StringLiteralExpression stringLiteralExpr
         ) {
             String path = stringLiteralExpr.getValue();
-            URI uri = FileSystemUtil.resolveURI(staticContext.getStaticBaseURI(), path, expression.getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(
+                staticContext.getStaticBaseURI(),
+                path,
+                expression.getMetadata()
+            );
             if (!FileSystemUtil.exists(uri, this.rumbleRuntimeConfiguration, expression.getMetadata())) {
                 return false;
             }
@@ -784,7 +788,11 @@ public class InferTypeVisitor extends AbstractNodeVisitor<StaticContext> {
                 && args.get(0) instanceof StringLiteralExpression stringLiteralExpr
         ) {
             String path = stringLiteralExpr.getValue();
-            URI uri = FileSystemUtil.resolveURI(staticContext.getStaticBaseURI(), path, expression.getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(
+                staticContext.getStaticBaseURI(),
+                path,
+                expression.getMetadata()
+            );
             if (!FileSystemUtil.exists(uri, this.rumbleRuntimeConfiguration, expression.getMetadata())) {
                 return false;
             }

--- a/src/main/java/org/rumbledb/compiler/ModuleImportLoader.java
+++ b/src/main/java/org/rumbledb/compiler/ModuleImportLoader.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+package org.rumbledb.compiler;
+
+import org.rumbledb.config.CompilationConfiguration;
+import org.rumbledb.context.StaticContext;
+import org.rumbledb.exceptions.CannotRetrieveResourceException;
+import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.exceptions.ModuleNotFoundException;
+import org.rumbledb.exceptions.RumbleException;
+import org.rumbledb.expressions.module.LibraryModule;
+import org.rumbledb.runtime.functions.input.FileSystemUtil;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+/** Shared module import semantics for the JSONiq and XQuery frontends. */
+final class ModuleImportLoader {
+
+    private ModuleImportLoader() {
+    }
+
+    public static LibraryModule load(
+            String namespace,
+            List<String> locationHints,
+            StaticContext importingModuleContext,
+            CompilationConfiguration compilationConfiguration,
+            ExceptionMetadata metadata
+    ) {
+        URI baseURI = importingModuleContext.getStaticBaseURI();
+        URI namespaceURI = FileSystemUtil.resolveURI(baseURI, namespace, metadata);
+        List<String> candidates = locationHints.isEmpty() ? List.of(namespace) : locationHints;
+        Exception lastFailure = null;
+
+        for (String candidate : candidates) {
+            URI location = FileSystemUtil.resolveURI(baseURI, candidate, metadata);
+            try {
+                LibraryModule module = VisitorHelpers.parseLibraryModuleFromLocation(
+                    location,
+                    importingModuleContext,
+                    compilationConfiguration,
+                    metadata
+                );
+                validateNamespace(namespaceURI, module, metadata);
+                return module;
+            } catch (IOException | CannotRetrieveResourceException e) {
+                lastFailure = e;
+            }
+        }
+
+        RumbleException exception = new ModuleNotFoundException(
+                "Module not found: " + namespace + failureMessage(lastFailure),
+                metadata
+        );
+        if (lastFailure != null) {
+            exception.initCause(lastFailure);
+        }
+        throw exception;
+    }
+
+    private static void validateNamespace(
+            URI expectedNamespace,
+            LibraryModule module,
+            ExceptionMetadata metadata
+    ) {
+        if (expectedNamespace.toString().equals(module.getNamespace())) {
+            return;
+        }
+        throw new ModuleNotFoundException(
+                "A module with namespace "
+                    + expectedNamespace
+                    + " was not found. The namespace of the module at this location was: "
+                    + module.getNamespace(),
+                metadata
+        );
+    }
+
+    private static String failureMessage(Exception failure) {
+        if (failure == null || failure.getMessage() == null) {
+            return "";
+        }
+        return " Cause: " + failure.getMessage();
+    }
+}

--- a/src/main/java/org/rumbledb/compiler/ModuleImportLoader.java
+++ b/src/main/java/org/rumbledb/compiler/ModuleImportLoader.java
@@ -47,7 +47,17 @@ final class ModuleImportLoader {
                     compilationConfiguration,
                     metadata
                 );
-                validateNamespace(namespaceURI, module, metadata);
+
+                if (!namespaceURI.toString().equals(module.getNamespace())) {
+                    throw new ModuleNotFoundException(
+                            "A module with namespace "
+                                + namespaceURI
+                                + " was not found. The namespace of the module at this location was: "
+                                + module.getNamespace(),
+                            metadata
+                    );
+                }
+
                 return module;
             } catch (IOException | CannotRetrieveResourceException e) {
                 lastFailure = e;
@@ -55,36 +65,15 @@ final class ModuleImportLoader {
         }
 
         RumbleException exception = new ModuleNotFoundException(
-                "Module not found: " + namespace + failureMessage(lastFailure),
+                "Module not found: %s, cause: %s".formatted(
+                    namespaceURI,
+                    lastFailure != null ? lastFailure.getMessage() : "unknown"
+                ),
                 metadata
         );
         if (lastFailure != null) {
             exception.initCause(lastFailure);
         }
         throw exception;
-    }
-
-    private static void validateNamespace(
-            URI expectedNamespace,
-            LibraryModule module,
-            ExceptionMetadata metadata
-    ) {
-        if (expectedNamespace.toString().equals(module.getNamespace())) {
-            return;
-        }
-        throw new ModuleNotFoundException(
-                "A module with namespace "
-                    + expectedNamespace
-                    + " was not found. The namespace of the module at this location was: "
-                    + module.getNamespace(),
-                metadata
-        );
-    }
-
-    private static String failureMessage(Exception failure) {
-        if (failure == null || failure.getMessage() == null) {
-            return "";
-        }
-        return " Cause: " + failure.getMessage();
     }
 }

--- a/src/main/java/org/rumbledb/compiler/ModuleImportLoader.java
+++ b/src/main/java/org/rumbledb/compiler/ModuleImportLoader.java
@@ -14,7 +14,6 @@ import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.ModuleNotFoundException;
 import org.rumbledb.exceptions.RumbleException;
 import org.rumbledb.expressions.module.LibraryModule;
-import org.rumbledb.runtime.functions.input.FileSystemUtil;
 
 import java.io.IOException;
 import java.net.URI;
@@ -34,12 +33,12 @@ final class ModuleImportLoader {
             ExceptionMetadata metadata
     ) {
         URI baseURI = importingModuleContext.getStaticBaseURI();
-        URI namespaceURI = FileSystemUtil.resolveURI(baseURI, namespace, metadata);
+        URI namespaceURI = URILiteralUtils.resolve(baseURI, namespace, metadata);
         List<String> candidates = locationHints.isEmpty() ? List.of(namespace) : locationHints;
         Exception lastFailure = null;
 
         for (String candidate : candidates) {
-            URI location = FileSystemUtil.resolveURI(baseURI, candidate, metadata);
+            URI location = URILiteralUtils.resolve(baseURI, candidate, metadata);
             try {
                 LibraryModule module = VisitorHelpers.parseLibraryModuleFromLocation(
                     location,

--- a/src/main/java/org/rumbledb/compiler/ModuleImportLoader.java
+++ b/src/main/java/org/rumbledb/compiler/ModuleImportLoader.java
@@ -7,6 +7,7 @@
 
 package org.rumbledb.compiler;
 
+import org.rumbledb.compiler.utils.URILiteralUtils;
 import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.context.StaticContext;
 import org.rumbledb.exceptions.CannotRetrieveResourceException;

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -28,6 +28,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.rumbledb.api.Item;
+import org.rumbledb.compiler.utils.URILiteralUtils;
 import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
 import org.rumbledb.context.FunctionIdentifier;

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -28,6 +28,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.rumbledb.api.Item;
+import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
 import org.rumbledb.context.FunctionIdentifier;
 import org.rumbledb.context.Name;
@@ -185,7 +186,6 @@ import org.rumbledb.types.ItemTypeFactory;
 import org.rumbledb.types.ItemTypeReference;
 import org.rumbledb.types.SequenceType;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.ArrayList;
@@ -210,7 +210,9 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     private StaticContext moduleContext;
     private RumbleRuntimeConfiguration configuration;
+    private CompilationConfiguration compilationConfiguration;
     private boolean isMainModule;
+    private String libraryModuleNamespace;
     private String code;
     private ArrayDeque<Map<String, String>> dirElemNamespaceFrames;
     private final CommonTokenStream jsoniqTokenStream;
@@ -218,23 +220,24 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     public TranslationVisitor(
             StaticContext moduleContext,
             boolean isMainModule,
-            RumbleRuntimeConfiguration configuration,
+            CompilationConfiguration compilationConfiguration,
             String code,
             CommonTokenStream jsoniqTokenStream
     ) {
         this.moduleContext = moduleContext;
         this.moduleContext.bindDefaultNamespaces();
-        this.configuration = configuration;
+        this.compilationConfiguration = compilationConfiguration;
+        this.configuration = compilationConfiguration.runtimeConfiguration();
         this.isMainModule = isMainModule;
         this.code = code;
         this.dirElemNamespaceFrames = new ArrayDeque<>();
         this.jsoniqTokenStream = jsoniqTokenStream;
 
-        if (configuration.getQueryLanguage().equals("jsoniq10")) {
+        if (this.configuration.getQueryLanguage().equals("jsoniq10")) {
             this.moduleContext.setQueryLanguage("jsoniq10");
-        } else if (configuration.getQueryLanguage().equals("jsoniq31")) {
+        } else if (this.configuration.getQueryLanguage().equals("jsoniq31")) {
             this.moduleContext.setQueryLanguage("jsoniq31");
-        } else if (configuration.getQueryLanguage().equals("jsoniq40")) {
+        } else if (this.configuration.getQueryLanguage().equals("jsoniq40")) {
             this.moduleContext.setQueryLanguage("jsoniq40");
         }
     }
@@ -375,6 +378,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
             namespace,
             createMetadataFromContext(ctx)
         );
+        this.libraryModuleNamespace = resolvedURI.toString();
         bindNamespace(
             prefix,
             resolvedURI.toString(),
@@ -474,16 +478,15 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
                     annotatedDeclaration.varDecl()
                 );
                 if (!this.isMainModule) {
-                    String moduleNamespace = this.moduleContext.getStaticBaseURI().toString();
                     String variableNamespace = variableDeclaration.getVariableName().getNamespace();
-                    if (variableNamespace == null || !variableNamespace.equals(moduleNamespace)) {
+                    if (variableNamespace == null || !variableNamespace.equals(this.libraryModuleNamespace)) {
                         throw new NamespaceDoesNotMatchModuleException(
                                 "Variable "
                                     + variableDeclaration.getVariableName().getLocalName()
                                     + ": namespace "
                                     + variableNamespace
                                     + " must match module namespace "
-                                    + moduleNamespace,
+                                    + this.libraryModuleNamespace,
                                 createMetadataFromContext(annotatedDeclaration.varDecl())
                         );
                     }
@@ -499,16 +502,15 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
                     annotatedDeclaration.functionDecl()
                 );
                 if (!this.isMainModule) {
-                    String moduleNamespace = this.moduleContext.getStaticBaseURI().toString();
                     String functionNamespace = inlineFunctionExpression.getName().getNamespace();
-                    if (functionNamespace == null || !functionNamespace.equals(moduleNamespace)) {
+                    if (functionNamespace == null || !functionNamespace.equals(this.libraryModuleNamespace)) {
                         throw new NamespaceDoesNotMatchModuleException(
                                 "Function "
                                     + inlineFunctionExpression.getName().getLocalName()
                                     + ": namespace "
                                     + functionNamespace
                                     + " must match module namespace "
-                                    + moduleNamespace,
+                                    + this.libraryModuleNamespace,
                                 createMetadataFromContext(annotatedDeclaration.functionDecl())
                         );
                     }
@@ -525,16 +527,15 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
                 );
 
                 if (!this.isMainModule) {
-                    String moduleNamespace = this.moduleContext.getStaticBaseURI().toString();
                     String typeNamespace = typeDeclaration.getDefinition().getName().getNamespace();
-                    if (typeNamespace == null || !typeNamespace.equals(moduleNamespace)) {
+                    if (typeNamespace == null || !typeNamespace.equals(this.libraryModuleNamespace)) {
                         throw new NamespaceDoesNotMatchModuleException(
                                 "Type "
                                     + typeDeclaration.getDefinition().getName().getLocalName()
                                     + ": namespace "
                                     + typeNamespace
                                     + " must match module namespace "
-                                    + moduleNamespace,
+                                    + this.libraryModuleNamespace,
                                 createMetadataFromContext(annotatedDeclaration.typeDecl())
                         );
                     }
@@ -3927,47 +3928,20 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     public LibraryModule processModuleImport(JsoniqParser.ModuleImportContext ctx) {
         String namespace = processURILiteral(ctx.targetNamespace);
-        URI resolvedURI = FileSystemUtil.resolveURI(
-            this.moduleContext.getStaticBaseURI(),
+        List<String> locationHints = ctx.locations.stream()
+            .map(this::processURILiteral)
+            .collect(Collectors.toList());
+        LibraryModule libraryModule = ModuleImportLoader.load(
             namespace,
+            locationHints,
+            this.moduleContext,
+            this.compilationConfiguration,
             createMetadataFromContext(ctx)
         );
-        LibraryModule libraryModule = null;
-        try {
-            libraryModule = VisitorHelpers.parseLibraryModuleFromLocation(
-                resolvedURI,
-                this.configuration,
-                this.moduleContext,
-                createMetadataFromContext(ctx)
-            );
-            if (!resolvedURI.toString().equals(libraryModule.getNamespace())) {
-                throw new ModuleNotFoundException(
-                        "A module with namespace "
-                            + resolvedURI.toString()
-                            + " was not found. The namespace of the module at this location was: "
-                            + libraryModule.getNamespace(),
-                        createMetadataFromContext(ctx)
-                );
-            }
-        } catch (IOException e) {
-            RumbleException exception = new ModuleNotFoundException(
-                    "I/O error while attempting to import a module: " + namespace + " Cause: " + e.getMessage(),
-                    createMetadataFromContext(ctx)
-            );
-            exception.initCause(e);
-            throw exception;
-        } catch (CannotRetrieveResourceException e) {
-            RumbleException exception = new ModuleNotFoundException(
-                    "Module not found: " + namespace + " Cause: " + e.getMessage(),
-                    createMetadataFromContext(ctx)
-            );
-            exception.initCause(e);
-            throw exception;
-        }
         if (ctx.ncName() != null) {
             bindNamespace(
                 ctx.ncName().getText(),
-                resolvedURI.toString(),
+                libraryModule.getNamespace(),
                 createMetadataFromContext(ctx)
             );
         }

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -177,7 +177,6 @@ import org.rumbledb.parser.jsoniq.JsoniqParser.DefaultCollationDeclContext;
 import org.rumbledb.parser.jsoniq.JsoniqParser.EmptyOrderDeclContext;
 import org.rumbledb.parser.jsoniq.JsoniqParser.SetterContext;
 import org.rumbledb.parser.jsoniq.JsoniqParser.UriLiteralContext;
-import org.rumbledb.runtime.functions.input.FileSystemUtil;
 import org.rumbledb.runtime.update.primitives.Mode;
 import org.rumbledb.types.BuiltinTypesCatalogue;
 import org.rumbledb.types.ElementNodeItemType;
@@ -374,7 +373,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         if (namespace.equals("")) {
             throw new EmptyModuleURIException("Module URI is empty.", createMetadataFromContext(ctx));
         }
-        URI resolvedURI = FileSystemUtil.resolveURI(
+        URI resolvedURI = URILiteralUtils.resolve(
             this.moduleContext.getStaticBaseURI(),
             namespace,
             createMetadataFromContext(ctx)
@@ -445,10 +444,10 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
                     );
                 }
                 String uriString = processURILiteral(setterContext.baseURIDecl().uriLiteral());
-                URI uri = FileSystemUtil.resolveURI(
+                URI uri = URILiteralUtils.resolve(
                     this.moduleContext.getStaticBaseURI(),
                     uriString,
-                    ExceptionMetadata.EMPTY_METADATA
+                    createMetadataFromContext(setterContext.baseURIDecl())
                 );
                 this.moduleContext.setStaticBaseUri(uri);
                 baseURISet = true;

--- a/src/main/java/org/rumbledb/compiler/URILiteralUtils.java
+++ b/src/main/java/org/rumbledb/compiler/URILiteralUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+package org.rumbledb.compiler;
+
+import org.rumbledb.exceptions.CannotRetrieveResourceException;
+import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.exceptions.InvalidURILiteralException;
+import org.rumbledb.runtime.functions.input.FileSystemUtil;
+
+import java.net.URI;
+
+final class URILiteralUtils {
+
+    private URILiteralUtils() {
+    }
+
+    static URI resolve(URI baseURI, String literal, ExceptionMetadata metadata) {
+        try {
+            return FileSystemUtil.resolveURI(baseURI, literal, metadata);
+        } catch (CannotRetrieveResourceException exception) {
+            InvalidURILiteralException result = new InvalidURILiteralException(
+                    "Invalid URI literal: " + literal,
+                    metadata
+            );
+            result.initCause(exception);
+            throw result;
+        }
+    }
+}

--- a/src/main/java/org/rumbledb/compiler/VisitorHelpers.java
+++ b/src/main/java/org/rumbledb/compiler/VisitorHelpers.java
@@ -7,6 +7,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.commons.io.IOUtils;
 import org.rumbledb.compiler.wrapper.DescendentSequentialProperties;
+import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
 import org.rumbledb.context.DynamicContext;
 import org.rumbledb.context.FunctionIdentifier;
@@ -28,9 +29,9 @@ import org.rumbledb.parser.xquery.XQueryLexer;
 import org.rumbledb.parser.xquery.XQueryParser;
 import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.runtime.functions.input.FileSystemUtil;
+import org.rumbledb.resources.ResolvedResource;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -148,64 +149,123 @@ public class VisitorHelpers {
         return resolved;
     }
 
-    public static MainModule parseMainModuleFromLocation(URI location, RumbleRuntimeConfiguration configuration)
-            throws IOException {
-        InputStream in = FileSystemUtil.getDataInputStream(location, configuration, ExceptionMetadata.EMPTY_METADATA);
-        String query = IOUtils.toString(in, StandardCharsets.UTF_8.name());
-        if (configuration.getStaticBaseUri() != null) {
-            location = resolveStaticBaseUri(configuration.getStaticBaseUri(), configuration);
-        }
-        return parseMainModule(query, location, configuration);
+    private record ModuleSource(String query, URI systemId) {
     }
 
-    public static LibraryModule parseLibraryModuleFromLocation(
+    private static ModuleSource readModuleSource(
             URI location,
-            RumbleRuntimeConfiguration configuration,
-            StaticContext importingModuleContext,
+            CompilationConfiguration compilationConfiguration,
             ExceptionMetadata metadata
     )
             throws IOException {
-        InputStream in = FileSystemUtil.getDataInputStream(location, configuration, metadata);
-        String query = IOUtils.toString(in, StandardCharsets.UTF_8.name());
-        if (configuration.getStaticBaseUri() != null) {
-            location = resolveStaticBaseUri(configuration.getStaticBaseUri(), configuration);
+        RumbleRuntimeConfiguration configuration = compilationConfiguration.runtimeConfiguration();
+        try (
+            ResolvedResource resource = compilationConfiguration.resourceResolver()
+                .resolve(location, configuration, metadata)
+        ) {
+            String query = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8.name());
+            URI systemId = resource.getSystemId();
+            if (configuration.getStaticBaseUri() != null) {
+                systemId = resolveStaticBaseUri(configuration.getStaticBaseUri(), configuration);
+            }
+            return new ModuleSource(query, systemId);
         }
-        return parseLibraryModule(query, location, importingModuleContext, configuration);
+    }
+
+    private static boolean shouldParseAsXQuery(
+            String query,
+            URI uri,
+            RumbleRuntimeConfiguration configuration
+    ) {
+        if (query.contains("xquery version")) {
+            return true;
+        }
+        if (query.contains("jsoniq version")) {
+            return false;
+        }
+        String location = uri.toString();
+        if (location.endsWith(".xq") || location.endsWith(".xqy") || location.endsWith(".xquery")) {
+            return true;
+        }
+        if (location.endsWith(".jq") || location.endsWith(".jsoniq")) {
+            return false;
+        }
+        return configuration.getQueryLanguage().startsWith("xquery");
+    }
+
+    public static MainModule parseMainModuleFromLocation(URI location, RumbleRuntimeConfiguration configuration)
+            throws IOException {
+        return parseMainModuleFromLocation(location, new CompilationConfiguration(configuration));
+    }
+
+    public static MainModule parseMainModuleFromLocation(
+            URI location,
+            CompilationConfiguration compilationConfiguration
+    )
+            throws IOException {
+        ModuleSource source = readModuleSource(
+            location,
+            compilationConfiguration,
+            ExceptionMetadata.EMPTY_METADATA
+        );
+        return parseMainModule(source.query(), source.systemId(), compilationConfiguration);
+    }
+
+    static LibraryModule parseLibraryModuleFromLocation(
+            URI location,
+            StaticContext importingModuleContext,
+            CompilationConfiguration compilationConfiguration,
+            ExceptionMetadata metadata
+    )
+            throws IOException {
+        ModuleSource source = readModuleSource(location, compilationConfiguration, metadata);
+        return parseLibraryModule(
+            source.query(),
+            source.systemId(),
+            importingModuleContext,
+            compilationConfiguration
+        );
     }
 
     public static MainModule parseMainModuleFromQuery(String query, RumbleRuntimeConfiguration configuration) {
+        return parseMainModuleFromQuery(query, new CompilationConfiguration(configuration));
+    }
+
+    public static MainModule parseMainModuleFromQuery(
+            String query,
+            CompilationConfiguration compilationConfiguration
+    ) {
+        RumbleRuntimeConfiguration configuration = compilationConfiguration.runtimeConfiguration();
         String url = ".";
         if (configuration.getStaticBaseUri() != null) {
             url = configuration.getStaticBaseUri();
         }
         URI location = resolveStaticBaseUri(url, configuration);
-        return parseMainModule(query, location, configuration);
+        return parseMainModule(query, location, compilationConfiguration);
     }
 
     public static MainModule parseMainModule(String query, URI uri, RumbleRuntimeConfiguration configuration) {
-        if (query.contains("xquery version")) {
-            return parseXQueryMainModule(query, uri, configuration);
-        } else if (query.contains("jsoniq version")) {
-            return parseJSONiqMainModule(query, uri, configuration);
-        }
-        if (uri.toString().endsWith(".xq") || uri.toString().endsWith(".xqy") || uri.toString().endsWith(".xquery")) {
-            return parseXQueryMainModule(query, uri, configuration);
-        }
-        if (uri.toString().endsWith(".jq") || uri.toString().endsWith(".jsoniq")) {
-            return parseJSONiqMainModule(query, uri, configuration);
-        } else if (configuration.getQueryLanguage().startsWith("xquery")) {
-            return parseXQueryMainModule(query, uri, configuration);
-        } else {
-            return parseJSONiqMainModule(query, uri, configuration);
-        }
-
+        return parseMainModule(query, uri, new CompilationConfiguration(configuration));
     }
 
-    public static MainModule parseJSONiqMainModule(
+    public static MainModule parseMainModule(
             String query,
             URI uri,
-            RumbleRuntimeConfiguration configuration
+            CompilationConfiguration compilationConfiguration
     ) {
+        RumbleRuntimeConfiguration configuration = compilationConfiguration.runtimeConfiguration();
+        if (shouldParseAsXQuery(query, uri, configuration)) {
+            return parseXQueryMainModule(query, uri, compilationConfiguration);
+        }
+        return parseJSONiqMainModule(query, uri, compilationConfiguration);
+    }
+
+    private static MainModule parseJSONiqMainModule(
+            String query,
+            URI uri,
+            CompilationConfiguration compilationConfiguration
+    ) {
+        RumbleRuntimeConfiguration configuration = compilationConfiguration.runtimeConfiguration();
         CharStream stream = CharStreams.fromString(query);
         JsoniqLexer lexer = new JsoniqLexer(stream);
         CommonTokenStream jsoniqTokens = new CommonTokenStream(lexer);
@@ -215,7 +275,13 @@ public class VisitorHelpers {
         UserDefinedFunctionExecutionModes executionModes = new UserDefinedFunctionExecutionModes();
         executionModes.setQueryLanguage(configuration.getQueryLanguage());
         moduleContext.setUserDefinedFunctionsExecutionModes(executionModes);
-        TranslationVisitor visitor = new TranslationVisitor(moduleContext, true, configuration, query, jsoniqTokens);
+        TranslationVisitor visitor = new TranslationVisitor(
+                moduleContext,
+                true,
+                compilationConfiguration,
+                query,
+                jsoniqTokens
+        );
         try {
             // TODO Handle module extras
             JsoniqParser.ModuleContext modulectx = parser.moduleAndThisIsIt().module();
@@ -313,11 +379,12 @@ public class VisitorHelpers {
         }
     }
 
-    public static MainModule parseXQueryMainModule(
+    private static MainModule parseXQueryMainModule(
             String query,
             URI uri,
-            RumbleRuntimeConfiguration configuration
+            CompilationConfiguration compilationConfiguration
     ) {
+        RumbleRuntimeConfiguration configuration = compilationConfiguration.runtimeConfiguration();
         CharStream stream = CharStreams.fromString(query);
         XQueryLexer lexer = new XQueryLexer(stream);
         CommonTokenStream xQueryTokens = new CommonTokenStream(lexer);
@@ -330,7 +397,7 @@ public class VisitorHelpers {
         XQueryTranslationVisitor visitor = new XQueryTranslationVisitor(
                 moduleContext,
                 true,
-                configuration,
+                compilationConfiguration,
                 query,
                 xQueryTokens
         );
@@ -369,36 +436,26 @@ public class VisitorHelpers {
         }
     }
 
-    public static LibraryModule parseLibraryModule(
+    private static LibraryModule parseLibraryModule(
             String query,
             URI uri,
             StaticContext importingModuleContext,
-            RumbleRuntimeConfiguration configuration
+            CompilationConfiguration compilationConfiguration
     ) {
-        if (query.contains("xquery version")) {
-            return parseXQueryLibraryModule(query, uri, importingModuleContext, configuration);
-        } else if (query.contains("jsoniq version")) {
-            return parseJSONiqLibraryModule(query, uri, importingModuleContext, configuration);
+        RumbleRuntimeConfiguration configuration = compilationConfiguration.runtimeConfiguration();
+        if (shouldParseAsXQuery(query, uri, configuration)) {
+            return parseXQueryLibraryModule(query, uri, importingModuleContext, compilationConfiguration);
         }
-        if (uri.toString().endsWith(".xq") || uri.toString().endsWith(".xqy") || uri.toString().endsWith(".xquery")) {
-            return parseXQueryLibraryModule(query, uri, importingModuleContext, configuration);
-        }
-        if (uri.toString().endsWith(".jq") || uri.toString().endsWith(".jsoniq")) {
-            return parseJSONiqLibraryModule(query, uri, importingModuleContext, configuration);
-        } else if (configuration.getQueryLanguage().startsWith("xquery")) {
-            return parseXQueryLibraryModule(query, uri, importingModuleContext, configuration);
-        } else {
-            return parseJSONiqLibraryModule(query, uri, importingModuleContext, configuration);
-        }
-
+        return parseJSONiqLibraryModule(query, uri, importingModuleContext, compilationConfiguration);
     }
 
-    public static LibraryModule parseJSONiqLibraryModule(
+    private static LibraryModule parseJSONiqLibraryModule(
             String query,
             URI uri,
             StaticContext importingModuleContext,
-            RumbleRuntimeConfiguration configuration
+            CompilationConfiguration compilationConfiguration
     ) {
+        RumbleRuntimeConfiguration configuration = compilationConfiguration.runtimeConfiguration();
         CharStream stream = CharStreams.fromString(query);
         JsoniqLexer lexer = new JsoniqLexer(stream);
         CommonTokenStream jsoniqTokens = new CommonTokenStream(lexer);
@@ -408,7 +465,13 @@ public class VisitorHelpers {
         moduleContext.setUserDefinedFunctionsExecutionModes(
             importingModuleContext.getUserDefinedFunctionsExecutionModes()
         );
-        TranslationVisitor visitor = new TranslationVisitor(moduleContext, false, configuration, query, jsoniqTokens);
+        TranslationVisitor visitor = new TranslationVisitor(
+                moduleContext,
+                false,
+                compilationConfiguration,
+                query,
+                jsoniqTokens
+        );
         try {
             // TODO Handle module extras
             JsoniqParser.ModuleContext main = parser.moduleAndThisIsIt().module();
@@ -431,12 +494,13 @@ public class VisitorHelpers {
         }
     }
 
-    public static LibraryModule parseXQueryLibraryModule(
+    private static LibraryModule parseXQueryLibraryModule(
             String query,
             URI uri,
             StaticContext importingModuleContext,
-            RumbleRuntimeConfiguration configuration
+            CompilationConfiguration compilationConfiguration
     ) {
+        RumbleRuntimeConfiguration configuration = compilationConfiguration.runtimeConfiguration();
         CharStream stream = CharStreams.fromString(query);
         XQueryLexer lexer = new XQueryLexer(stream);
         CommonTokenStream xQueryTokens = new CommonTokenStream(lexer);
@@ -449,7 +513,7 @@ public class VisitorHelpers {
         XQueryTranslationVisitor visitor = new XQueryTranslationVisitor(
                 moduleContext,
                 false,
-                configuration,
+                compilationConfiguration,
                 query,
                 xQueryTokens
         );

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -27,6 +27,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.rumbledb.compiler.utils.URILiteralUtils;
 import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
 import org.rumbledb.context.FunctionIdentifier;

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -27,6 +27,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
 import org.rumbledb.context.FunctionIdentifier;
 import org.rumbledb.context.Name;
@@ -166,7 +167,6 @@ import org.rumbledb.types.SequenceType;
 
 import static org.rumbledb.types.SequenceType.createSequenceType;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.ArrayList;
@@ -190,7 +190,9 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
 
     private StaticContext moduleContext;
     private RumbleRuntimeConfiguration configuration;
+    private CompilationConfiguration compilationConfiguration;
     private boolean isMainModule;
+    private String libraryModuleNamespace;
     private String code;
     private ArrayDeque<Map<String, String>> dirElemNamespaceFrames;
     private final CommonTokenStream xQueryTokenStream;
@@ -198,25 +200,26 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     public XQueryTranslationVisitor(
             StaticContext moduleContext,
             boolean isMainModule,
-            RumbleRuntimeConfiguration configuration,
+            CompilationConfiguration compilationConfiguration,
             String code,
             CommonTokenStream xQueryTokenStream
     ) {
         this.moduleContext = moduleContext;
         this.moduleContext.bindDefaultNamespaces();
-        this.configuration = configuration;
+        this.compilationConfiguration = compilationConfiguration;
+        this.configuration = compilationConfiguration.runtimeConfiguration();
         this.isMainModule = isMainModule;
         this.code = code;
         this.dirElemNamespaceFrames = new ArrayDeque<>();
         this.xQueryTokenStream = xQueryTokenStream;
 
-        if (configuration.getQueryLanguage().equals("xquery10")) {
+        if (this.configuration.getQueryLanguage().equals("xquery10")) {
             this.moduleContext.setQueryLanguage("xquery10");
-        } else if (configuration.getQueryLanguage().equals("xquery30")) {
+        } else if (this.configuration.getQueryLanguage().equals("xquery30")) {
             this.moduleContext.setQueryLanguage("xquery30");
-        } else if (configuration.getQueryLanguage().equals("xquery31")) {
+        } else if (this.configuration.getQueryLanguage().equals("xquery31")) {
             this.moduleContext.setQueryLanguage("xquery31");
-        } else if (configuration.getQueryLanguage().equals("xquery40")) {
+        } else if (this.configuration.getQueryLanguage().equals("xquery40")) {
             this.moduleContext.setQueryLanguage("xquery40");
         }
     }
@@ -359,6 +362,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
             namespace,
             createMetadataFromContext(ctx)
         );
+        this.libraryModuleNamespace = resolvedURI.toString();
         bindNamespace(
             prefix,
             resolvedURI.toString(),
@@ -415,16 +419,15 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
                     annotatedDeclaration.varDecl()
                 );
                 if (!this.isMainModule) {
-                    String moduleNamespace = this.moduleContext.getStaticBaseURI().toString();
                     String variableNamespace = variableDeclaration.getVariableName().getNamespace();
-                    if (variableNamespace == null || !variableNamespace.equals(moduleNamespace)) {
+                    if (variableNamespace == null || !variableNamespace.equals(this.libraryModuleNamespace)) {
                         throw new NamespaceDoesNotMatchModuleException(
                                 "Variable "
                                     + variableDeclaration.getVariableName().getLocalName()
                                     + ": namespace "
                                     + variableNamespace
                                     + " must match module namespace "
-                                    + moduleNamespace,
+                                    + this.libraryModuleNamespace,
                                 createMetadataFromContext(annotatedDeclaration.varDecl())
                         );
                     }
@@ -440,16 +443,15 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
                     annotatedDeclaration.functionDecl()
                 );
                 if (!this.isMainModule) {
-                    String moduleNamespace = this.moduleContext.getStaticBaseURI().toString();
                     String functionNamespace = inlineFunctionExpression.getName().getNamespace();
-                    if (functionNamespace == null || !functionNamespace.equals(moduleNamespace)) {
+                    if (functionNamespace == null || !functionNamespace.equals(this.libraryModuleNamespace)) {
                         throw new NamespaceDoesNotMatchModuleException(
                                 "Function "
                                     + inlineFunctionExpression.getName().getLocalName()
                                     + ": namespace "
                                     + functionNamespace
                                     + " must match module namespace "
-                                    + moduleNamespace,
+                                    + this.libraryModuleNamespace,
                                 createMetadataFromContext(annotatedDeclaration.functionDecl())
                         );
                     }
@@ -3621,47 +3623,20 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
 
     public LibraryModule processModuleImport(XQueryParser.ModuleImportContext ctx) {
         String namespace = processURILiteral(ctx.targetNamespace);
-        URI resolvedURI = FileSystemUtil.resolveURI(
-            this.moduleContext.getStaticBaseURI(),
+        List<String> locationHints = ctx.locations.stream()
+            .map(this::processURILiteral)
+            .collect(Collectors.toList());
+        LibraryModule libraryModule = ModuleImportLoader.load(
             namespace,
+            locationHints,
+            this.moduleContext,
+            this.compilationConfiguration,
             createMetadataFromContext(ctx)
         );
-        LibraryModule libraryModule = null;
-        try {
-            libraryModule = VisitorHelpers.parseLibraryModuleFromLocation(
-                resolvedURI,
-                this.configuration,
-                this.moduleContext,
-                createMetadataFromContext(ctx)
-            );
-            if (!resolvedURI.toString().equals(libraryModule.getNamespace())) {
-                throw new ModuleNotFoundException(
-                        "A module with namespace "
-                            + resolvedURI.toString()
-                            + " was not found. The namespace of the module at this location was: "
-                            + libraryModule.getNamespace(),
-                        createMetadataFromContext(ctx)
-                );
-            }
-        } catch (IOException e) {
-            RumbleException exception = new ModuleNotFoundException(
-                    "I/O error while attempting to import a module: " + namespace + " Cause: " + e.getMessage(),
-                    createMetadataFromContext(ctx)
-            );
-            exception.initCause(e);
-            throw exception;
-        } catch (CannotRetrieveResourceException e) {
-            RumbleException exception = new ModuleNotFoundException(
-                    "Module not found: " + namespace + " Cause: " + e.getMessage(),
-                    createMetadataFromContext(ctx)
-            );
-            exception.initCause(e);
-            throw exception;
-        }
         if (ctx.ncName() != null) {
             bindNamespace(
                 ctx.ncName().getText(),
-                resolvedURI.toString(),
+                libraryModule.getNamespace(),
                 createMetadataFromContext(ctx)
             );
         }

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -157,7 +157,6 @@ import org.rumbledb.parser.xquery.XQueryParser.DefaultCollationDeclContext;
 import org.rumbledb.parser.xquery.XQueryParser.EmptyOrderDeclContext;
 import org.rumbledb.parser.xquery.XQueryParser.SetterContext;
 import org.rumbledb.parser.xquery.XQueryParser.UriLiteralContext;
-import org.rumbledb.runtime.functions.input.FileSystemUtil;
 import org.rumbledb.types.BuiltinTypesCatalogue;
 import org.rumbledb.types.ElementNodeItemType;
 import org.rumbledb.types.FunctionSignature;
@@ -358,7 +357,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         if (namespace.equals("")) {
             throw new EmptyModuleURIException("Module URI is empty.", createMetadataFromContext(ctx));
         }
-        URI resolvedURI = FileSystemUtil.resolveURI(
+        URI resolvedURI = URILiteralUtils.resolve(
             this.moduleContext.getStaticBaseURI(),
             namespace,
             createMetadataFromContext(ctx)
@@ -539,10 +538,10 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
                 );
             }
             String uriString = processURILiteral(setterContext.baseURIDecl().uriLiteral());
-            URI uri = FileSystemUtil.resolveURI(
+            URI uri = URILiteralUtils.resolve(
                 this.moduleContext.getStaticBaseURI(),
                 uriString,
-                ExceptionMetadata.EMPTY_METADATA
+                createMetadataFromContext(setterContext.baseURIDecl())
             );
             this.moduleContext.setStaticBaseUri(uri);
             flags.baseURISet = true;

--- a/src/main/java/org/rumbledb/compiler/utils/URILiteralUtils.java
+++ b/src/main/java/org/rumbledb/compiler/utils/URILiteralUtils.java
@@ -5,7 +5,7 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0.
  */
 
-package org.rumbledb.compiler;
+package org.rumbledb.compiler.utils;
 
 import org.rumbledb.exceptions.CannotRetrieveResourceException;
 import org.rumbledb.exceptions.ExceptionMetadata;
@@ -14,12 +14,12 @@ import org.rumbledb.runtime.functions.input.FileSystemUtil;
 
 import java.net.URI;
 
-final class URILiteralUtils {
+public final class URILiteralUtils {
 
     private URILiteralUtils() {
     }
 
-    static URI resolve(URI baseURI, String literal, ExceptionMetadata metadata) {
+    public static URI resolve(URI baseURI, String literal, ExceptionMetadata metadata) {
         try {
             return FileSystemUtil.resolveURI(baseURI, literal, metadata);
         } catch (CannotRetrieveResourceException exception) {

--- a/src/main/java/org/rumbledb/config/CompilationConfiguration.java
+++ b/src/main/java/org/rumbledb/config/CompilationConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+package org.rumbledb.config;
+
+import org.rumbledb.resources.ResourceResolver;
+
+import java.util.Objects;
+
+/** Configuration and resource resolution services used during compilation. */
+public record CompilationConfiguration(
+        RumbleRuntimeConfiguration runtimeConfiguration,
+        ResourceResolver resourceResolver) {
+
+    public CompilationConfiguration {
+        Objects.requireNonNull(runtimeConfiguration, "runtimeConfiguration must not be null");
+        Objects.requireNonNull(resourceResolver, "resourceResolver must not be null");
+    }
+
+    public CompilationConfiguration(RumbleRuntimeConfiguration runtimeConfiguration) {
+        this(runtimeConfiguration, new ResourceResolver());
+    }
+}

--- a/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
+++ b/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
@@ -186,6 +186,7 @@ public final class ErrorCode implements Serializable {
     public static final ErrorCode DefaultCollationExceptionCode = registerBuiltIn("XQST0038");
     public static final ErrorCode DuplicateParamName = registerBuiltIn("XQST0039");
     public static final ErrorCode AnnotationInReservedNamespaceErrorCode = registerBuiltIn("XQST0045");
+    public static final ErrorCode InvalidURILiteralErrorCode = registerBuiltIn("XQST0046");
     public static final ErrorCode DuplicateModuleTargetNamespace = registerBuiltIn("XQST0047");
     public static final ErrorCode NamespaceDoesNotMatchModule = registerBuiltIn("XQST0048");
     public static final ErrorCode VariableAlreadyExists = registerBuiltIn("XQST0049");

--- a/src/main/java/org/rumbledb/exceptions/InvalidURILiteralException.java
+++ b/src/main/java/org/rumbledb/exceptions/InvalidURILiteralException.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+package org.rumbledb.exceptions;
+
+import org.rumbledb.errorcodes.ErrorCode;
+
+public class InvalidURILiteralException extends RumbleException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidURILiteralException(String message, ExceptionMetadata metadata) {
+        super(message, ErrorCode.InvalidURILiteralErrorCode, metadata);
+    }
+}

--- a/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
+++ b/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
@@ -117,7 +117,7 @@ schemaPrefix: (KW_NAMESPACE ncName EQUAL | KW_DEFAULT KW_ELEMENT KW_NAMESPACE) ;
 moduleImport: KW_IMPORT KW_MODULE
               (KW_NAMESPACE prefix=ncName EQUAL)?
               targetNamespace=uriLiteral
-              (KW_AT uriLiteral (COMMA uriLiteral)*)? ;
+              (KW_AT locations+=uriLiteral (COMMA locations+=uriLiteral)*)? ;
 
 
 namespaceDecl: KW_DECLARE KW_NAMESPACE ncName EQUAL uriLiteral ;

--- a/src/main/java/org/rumbledb/parser/xquery/XQueryParser.g4
+++ b/src/main/java/org/rumbledb/parser/xquery/XQueryParser.g4
@@ -116,7 +116,7 @@ schemaPrefix: (KW_NAMESPACE ncName EQUAL | KW_DEFAULT KW_ELEMENT KW_NAMESPACE) ;
 moduleImport: KW_IMPORT KW_MODULE
               (KW_NAMESPACE prefix=ncName EQUAL)?
               targetNamespace=uriLiteral
-              (KW_AT uriLiteral (COMMA uriLiteral)*)? ;
+              (KW_AT locations+=uriLiteral (COMMA locations+=uriLiteral)*)? ;
 
 
 namespaceDecl: KW_DECLARE KW_NAMESPACE ncName EQUAL uriLiteral ;

--- a/src/main/java/org/rumbledb/resources/ResolvedResource.java
+++ b/src/main/java/org/rumbledb/resources/ResolvedResource.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+package org.rumbledb.resources;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Objects;
+
+public final class ResolvedResource implements AutoCloseable {
+
+    private final URI systemId;
+    private final InputStream inputStream;
+
+    public ResolvedResource(URI systemId, InputStream inputStream) {
+        this.systemId = Objects.requireNonNull(systemId, "systemId must not be null");
+        this.inputStream = Objects.requireNonNull(inputStream, "inputStream must not be null");
+    }
+
+    public URI getSystemId() {
+        return this.systemId;
+    }
+
+    public InputStream getInputStream() {
+        return this.inputStream;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.inputStream.close();
+    }
+}

--- a/src/main/java/org/rumbledb/resources/ResourceResolver.java
+++ b/src/main/java/org/rumbledb/resources/ResourceResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ */
+
+package org.rumbledb.resources;
+
+import org.rumbledb.config.RumbleRuntimeConfiguration;
+import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.runtime.functions.input.FileSystemUtil;
+
+import java.net.URI;
+import java.util.Map;
+
+/** Resolves logical resource URIs to source content used during query compilation. */
+public final class ResourceResolver {
+
+    private final Map<URI, URI> mappings;
+
+    public ResourceResolver() {
+        this(Map.of());
+    }
+
+    public ResourceResolver(Map<URI, URI> mappings) {
+        this.mappings = Map.copyOf(mappings);
+    }
+
+    public ResolvedResource resolve(
+            URI requestedURI,
+            RumbleRuntimeConfiguration configuration,
+            ExceptionMetadata metadata
+    ) {
+        URI physicalURI = this.mappings.getOrDefault(requestedURI, requestedURI);
+        return new ResolvedResource(
+                physicalURI,
+                FileSystemUtil.getDataInputStream(physicalURI, configuration, metadata)
+        );
+    }
+}

--- a/src/main/java/org/rumbledb/runtime/functions/input/AvroFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/AvroFileFunctionIterator.java
@@ -54,7 +54,7 @@ public class AvroFileFunctionIterator extends DataFrameRuntimeIterator {
         Item stringItem = this.children.get(0)
             .materializeFirstItemOrNull(context);
         String url = stringItem.getStringValue();
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }
@@ -69,7 +69,7 @@ public class AvroFileFunctionIterator extends DataFrameRuntimeIterator {
                     Item value = values.get(i);
                     if (value.isString()) {
                         if (keys.get(i).equals("avroSchema")) {
-                            URI schemaURI = FileSystemUtil.resolveURI(
+                            URI schemaURI = FileSystemUtil.resolveFileSystemURI(
                                 this.staticURI,
                                 value.getStringValue(),
                                 getMetadata()

--- a/src/main/java/org/rumbledb/runtime/functions/input/CSVFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/CSVFileFunctionIterator.java
@@ -56,7 +56,7 @@ public class CSVFileFunctionIterator extends DataFrameRuntimeIterator {
         Item stringItem = this.children.get(0)
             .materializeFirstItemOrNull(context);
         String url = stringItem.getStringValue();
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/DeltaFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/DeltaFileFunctionIterator.java
@@ -30,7 +30,7 @@ public class DeltaFileFunctionIterator extends DataFrameRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }
@@ -47,4 +47,3 @@ public class DeltaFileFunctionIterator extends DataFrameRuntimeIterator {
         );
     }
 }
-

--- a/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
@@ -76,6 +76,12 @@ public class FileSystemUtil {
     }
 
     private static URI parseURIReference(String value) throws URISyntaxException {
+        try {
+            return new Path(value).toUri();
+        } catch (HadoopIllegalArgumentException e) {
+            // Fall back to Java URI parsing for URI references Hadoop Path cannot parse.
+            // For example, urn: is a valid URI reference but not a valid Hadoop Path.
+        }
         String escapedValue = value.replace(" ", "%20");
         URI uri = new URI(escapedValue);
         if (!value.equals(escapedValue) && uri.isOpaque()) {

--- a/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
@@ -54,7 +54,7 @@ public class FileSystemUtil {
             );
         }
         try {
-            URI relativeURI = parseURIReference(url);
+            URI relativeURI = parseURI(url);
             URI resolvedURI = base.resolve(relativeURI);
             if (url.endsWith("/")) {
                 // preserve trailing slash if any for correct resolution against it as a directory in the future.
@@ -75,7 +75,7 @@ public class FileSystemUtil {
         }
     }
 
-    private static URI parseURIReference(String value) throws URISyntaxException {
+    private static URI parseURI(String value) throws URISyntaxException {
         try {
             return new Path(value).toUri();
         } catch (HadoopIllegalArgumentException e) {

--- a/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
@@ -53,8 +53,7 @@ public class FileSystemUtil {
             );
         }
         try {
-            Path relativePath = new Path(url);
-            URI relativeURI = relativePath.toUri();
+            URI relativeURI = new URI(url);
             URI resolvedURI = base.resolve(relativeURI);
             if (url.endsWith("/")) {
                 // preserve trailing slash if any for correct resolution against it as a directory in the future.

--- a/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -53,7 +54,7 @@ public class FileSystemUtil {
             );
         }
         try {
-            URI relativeURI = new URI(url);
+            URI relativeURI = parseURIReference(url);
             URI resolvedURI = base.resolve(relativeURI);
             if (url.endsWith("/")) {
                 // preserve trailing slash if any for correct resolution against it as a directory in the future.
@@ -72,6 +73,15 @@ public class FileSystemUtil {
             rumbleException.initCause(e);
             throw rumbleException;
         }
+    }
+
+    private static URI parseURIReference(String value) throws URISyntaxException {
+        String escapedValue = value.replace(" ", "%20");
+        URI uri = new URI(escapedValue);
+        if (!value.equals(escapedValue) && uri.isOpaque()) {
+            throw new URISyntaxException(value, "Spaces are not allowed in opaque URIs");
+        }
+        return uri;
     }
 
     /*

--- a/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/FileSystemUtil.java
@@ -47,6 +47,14 @@ public class FileSystemUtil {
     }
 
     public static URI resolveURI(URI base, String url, ExceptionMetadata metadata) {
+        return resolve(base, url, metadata, false);
+    }
+
+    public static URI resolveFileSystemURI(URI base, String url, ExceptionMetadata metadata) {
+        return resolve(base, url, metadata, true);
+    }
+
+    private static URI resolve(URI base, String url, ExceptionMetadata metadata, boolean fileSystemPath) {
         if (!base.isAbsolute()) {
             throw new OurBadException(
                     "The base URI is not absolute!",
@@ -54,7 +62,7 @@ public class FileSystemUtil {
             );
         }
         try {
-            URI relativeURI = parseURI(url);
+            URI relativeURI = fileSystemPath ? parseFileSystemURI(url) : parseURI(url);
             URI resolvedURI = base.resolve(relativeURI);
             if (url.endsWith("/")) {
                 // preserve trailing slash if any for correct resolution against it as a directory in the future.
@@ -76,18 +84,22 @@ public class FileSystemUtil {
     }
 
     private static URI parseURI(String value) throws URISyntaxException {
-        try {
-            return new Path(value).toUri();
-        } catch (HadoopIllegalArgumentException e) {
-            // Fall back to Java URI parsing for URI references Hadoop Path cannot parse.
-            // For example, urn: is a valid URI reference but not a valid Hadoop Path.
-        }
         String escapedValue = value.replace(" ", "%20");
         URI uri = new URI(escapedValue);
         if (!value.equals(escapedValue) && uri.isOpaque()) {
             throw new URISyntaxException(value, "Spaces are not allowed in opaque URIs");
         }
         return uri;
+    }
+
+    private static URI parseFileSystemURI(String value) throws URISyntaxException {
+        try {
+            return new Path(value).toUri();
+        } catch (HadoopIllegalArgumentException e) {
+            // Fall back to Java URI parsing for URI references Hadoop Path cannot parse.
+            // For example, urn: is a valid URI reference but not a valid Hadoop Path.
+            return parseURI(value);
+        }
     }
 
     /*

--- a/src/main/java/org/rumbledb/runtime/functions/input/JsonLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/JsonLinesFunctionIterator.java
@@ -68,7 +68,7 @@ public class JsonLinesFunctionIterator extends HybridRuntimeIterator {
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
         String url = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
 
         int partitions = -1;
         if (this.children.size() > 1) {
@@ -131,7 +131,7 @@ public class JsonLinesFunctionIterator extends HybridRuntimeIterator {
 
     protected void init() {
         try {
-            URI uri = FileSystemUtil.resolveURI(
+            URI uri = FileSystemUtil.resolveFileSystemURI(
                 this.staticURI,
                 this.path.getStringValue(),
                 getMetadata()

--- a/src/main/java/org/rumbledb/runtime/functions/input/LibSVMFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/LibSVMFileFunctionIterator.java
@@ -52,7 +52,7 @@ public class LibSVMFileFunctionIterator extends DataFrameRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/ParquetFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/ParquetFileFunctionIterator.java
@@ -51,7 +51,7 @@ public class ParquetFileFunctionIterator extends DataFrameRuntimeIterator {
 
         String url = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
 
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/RootFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/RootFileFunctionIterator.java
@@ -60,7 +60,7 @@ public class RootFileFunctionIterator extends DataFrameRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/StructuredJsonLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/StructuredJsonLinesFunctionIterator.java
@@ -54,7 +54,7 @@ public class StructuredJsonLinesFunctionIterator extends DataFrameRuntimeIterato
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/UnparsedTextLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/UnparsedTextLinesFunctionIterator.java
@@ -60,7 +60,7 @@ public class UnparsedTextLinesFunctionIterator extends RDDRuntimeIterator {
                 .getJavaSparkContext()
                 .emptyRDD();
         }
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url.getStringValue(), getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url.getStringValue(), getMetadata());
         int partitions = -1;
         if (this.children.size() > 1) {
             partitions = this.children.get(1).materializeFirstItemOrNull(context).getIntValue();

--- a/src/main/java/org/rumbledb/runtime/functions/input/XmlFilesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/XmlFilesFunctionIterator.java
@@ -60,7 +60,7 @@ public class XmlFilesFunctionIterator extends RDDRuntimeIterator {
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
         String url = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
 
         int partitions = 32;
         if (this.children.size() > 1) {

--- a/src/main/java/org/rumbledb/runtime/functions/io/CollectionFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/CollectionFunctionIterator.java
@@ -35,7 +35,7 @@ public class CollectionFunctionIterator extends DataFrameRuntimeIterator {
             throw new CannotRetrieveResourceException("No default collection is defined.", getMetadata());
         }
         String url = stringItem.getStringValue();
-        URI uri = FileSystemUtil.resolveURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/io/LocalTextFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/LocalTextFileFunctionIterator.java
@@ -65,7 +65,7 @@ public class LocalTextFileFunctionIterator extends LocalFunctionCallIterator {
                     getMetadata()
             );
         }
-        URI uri = FileSystemUtil.resolveURI(
+        URI uri = FileSystemUtil.resolveFileSystemURI(
             this.staticURI,
             path.getStringValue(),
             getMetadata()
@@ -99,7 +99,7 @@ public class LocalTextFileFunctionIterator extends LocalFunctionCallIterator {
                     getMetadata()
             );
         }
-        URI uri = FileSystemUtil.resolveURI(
+        URI uri = FileSystemUtil.resolveFileSystemURI(
             this.staticURI,
             path.getStringValue(),
             getMetadata()

--- a/src/main/java/org/rumbledb/runtime/update/expression/CreateCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/CreateCollectionIterator.java
@@ -110,7 +110,7 @@ public class CreateCollectionIterator extends HybridRuntimeIterator {
         Mode mode = this.mode;
         // If it is a delta-file() call we need to resolve the path to an absolute path.
         if (mode == Mode.DELTA) {
-            URI uri = FileSystemUtil.resolveURI(this.staticURI, logicalPath, getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, logicalPath, getMetadata());
             logicalPath = FileSystemUtil.convertURIToStringForSpark(uri);
         }
 

--- a/src/main/java/org/rumbledb/runtime/update/expression/InsertIndexIntoCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/InsertIndexIntoCollectionIterator.java
@@ -139,7 +139,7 @@ public class InsertIndexIntoCollectionIterator extends HybridRuntimeIterator {
         String logicalPath = targetItem.getStringValue();
         Mode mode = this.mode;
         if (mode == Mode.DELTA) {
-            URI uri = FileSystemUtil.resolveURI(this.staticURI, logicalPath, getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, logicalPath, getMetadata());
             logicalPath = FileSystemUtil.convertURIToStringForSpark(uri);
         }
 

--- a/src/main/java/org/rumbledb/runtime/update/expression/TruncateCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/TruncateCollectionIterator.java
@@ -98,7 +98,7 @@ public class TruncateCollectionIterator extends HybridRuntimeIterator {
         String logicalPath = collectionNameItem.getStringValue();
         Mode mode = this.mode;
         if (mode == Mode.DELTA) {
-            URI uri = FileSystemUtil.resolveURI(this.staticURI, logicalPath, getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, logicalPath, getMetadata());
             if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
                 throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
             }


### PR DESCRIPTION
ResourceResolver handles how URIs are resolved, and provides API to override. Rumble API has been modified to accept an instance of this class.

`CompilationConfiguration` class has been added to wrap RumbleRuntimeConfiguration + ResourceResolver class.

This is because in `next` branch, we will also have `ExternalBindings` class, and it will go there.