### PR TITLE
Remove Serializable and KryoSerializable implementations from compiler-only classes

### DIFF
--- a/src/main/java/org/rumbledb/context/InScopeVariable.java
+++ b/src/main/java/org/rumbledb/context/InScopeVariable.java
@@ -1,17 +1,10 @@
 package org.rumbledb.context;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoSerializable;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.expressions.ExecutionMode;
 import org.rumbledb.types.SequenceType;
 
-import java.io.Serializable;
-
-public class InScopeVariable implements Serializable, KryoSerializable {
-    private static final long serialVersionUID = 1L;
+public class InScopeVariable {
 
     private Name name;
     private SequenceType sequenceType;
@@ -64,22 +57,6 @@ public class InScopeVariable implements Serializable, KryoSerializable {
 
     public void setStorageMode(ExecutionMode mode) {
         this.storageMode = mode;
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output) {
-        kryo.writeObject(output, this.name);
-        kryo.writeObject(output, this.sequenceType);
-        kryo.writeObject(output, this.metadata);
-        kryo.writeObject(output, this.storageMode);
-    }
-
-    @Override
-    public void read(Kryo kryo, Input input) {
-        this.name = kryo.readObject(input, Name.class);
-        this.sequenceType = kryo.readObject(input, SequenceType.class);
-        this.metadata = kryo.readObject(input, ExceptionMetadata.class);
-        this.storageMode = kryo.readObject(input, ExecutionMode.class);
     }
 
     public boolean isAssignable() {

--- a/src/main/java/org/rumbledb/context/StaticContext.java
+++ b/src/main/java/org/rumbledb/context/StaticContext.java
@@ -20,7 +20,6 @@
 
 package org.rumbledb.context;
 
-import java.io.Serializable;
 import java.net.URI;
 import java.util.LinkedHashSet;
 import java.util.Collections;
@@ -42,39 +41,31 @@ import org.rumbledb.types.FunctionSignature;
 import org.rumbledb.types.ItemType;
 import org.rumbledb.types.SequenceType;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoSerializable;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+public class StaticContext {
 
-public class StaticContext implements Serializable, KryoSerializable {
-
-    private static final long serialVersionUID = 1L;
-
-    private transient Map<Name, InScopeVariable> inScopeVariables;
-    private transient Map<String, String> staticallyKnownNamespaces;
-    private transient UserDefinedFunctionExecutionModes userDefinedFunctionExecutionModes;
-    private transient InScopeSchemaTypes inScopeSchemaTypes;
+    private Map<Name, InScopeVariable> inScopeVariables;
+    private Map<String, String> staticallyKnownNamespaces;
+    private UserDefinedFunctionExecutionModes userDefinedFunctionExecutionModes;
+    private InScopeSchemaTypes inScopeSchemaTypes;
     private String queryLanguage;
     private StaticContext parent;
     private URI staticBaseURI;
     private boolean emptySequenceOrderLeast;
     private boolean boundarySpacePreserve;
     private SerializationParameters serializationParameters;
-    private transient Set<String> explicitSerializationParameterNames;
+    private Set<String> explicitSerializationParameterNames;
     private boolean isQuerySideEffecting;
-    private transient Set<String> staticallyKnownCollations;
-    private transient String defaultCollation;
+    private Set<String> staticallyKnownCollations;
+    private String defaultCollation;
 
     /**
      * XQuery {@code declare default function namespace}; when null, unprefixed function names use
      * {@link Name#JSONIQ_DEFAULT_FUNCTION_NS} (Rumble's usual fn/jn/... resolution path).
      */
-    private transient String defaultFunctionNamespaceUri;
+    private String defaultFunctionNamespaceUri;
 
-    // TODO: should these be transient?
-    private transient SequenceType contextItemStaticType;
-    private transient Map<FunctionIdentifier, FunctionSignature> staticallyKnownFunctionSignatures;
+    private SequenceType contextItemStaticType;
+    private Map<FunctionIdentifier, FunctionSignature> staticallyKnownFunctionSignatures;
     private static final Map<String, String> defaultBindings;
 
     private DecimalFormatDefinition defaultDecimalFormat;
@@ -441,29 +432,6 @@ public class StaticContext implements Serializable, KryoSerializable {
             bindings.putAll(this.staticallyKnownNamespaces);
         }
         return bindings;
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output) {
-        kryo.writeObjectOrNull(output, this.parent, StaticContext.class);
-        kryo.writeObject(output, this.staticBaseURI);
-        output.writeBoolean(this.emptySequenceOrderLeast);
-        output.writeBoolean(this.boundarySpacePreserve);
-        kryo.writeObjectOrNull(output, this.serializationParameters, SerializationParameters.class);
-    }
-
-    @Override
-    public void read(Kryo kryo, Input input) {
-        this.parent = kryo.readObjectOrNull(input, StaticContext.class);
-        this.staticBaseURI = kryo.readObject(input, URI.class);
-        this.emptySequenceOrderLeast = input.readBoolean();
-        this.boundarySpacePreserve = input.readBoolean();
-        // Backward compatibility: older serialized artifacts may not contain the serialization parameters field.
-        this.serializationParameters = kryo.readObjectOrNull(input, SerializationParameters.class);
-        // Pointer chain semantics: only root initializes defaults; non-root leaves null to inherit from parent.
-        if (this.serializationParameters == null && this.parent == null) {
-            this.serializationParameters = SerializationParameters.defaults();
-        }
     }
 
     /**

--- a/src/main/java/org/rumbledb/context/UserDefinedFunctionExecutionModes.java
+++ b/src/main/java/org/rumbledb/context/UserDefinedFunctionExecutionModes.java
@@ -20,26 +20,19 @@
 
 package org.rumbledb.context;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoSerializable;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
 import org.rumbledb.exceptions.DuplicateFunctionIdentifierException;
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.OurBadException;
 import org.rumbledb.exceptions.UnknownFunctionCallException;
 import org.rumbledb.expressions.ExecutionMode;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class UserDefinedFunctionExecutionModes implements Serializable, KryoSerializable {
-
-    private static final long serialVersionUID = 1L;
+public class UserDefinedFunctionExecutionModes {
 
     // two maps for User defined function are needed as execution mode is known at static analysis phase
     // but functions items are fully known at runtimeIterator generation
@@ -177,23 +170,6 @@ public class UserDefinedFunctionExecutionModes implements Serializable, KryoSeri
     public List<FunctionIdentifier> getUserDefinedFunctionIdentifiersWithUnsetExecutionModes() {
         return this.userDefinedFunctionIdentifiersWithUnsetExecutionModes;
     }
-
-    @Override
-    public void write(Kryo kryo, Output output) {
-        kryo.writeObject(output, this.userDefinedFunctionsExecutionMode);
-        kryo.writeObject(output, this.userDefinedFunctionIdentifiersWithUnsetExecutionModes);
-        kryo.writeObject(output, this.userDefinedFunctionsParametersStorageMode);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public void read(Kryo kryo, Input input) {
-        this.userDefinedFunctionsExecutionMode = kryo.readObject(input, HashMap.class);
-        this.userDefinedFunctionIdentifiersWithUnsetExecutionModes = kryo.readObject(input, List.class);
-        this.userDefinedFunctionsParametersStorageMode = kryo.readObject(input, HashMap.class);
-    }
-
-
 
     @Override
     public String toString() {

--- a/src/main/java/org/rumbledb/expressions/primary/VariableReferenceExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/VariableReferenceExpression.java
@@ -28,13 +28,10 @@ import org.rumbledb.expressions.Expression;
 import org.rumbledb.expressions.Node;
 import org.rumbledb.types.SequenceType;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class VariableReferenceExpression extends Expression implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class VariableReferenceExpression extends Expression {
     private Name name;
     private SequenceType type;
 

--- a/src/main/java/org/rumbledb/items/parsing/ItemParser.java
+++ b/src/main/java/org/rumbledb/items/parsing/ItemParser.java
@@ -58,7 +58,6 @@ import org.w3c.dom.NodeList;
 import sparksoniq.spark.SparkSessionManager;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -73,10 +72,7 @@ import java.util.Map;
 import java.util.Collections;
 import java.util.Set;
 
-public class ItemParser implements Serializable {
-
-
-    private static final long serialVersionUID = 1L;
+public class ItemParser {
 
     /**
      * Parses a JSON string to an item.

--- a/src/main/java/org/rumbledb/items/parsing/JSONParsingOptions.java
+++ b/src/main/java/org/rumbledb/items/parsing/JSONParsingOptions.java
@@ -12,18 +12,13 @@ import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.runtime.primary.StringRuntimeIterator;
 import org.rumbledb.types.SequenceType;
 
-import java.io.Serial;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
 @Getter
-public final class JSONParsingOptions implements Serializable {
-
-    @Serial
-    private static final long serialVersionUID = 1L;
+public final class JSONParsingOptions {
 
     public static final String DUPLICATES_REJECT = "reject";
     public static final String DUPLICATES_USE_FIRST = "use-first";


### PR DESCRIPTION
Similar to StaticContext, these classes are not part of serialization graph, so implementing Serializable does not make any sense (adding unused codes)
