### PR TITLE
Add `legacy` option to `fn:parse-json`, `fn:json-doc`

### DIFF
--- a/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
+++ b/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
@@ -55,7 +55,11 @@ public final class ErrorCode implements Serializable {
 
     @Override
     public String toString() {
-        return this.name.getLocalName();
+        String namespace = this.name.getNamespace();
+        if (Name.ERROR_NS.equals(namespace)) {
+            return this.name.getLocalName();
+        }
+        return "Q{" + (namespace == null ? "" : namespace) + "}" + this.name.getLocalName();
     }
 
     @Override

--- a/src/main/java/org/rumbledb/items/parsing/JSONParsingOptions.java
+++ b/src/main/java/org/rumbledb/items/parsing/JSONParsingOptions.java
@@ -50,14 +50,14 @@ public final class JSONParsingOptions implements Serializable {
     public static final Function<String, String> DEFAULT_FALLBACK = s -> "\uFFFD";
 
     // RumbleDB-specific extension, not part of the W3C specification.
-    public static final boolean DEFAULT_FAST_PATH = false;
+    public static final boolean DEFAULT_LEGACY = false;
 
     private final boolean liberal;
     private final String duplicates;
     private final boolean escape;
     private final String numberFormat;
     private final Function<String, String> fallback;
-    private final boolean fastPath;
+    private final boolean legacy;
 
     private JSONParsingOptions(
             boolean liberal,
@@ -65,14 +65,14 @@ public final class JSONParsingOptions implements Serializable {
             boolean escape,
             Function<String, String> fallback,
             String numberFormat,
-            boolean fastPath
+            boolean legacy
     ) {
         this.liberal = liberal;
         this.duplicates = duplicates;
         this.escape = escape;
         this.fallback = fallback;
         this.numberFormat = numberFormat;
-        this.fastPath = fastPath;
+        this.legacy = legacy;
     }
 
     public static JSONParsingOptions defaultInstance(boolean isJSONiq10) {
@@ -82,7 +82,7 @@ public final class JSONParsingOptions implements Serializable {
                 DEFAULT_ESCAPE,
                 DEFAULT_FALLBACK,
                 getDefaultNumberFormat(isJSONiq10),
-                DEFAULT_FAST_PATH
+                DEFAULT_LEGACY
         );
     }
 
@@ -96,8 +96,8 @@ public final class JSONParsingOptions implements Serializable {
             + this.escape
             + ", fallback: "
             + this.fallback
-            + ", fast-path: "
-            + this.fastPath
+            + ", legacy: "
+            + this.legacy
             + "]";
     }
 
@@ -173,7 +173,7 @@ public final class JSONParsingOptions implements Serializable {
         Function<String, String> fallback = JSONParsingOptions.DEFAULT_FALLBACK;
         boolean fallbackExplicitlySet = false;
 
-        boolean fastPath = JSONParsingOptions.DEFAULT_FAST_PATH;
+        boolean legacy = JSONParsingOptions.DEFAULT_LEGACY;
 
         if (optionsItem == null) {
             return JSONParsingOptions.defaultInstance(isJSONiq10);
@@ -233,8 +233,8 @@ public final class JSONParsingOptions implements Serializable {
                     fallbackExplicitlySet = true;
                     break;
                 }
-                case "fast-path":
-                    fastPath = requireSingleBooleanOption("fast-path", sequence, metadata);
+                case "legacy":
+                    legacy = requireSingleBooleanOption("legacy", sequence, metadata);
                     break;
                 default:
                     break;
@@ -248,7 +248,7 @@ public final class JSONParsingOptions implements Serializable {
             );
         }
 
-        if (fastPath) {
+        if (legacy) {
             boolean othersAreDefault = liberal == JSONParsingOptions.DEFAULT_LIBERAL
                 && JSONParsingOptions.DEFAULT_DUPLICATES.equals(duplicates)
                 && escape == JSONParsingOptions.DEFAULT_ESCAPE
@@ -256,14 +256,14 @@ public final class JSONParsingOptions implements Serializable {
                 && numberFormat.equals(JSONParsingOptions.getDefaultNumberFormat(isJSONiq10));
             if (!othersAreDefault) {
                 throw new InvalidOptionException(
-                        "Invalid options: option 'fast-path' can only be combined with default values "
+                        "Invalid options: option 'legacy' can only be combined with default values "
                             + "for 'liberal', 'duplicates', 'escape', 'fallback', and 'number-format'.",
                         metadata
                 );
             }
         }
 
-        return new JSONParsingOptions(liberal, duplicates, escape, fallback, numberFormat, fastPath);
+        return new JSONParsingOptions(liberal, duplicates, escape, fallback, numberFormat, legacy);
     }
 
     private static String validatedStringOption(

--- a/src/main/java/org/rumbledb/items/parsing/JSONParsingOptions.java
+++ b/src/main/java/org/rumbledb/items/parsing/JSONParsingOptions.java
@@ -1,5 +1,6 @@
 package org.rumbledb.items.parsing;
 
+import lombok.Getter;
 import org.rumbledb.api.Item;
 import org.rumbledb.context.DynamicContext;
 import org.rumbledb.context.Name;
@@ -18,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
+@Getter
 public final class JSONParsingOptions implements Serializable {
 
     @Serial
@@ -47,24 +49,30 @@ public final class JSONParsingOptions implements Serializable {
     public static final boolean DEFAULT_ESCAPE = false;
     public static final Function<String, String> DEFAULT_FALLBACK = s -> "\uFFFD";
 
+    // RumbleDB-specific extension, not part of the W3C specification.
+    public static final boolean DEFAULT_FAST_PATH = false;
+
     private final boolean liberal;
     private final String duplicates;
     private final boolean escape;
     private final String numberFormat;
     private final Function<String, String> fallback;
+    private final boolean fastPath;
 
     private JSONParsingOptions(
             boolean liberal,
             String duplicates,
             boolean escape,
             Function<String, String> fallback,
-            String numberFormat
+            String numberFormat,
+            boolean fastPath
     ) {
         this.liberal = liberal;
         this.duplicates = duplicates;
         this.escape = escape;
         this.fallback = fallback;
         this.numberFormat = numberFormat;
+        this.fastPath = fastPath;
     }
 
     public static JSONParsingOptions defaultInstance(boolean isJSONiq10) {
@@ -73,28 +81,9 @@ public final class JSONParsingOptions implements Serializable {
                 DEFAULT_DUPLICATES,
                 DEFAULT_ESCAPE,
                 DEFAULT_FALLBACK,
-                getDefaultNumberFormat(isJSONiq10)
+                getDefaultNumberFormat(isJSONiq10),
+                DEFAULT_FAST_PATH
         );
-    }
-
-    public boolean isLiberal() {
-        return this.liberal;
-    }
-
-    public String getDuplicates() {
-        return this.duplicates;
-    }
-
-    public boolean isEscape() {
-        return this.escape;
-    }
-
-    public Function<String, String> getFallback() {
-        return this.fallback;
-    }
-
-    public String getNumberFormat() {
-        return this.numberFormat;
     }
 
     @Override
@@ -107,6 +96,8 @@ public final class JSONParsingOptions implements Serializable {
             + this.escape
             + ", fallback: "
             + this.fallback
+            + ", fast-path: "
+            + this.fastPath
             + "]";
     }
 
@@ -182,6 +173,8 @@ public final class JSONParsingOptions implements Serializable {
         Function<String, String> fallback = JSONParsingOptions.DEFAULT_FALLBACK;
         boolean fallbackExplicitlySet = false;
 
+        boolean fastPath = JSONParsingOptions.DEFAULT_FAST_PATH;
+
         if (optionsItem == null) {
             return JSONParsingOptions.defaultInstance(isJSONiq10);
         }
@@ -240,6 +233,9 @@ public final class JSONParsingOptions implements Serializable {
                     fallbackExplicitlySet = true;
                     break;
                 }
+                case "fast-path":
+                    fastPath = requireSingleBooleanOption("fast-path", sequence, metadata);
+                    break;
                 default:
                     break;
             }
@@ -252,7 +248,22 @@ public final class JSONParsingOptions implements Serializable {
             );
         }
 
-        return new JSONParsingOptions(liberal, duplicates, escape, fallback, numberFormat);
+        if (fastPath) {
+            boolean othersAreDefault = liberal == JSONParsingOptions.DEFAULT_LIBERAL
+                && JSONParsingOptions.DEFAULT_DUPLICATES.equals(duplicates)
+                && escape == JSONParsingOptions.DEFAULT_ESCAPE
+                && !fallbackExplicitlySet
+                && numberFormat.equals(JSONParsingOptions.getDefaultNumberFormat(isJSONiq10));
+            if (!othersAreDefault) {
+                throw new InvalidOptionException(
+                        "Invalid options: option 'fast-path' can only be combined with default values "
+                            + "for 'liberal', 'duplicates', 'escape', 'fallback', and 'number-format'.",
+                        metadata
+                );
+            }
+        }
+
+        return new JSONParsingOptions(liberal, duplicates, escape, fallback, numberFormat, fastPath);
     }
 
     private static String validatedStringOption(

--- a/src/main/java/org/rumbledb/runtime/functions/json/JsonDocFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/json/JsonDocFunctionIterator.java
@@ -66,10 +66,11 @@ public class JsonDocFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
         String jsonText = readJsonResource(uri, context.getRumbleRuntimeConfiguration(), getMetadata());
 
-        if (options.isFastPath()) {
+        if (options.isLegacy()) {
             ConsoleOutput.warn(
-                "Warning: fn:json-doc option 'fast-path' skips spec-conformant JSON parsing for speed "
-                    + "and may produce unexpected results; retry without it if the output looks wrong."
+                "Warning: fn:json-doc option 'legacy' skips spec-conformant JSON parsing in favor of "
+                    + "RumbleDB's previous Gson-based parser and may produce unexpected results; "
+                    + "retry without it if the output looks wrong."
             );
             return ItemParser.getItemFromObject(
                 new JsonReader(new StringReader(jsonText)),

--- a/src/main/java/org/rumbledb/runtime/functions/json/JsonDocFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/json/JsonDocFunctionIterator.java
@@ -1,18 +1,16 @@
 package org.rumbledb.runtime.functions.json;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
+import com.google.gson.stream.JsonReader;
+
 import java.io.Serial;
+import java.io.StringReader;
 import java.net.URI;
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CodingErrorAction;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.rumbledb.api.Item;
+import org.rumbledb.cli.ConsoleOutput;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
 import org.rumbledb.context.DynamicContext;
 import org.rumbledb.context.RuntimeStaticContext;
@@ -25,6 +23,7 @@ import org.rumbledb.items.parsing.JSONParsingOptions;
 import org.rumbledb.runtime.AtMostOneItemLocalRuntimeIterator;
 import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.runtime.functions.input.FileSystemUtil;
+import org.rumbledb.runtime.functions.io.TextResourceUtil;
 
 
 public class JsonDocFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
@@ -66,6 +65,20 @@ public class JsonDocFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         URI uri = resolveJsonDocURI(pathItem.getStringValue(), this.staticURI, getMetadata());
 
         String jsonText = readJsonResource(uri, context.getRumbleRuntimeConfiguration(), getMetadata());
+
+        if (options.isFastPath()) {
+            ConsoleOutput.warn(
+                "Warning: fn:json-doc option 'fast-path' skips spec-conformant JSON parsing for speed "
+                    + "and may produce unexpected results; retry without it if the output looks wrong."
+            );
+            return ItemParser.getItemFromObject(
+                new JsonReader(new StringReader(jsonText)),
+                isJSONiq10,
+                options.getNumberFormat(),
+                getMetadata(),
+                false
+            );
+        }
 
         return ItemParser.getItemFromJSONString(
             jsonText,
@@ -111,14 +124,9 @@ public class JsonDocFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
 
     private static String readJsonResource(URI uri, RumbleRuntimeConfiguration conf, ExceptionMetadata metadata) {
-        try (
-            InputStream is = FileSystemUtil.getDataInputStream(
-                uri,
-                conf,
-                metadata
-            )
-        ) {
-            return readAll(is, metadata);
+        try {
+            byte[] bytes = TextResourceUtil.fetchBytes(uri, conf, metadata);
+            return decode(bytes, TextResourceUtil.detectEncoding(bytes), metadata);
         } catch (CannotInferEncodingException e) {
             throw e;
         } catch (UnavailableResourceException e) {
@@ -137,34 +145,9 @@ public class JsonDocFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         }
     }
 
-    private static String readAll(InputStream is, ExceptionMetadata metadata) {
-        try {
-            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-            byte[] data = new byte[8192];
-            int nRead;
-            while ((nRead = is.read(data, 0, data.length)) != -1) {
-                buffer.write(data, 0, nRead);
-            }
-            byte[] bytes = buffer.toByteArray();
-            return decode(bytes, detectEncoding(bytes), metadata);
-        } catch (CannotInferEncodingException e) {
-            throw e;
-        } catch (Exception e) {
-            UnavailableResourceException ex = new UnavailableResourceException(
-                    "Unable to read or decode the resource supplied to fn:json-doc().",
-                    metadata
-            );
-            ex.initCause(e);
-            throw ex;
-        }
-    }
-
     private static String decode(byte[] bytes, Charset charset, ExceptionMetadata metadata) {
         try {
-            CharsetDecoder decoder = charset.newDecoder()
-                .onMalformedInput(CodingErrorAction.REPORT)
-                .onUnmappableCharacter(CodingErrorAction.REPORT);
-            return decoder.decode(ByteBuffer.wrap(bytes)).toString();
+            return TextResourceUtil.decodeStrict(bytes, charset);
         } catch (CharacterCodingException e) {
             CannotInferEncodingException ex = new CannotInferEncodingException(
                     "Unable to infer the encoding of the resource supplied to fn:json-doc(): "
@@ -176,48 +159,5 @@ public class JsonDocFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
             ex.initCause(e);
             throw ex;
         }
-    }
-
-    /**
-     * Detects the resource encoding as required by fn:json-doc: UTF-8, UTF-16, or UTF-32,
-     * from a leading byte-order mark or from the NUL pattern of the first
-     * bytes.
-     */
-    private static Charset detectEncoding(byte[] b) {
-        int b0 = b.length > 0 ? b[0] & 0xFF : -1;
-        int b1 = b.length > 1 ? b[1] & 0xFF : -1;
-        int b2 = b.length > 2 ? b[2] & 0xFF : -1;
-        int b3 = b.length > 3 ? b[3] & 0xFF : -1;
-
-        if (b0 == 0x00 && b1 == 0x00 && b2 == 0xFE && b3 == 0xFF) {
-            return Charset.forName("UTF-32BE");
-        }
-        if (b0 == 0xFF && b1 == 0xFE && b2 == 0x00 && b3 == 0x00) {
-            return Charset.forName("UTF-32LE");
-        }
-        if (b0 == 0xFE && b1 == 0xFF) {
-            return StandardCharsets.UTF_16BE;
-        }
-        if (b0 == 0xFF && b1 == 0xFE) {
-            return StandardCharsets.UTF_16LE;
-        }
-        if (b0 == 0xEF && b1 == 0xBB && b2 == 0xBF) {
-            return StandardCharsets.UTF_8;
-        }
-
-        if (b0 == 0x00 && b1 == 0x00 && b2 == 0x00 && b3 > 0x00) {
-            return Charset.forName("UTF-32BE");
-        }
-        if (b0 > 0x00 && b1 == 0x00 && b2 == 0x00 && b3 == 0x00) {
-            return Charset.forName("UTF-32LE");
-        }
-        if (b0 == 0x00 && b1 > 0x00) {
-            return StandardCharsets.UTF_16BE;
-        }
-        if (b0 > 0x00 && b1 == 0x00) {
-            return StandardCharsets.UTF_16LE;
-        }
-
-        return StandardCharsets.UTF_8;
     }
 }

--- a/src/main/java/org/rumbledb/runtime/functions/json/ParseJsonFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/json/ParseJsonFunctionIterator.java
@@ -62,10 +62,11 @@ public class ParseJsonFunctionIterator extends AtMostOneItemLocalRuntimeIterator
             this.staticContext,
             getMetadata()
         );
-        if (options.isFastPath()) {
+        if (options.isLegacy()) {
             ConsoleOutput.warn(
-                "Warning: fn:parse-json option 'fast-path' skips spec-conformant JSON parsing for speed "
-                    + "and may produce unexpected results; retry without it if the output looks wrong."
+                "Warning: fn:parse-json option 'legacy' skips spec-conformant JSON parsing in favor of "
+                    + "RumbleDB's previous Gson-based parser and may produce unexpected results; "
+                    + "retry without it if the output looks wrong."
             );
             return ItemParser.getItemFromObject(
                 new JsonReader(new StringReader(stringItem.getStringValue())),

--- a/src/main/java/org/rumbledb/runtime/functions/json/ParseJsonFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/json/ParseJsonFunctionIterator.java
@@ -21,7 +21,9 @@
 
 package org.rumbledb.runtime.functions.json;
 
+import com.google.gson.stream.JsonReader;
 import org.rumbledb.api.Item;
+import org.rumbledb.cli.ConsoleOutput;
 import org.rumbledb.context.DynamicContext;
 import org.rumbledb.context.RuntimeStaticContext;
 import org.rumbledb.items.parsing.ItemParser;
@@ -30,6 +32,7 @@ import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.items.parsing.JSONParsingOptions;
 
 import java.io.Serial;
+import java.io.StringReader;
 import java.util.List;
 
 public class ParseJsonFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
@@ -59,6 +62,19 @@ public class ParseJsonFunctionIterator extends AtMostOneItemLocalRuntimeIterator
             this.staticContext,
             getMetadata()
         );
+        if (options.isFastPath()) {
+            ConsoleOutput.warn(
+                "Warning: fn:parse-json option 'fast-path' skips spec-conformant JSON parsing for speed "
+                    + "and may produce unexpected results; retry without it if the output looks wrong."
+            );
+            return ItemParser.getItemFromObject(
+                new JsonReader(new StringReader(stringItem.getStringValue())),
+                isJSONiq10,
+                options.getNumberFormat(),
+                getMetadata(),
+                false
+            );
+        }
         return ItemParser.getItemFromJSONString(
             stringItem.getStringValue(),
             options,

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/FoldLeftFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/FoldLeftFunctionIterator.java
@@ -15,12 +15,15 @@ import org.rumbledb.runtime.HybridRuntimeIterator;
 import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.types.SequenceType;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class FoldLeftFunctionIterator extends HybridRuntimeIterator {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private final RuntimeIterator sequenceIterator;
@@ -55,39 +58,60 @@ public class FoldLeftFunctionIterator extends HybridRuntimeIterator {
         List<Item> accumulator = this.zeroIterator.materialize(context);
         Item functionItem = this.functionIterator.materialize(context).get(0);
 
-        ConstantRuntimeIterator accumulatorArgument = null;
-        ConstantRuntimeIterator currentItemArgument = null;
-        RuntimeIterator reusableFunctionCall = null;
+        ReusableFunctionCall reusableCall = null;
 
         for (Item inputItem : inputItems) {
             if (accumulator.size() == 1) {
-                if (reusableFunctionCall == null) {
+                if (reusableCall == null) {
                     RuntimeStaticContext localItemStarContext = new RuntimeStaticContext(
                             getConfiguration(),
                             SequenceType.createSequenceType("item*"),
                             ExecutionMode.LOCAL,
                             getMetadata()
                     );
-                    accumulatorArgument = new ConstantRuntimeIterator(accumulator.get(0), localItemStarContext);
-                    currentItemArgument = new ConstantRuntimeIterator(inputItem, localItemStarContext);
-                    reusableFunctionCall = NamedFunctions.buildFunctionItemCallIterator(
+                    ConstantRuntimeIterator accumulatorArgument = new ConstantRuntimeIterator(
+                            accumulator.get(0),
+                            localItemStarContext
+                    );
+                    ConstantRuntimeIterator currentItemArgument = new ConstantRuntimeIterator(
+                            inputItem,
+                            localItemStarContext
+                    );
+                    RuntimeIterator functionCall = NamedFunctions.buildFunctionItemCallIterator(
                         functionItem,
                         this.staticContext,
                         ExecutionMode.LOCAL,
                         Arrays.asList(accumulatorArgument, currentItemArgument),
                         false
                     );
+                    reusableCall = new ReusableFunctionCall(accumulatorArgument, currentItemArgument, functionCall);
                 } else {
-                    accumulatorArgument.setItemForReuse(accumulator.get(0));
-                    currentItemArgument.setItemForReuse(inputItem);
+                    reusableCall.accumulatorArgument.setItemForReuse(accumulator.get(0));
+                    reusableCall.currentItemArgument.setItemForReuse(inputItem);
                 }
-                accumulator = reusableFunctionCall.materialize(context);
+                accumulator = reusableCall.functionCall.materialize(context);
             } else {
                 accumulator = applyFunction(functionItem, accumulator, Collections.singletonList(inputItem), context);
             }
         }
 
         this.resultSequence = accumulator;
+    }
+
+    private static final class ReusableFunctionCall {
+        private final ConstantRuntimeIterator accumulatorArgument;
+        private final ConstantRuntimeIterator currentItemArgument;
+        private final RuntimeIterator functionCall;
+
+        private ReusableFunctionCall(
+                ConstantRuntimeIterator accumulatorArgument,
+                ConstantRuntimeIterator currentItemArgument,
+                RuntimeIterator functionCall
+        ) {
+            this.accumulatorArgument = accumulatorArgument;
+            this.currentItemArgument = currentItemArgument;
+            this.functionCall = functionCall;
+        }
     }
 
     private RuntimeIterator createSequenceIterator(List<Item> items) {

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/FoldRightFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/FoldRightFunctionIterator.java
@@ -15,12 +15,15 @@ import org.rumbledb.runtime.HybridRuntimeIterator;
 import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.types.SequenceType;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class FoldRightFunctionIterator extends HybridRuntimeIterator {
+
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private final RuntimeIterator sequenceIterator;
@@ -55,34 +58,39 @@ public class FoldRightFunctionIterator extends HybridRuntimeIterator {
         List<Item> accumulator = this.zeroIterator.materialize(context);
         Item functionItem = this.functionIterator.materialize(context).get(0);
 
-        ConstantRuntimeIterator currentItemArgument = null;
-        ConstantRuntimeIterator accumulatorArgument = null;
-        RuntimeIterator reusableFunctionCall = null;
+        ReusableFunctionCall reusableCall = null;
 
         for (int i = inputItems.size() - 1; i >= 0; i--) {
             Item inputItem = inputItems.get(i);
             if (accumulator.size() == 1) {
-                if (reusableFunctionCall == null) {
+                if (reusableCall == null) {
                     RuntimeStaticContext localItemStarContext = new RuntimeStaticContext(
                             getConfiguration(),
                             SequenceType.createSequenceType("item*"),
                             ExecutionMode.LOCAL,
                             getMetadata()
                     );
-                    currentItemArgument = new ConstantRuntimeIterator(inputItem, localItemStarContext);
-                    accumulatorArgument = new ConstantRuntimeIterator(accumulator.get(0), localItemStarContext);
-                    reusableFunctionCall = NamedFunctions.buildFunctionItemCallIterator(
+                    ConstantRuntimeIterator currentItemArgument = new ConstantRuntimeIterator(
+                            inputItem,
+                            localItemStarContext
+                    );
+                    ConstantRuntimeIterator accumulatorArgument = new ConstantRuntimeIterator(
+                            accumulator.get(0),
+                            localItemStarContext
+                    );
+                    RuntimeIterator functionCall = NamedFunctions.buildFunctionItemCallIterator(
                         functionItem,
                         this.staticContext,
                         ExecutionMode.LOCAL,
                         Arrays.asList(currentItemArgument, accumulatorArgument),
                         false
                     );
+                    reusableCall = new ReusableFunctionCall(currentItemArgument, accumulatorArgument, functionCall);
                 } else {
-                    currentItemArgument.setItemForReuse(inputItem);
-                    accumulatorArgument.setItemForReuse(accumulator.get(0));
+                    reusableCall.currentItemArgument.setItemForReuse(inputItem);
+                    reusableCall.accumulatorArgument.setItemForReuse(accumulator.get(0));
                 }
-                accumulator = reusableFunctionCall.materialize(context);
+                accumulator = reusableCall.functionCall.materialize(context);
             } else {
                 accumulator = applyFunction(
                     functionItem,
@@ -94,6 +102,22 @@ public class FoldRightFunctionIterator extends HybridRuntimeIterator {
         }
 
         this.resultSequence = accumulator;
+    }
+
+    private static final class ReusableFunctionCall {
+        private final ConstantRuntimeIterator currentItemArgument;
+        private final ConstantRuntimeIterator accumulatorArgument;
+        private final RuntimeIterator functionCall;
+
+        private ReusableFunctionCall(
+                ConstantRuntimeIterator currentItemArgument,
+                ConstantRuntimeIterator accumulatorArgument,
+                RuntimeIterator functionCall
+        ) {
+            this.currentItemArgument = currentItemArgument;
+            this.accumulatorArgument = accumulatorArgument;
+            this.functionCall = functionCall;
+        }
     }
 
     private RuntimeIterator createSequenceIterator(List<Item> items) {

--- a/src/main/java/org/rumbledb/types/ErrorItemType.java
+++ b/src/main/java/org/rumbledb/types/ErrorItemType.java
@@ -1,5 +1,6 @@
 package org.rumbledb.types;
 
+import java.io.Serial;
 import java.util.Set;
 
 import org.rumbledb.config.RumbleRuntimeConfiguration;
@@ -15,6 +16,7 @@ import org.rumbledb.context.Name;
  */
 public class ErrorItemType implements ItemType {
 
+    @Serial
     private static final long serialVersionUID = 1L;
     private static final Name name = new Name(Name.XS_NS, "xs", "error");
 
@@ -75,7 +77,7 @@ public class ErrorItemType implements ItemType {
 
     @Override
     public String toString() {
-        return this.name.toString();
+        return name.toString();
     }
 
     @Override


### PR DESCRIPTION
Adds a RumbleDB-specific `legacy` option to `fn:json-doc` and `fn:parse-json`'s options map. It requires every other option to be left unset or at its default; when set, parsing is routed through the legacy Gson-based parser instead of RumbleDB's own spec-conformant parser. This can produce unexpected results for duplicate object keys and invalid codepoints, a warning is therefore emitted whenever `legacy` is used.

Users that already relied on the Gson-based parser's behavior before this rewrite can opt back into it via the legacy option.