### PR TITLE
Add missing `@Override` annotation

### DIFF
--- a/src/main/java/org/rumbledb/compiler/FunctionDependenciesVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/FunctionDependenciesVisitor.java
@@ -112,6 +112,7 @@ public class FunctionDependenciesVisitor extends AbstractNodeVisitor<FunctionIde
         return null;
     }
 
+    @Override
     public FunctionIdentifier visitFunctionDeclaration(
             FunctionDeclaration expression,
             FunctionIdentifier encompassingFunction
@@ -123,6 +124,7 @@ public class FunctionDependenciesVisitor extends AbstractNodeVisitor<FunctionIde
         return encompassingFunction;
     }
 
+    @Override
     public FunctionIdentifier visitFunctionCall(
             FunctionCallExpression expression,
             FunctionIdentifier encompassingFunction

--- a/src/main/java/org/rumbledb/compiler/InferTypeVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/InferTypeVisitor.java
@@ -2223,6 +2223,7 @@ public class InferTypeVisitor extends AbstractNodeVisitor<StaticContext> {
         return argument;
     }
 
+    @Override
     public StaticContext visitPostfixLookupExpression(PostfixLookupExpression expression, StaticContext argument) {
         visitDescendants(expression, argument);
 
@@ -2261,6 +2262,7 @@ public class InferTypeVisitor extends AbstractNodeVisitor<StaticContext> {
         return argument;
     }
 
+    @Override
     public StaticContext visitUnaryLookupExpression(UnaryLookupExpression expression, StaticContext argument) {
         visitDescendants(expression, argument);
         expression.setStaticSequenceType(SequenceType.createSequenceType("item*"));

--- a/src/main/java/org/rumbledb/compiler/ProjectionPushdownDetectionVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/ProjectionPushdownDetectionVisitor.java
@@ -145,6 +145,7 @@ public class ProjectionPushdownDetectionVisitor
         return result;
     }
 
+    @Override
     public ReferenceMap visitOrderByClause(OrderByClause clause, ReferenceMap argument) {
         // we create a copy of the references made by the outside world
         ReferenceMap result = new ReferenceMap(argument);

--- a/src/main/java/org/rumbledb/compiler/SequentialClassificationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/SequentialClassificationVisitor.java
@@ -60,6 +60,7 @@ public class SequentialClassificationVisitor extends AbstractNodeVisitor<Descend
         this.variableBlockLevel = new HashMap<>();
     }
 
+    @Override
     protected DescendentSequentialProperties defaultAction(Node node, DescendentSequentialProperties argument) {
         DescendentSequentialProperties result = this.visitDescendants(node, argument);
         if (node instanceof Expression expression) {

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -2052,6 +2052,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         return this.visitKeySpecifier(ctx.keySpecifier());
     }
 
+    @Override
     public Node visitKeySpecifier(JsoniqParser.KeySpecifierContext ctx) {
         if (ctx.lt != null) {
             return new StringLiteralExpression(
@@ -2475,6 +2476,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         );
     }
 
+    @Override
     public Node visitCompPIConstructor(JsoniqParser.CompPIConstructorContext ctx) {
         Expression contentExpression = (Expression) visit(ctx.enclosedExpression());
         if (ctx.ncName() != null) {

--- a/src/main/java/org/rumbledb/compiler/TypeIndependentNodeVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TypeIndependentNodeVisitor.java
@@ -73,6 +73,7 @@ public abstract class TypeIndependentNodeVisitor extends AbstractNodeVisitor<Nod
         return new FlworExpression((ReturnClause) result, expression.getMetadata());
     }
 
+    @Override
     public Node visitVariableReference(VariableReferenceExpression expression, Node argument) {
         VariableReferenceExpression result = new VariableReferenceExpression(
                 expression.getVariableName(),
@@ -235,6 +236,7 @@ public abstract class TypeIndependentNodeVisitor extends AbstractNodeVisitor<Nod
     // endregion
 
     // region primary
+    @Override
     public Node visitArrayConstructor(ArrayConstructorExpression expression, Node argument) {
         ArrayConstructorExpression result;
         if (expression.isFixedSlotsArrayConstructor()) {
@@ -326,32 +328,39 @@ public abstract class TypeIndependentNodeVisitor extends AbstractNodeVisitor<Nod
         return result;
     }
 
+    @Override
     public Node visitNamedFunctionRef(NamedFunctionReferenceExpression expression, Node argument) {
         return new NamedFunctionReferenceExpression(expression.getIdentifier(), expression.getMetadata());
     }
     // endregion
 
     // region literal
+    @Override
     public Node visitInteger(IntegerLiteralExpression expression, Node argument) {
         return new IntegerLiteralExpression(expression.getLexicalValue(), expression.getMetadata());
     }
 
+    @Override
     public Node visitString(StringLiteralExpression expression, Node argument) {
         return new StringLiteralExpression(expression.getValue(), expression.getMetadata());
     }
 
+    @Override
     public Node visitDouble(DoubleLiteralExpression expression, Node argument) {
         return new DoubleLiteralExpression(expression.getValue(), expression.getMetadata());
     }
 
+    @Override
     public Node visitDecimal(DecimalLiteralExpression expression, Node argument) {
         return new DecimalLiteralExpression(expression.getValue(), expression.getMetadata());
     }
 
+    @Override
     public Node visitNull(NullLiteralExpression expression, Node argument) {
         return new NullLiteralExpression(expression.getMetadata());
     }
 
+    @Override
     public Node visitBoolean(BooleanLiteralExpression expression, Node argument) {
         return new BooleanLiteralExpression(expression.getValue(), expression.getMetadata());
     }

--- a/src/main/java/org/rumbledb/compiler/VariableDependenciesVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/VariableDependenciesVisitor.java
@@ -300,6 +300,7 @@ public class VariableDependenciesVisitor extends AbstractNodeVisitor<Void> {
         return null;
     }
 
+    @Override
     public Void visitGroupByClause(GroupByClause expression, Void argument) {
         visit(expression.getPreviousClause(), null);
         addOutputVariableDependencies(expression, getOutputVariableDependencies(expression.getPreviousClause()));
@@ -321,6 +322,7 @@ public class VariableDependenciesVisitor extends AbstractNodeVisitor<Void> {
         return null;
     }
 
+    @Override
     public Void visitOrderByClause(OrderByClause expression, Void argument) {
         visit(expression.getPreviousClause(), null);
         addOutputVariableDependencies(expression, getOutputVariableDependencies(expression.getPreviousClause()));
@@ -338,6 +340,7 @@ public class VariableDependenciesVisitor extends AbstractNodeVisitor<Void> {
         return null;
     }
 
+    @Override
     public Void visitWhereClause(WhereClause expression, Void argument) {
         visit(expression.getPreviousClause(), null);
         addOutputVariableDependencies(expression, getOutputVariableDependencies(expression.getPreviousClause()));
@@ -352,6 +355,7 @@ public class VariableDependenciesVisitor extends AbstractNodeVisitor<Void> {
         return null;
     }
 
+    @Override
     public Void visitCountClause(CountClause expression, Void argument) {
         visit(expression.getPreviousClause(), null);
         addOutputVariableDependencies(expression, getOutputVariableDependencies(expression.getPreviousClause()));
@@ -363,6 +367,7 @@ public class VariableDependenciesVisitor extends AbstractNodeVisitor<Void> {
         return null;
     }
 
+    @Override
     public Void visitReturnClause(ReturnClause expression, Void argument) {
         visit(expression.getReturnExpr(), null);
         addInputVariableDependencies(expression, getInputVariableDependencies(expression.getReturnExpr()));
@@ -374,6 +379,7 @@ public class VariableDependenciesVisitor extends AbstractNodeVisitor<Void> {
         return null;
     }
 
+    @Override
     public Void visitFilterExpression(FilterExpression expression, Void argument) {
         visit(expression.getMainExpression(), null);
         visit(expression.getPredicateExpression(), null);

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -1844,6 +1844,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         return this.visitKeySpecifier(ctx.keySpecifier());
     }
 
+    @Override
     public Node visitKeySpecifier(XQueryParser.KeySpecifierContext ctx) {
         if (ctx.lt != null) {
             return new StringLiteralExpression(
@@ -2197,6 +2198,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         );
     }
 
+    @Override
     public Node visitCompPIConstructor(XQueryParser.CompPIConstructorContext ctx) {
         Expression contentExpression = (Expression) visit(ctx.enclosedExpression());
         if (ctx.ncName() != null) {

--- a/src/main/java/org/rumbledb/expressions/arithmetic/AdditiveExpression.java
+++ b/src/main/java/org/rumbledb/expressions/arithmetic/AdditiveExpression.java
@@ -68,6 +68,7 @@ public class AdditiveExpression extends Expression {
         return this.isMinus;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/arithmetic/MultiplicativeExpression.java
+++ b/src/main/java/org/rumbledb/expressions/arithmetic/MultiplicativeExpression.java
@@ -104,6 +104,7 @@ public class MultiplicativeExpression extends Expression {
         return this.multiplicativeOperator;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/arithmetic/UnaryExpression.java
+++ b/src/main/java/org/rumbledb/expressions/arithmetic/UnaryExpression.java
@@ -63,6 +63,7 @@ public class UnaryExpression extends Expression {
         return Collections.singletonList(this.mainExpression);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/comparison/ComparisonExpression.java
+++ b/src/main/java/org/rumbledb/expressions/comparison/ComparisonExpression.java
@@ -188,6 +188,7 @@ public class ComparisonExpression extends Expression {
         return this.comparisonOperator;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/flowr/Clause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/Clause.java
@@ -223,6 +223,7 @@ public abstract class Clause extends Node {
     }
 
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/flowr/CountClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/CountClause.java
@@ -51,6 +51,7 @@ public class CountClause extends Clause {
         return this.variableName;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/flowr/FlworExpression.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/FlworExpression.java
@@ -52,6 +52,7 @@ public class FlworExpression extends Expression {
         return this.returnClause;
     }
 
+    @Override
     public List<Node> getChildren() {
         return Collections.singletonList(this.returnClause);
     }

--- a/src/main/java/org/rumbledb/expressions/flowr/ForClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/ForClause.java
@@ -121,6 +121,7 @@ public class ForClause extends Clause {
         return visitor.visitForClause(this, argument);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/flowr/GroupByClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/GroupByClause.java
@@ -62,6 +62,7 @@ public class GroupByClause extends Clause {
         return visitor.visitGroupByClause(this, argument);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/flowr/LetClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/LetClause.java
@@ -109,6 +109,7 @@ public class LetClause extends Clause {
         return visitor.visitLetClause(this, argument);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/flowr/SimpleMapExpression.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/SimpleMapExpression.java
@@ -61,6 +61,7 @@ public class SimpleMapExpression extends Expression {
         return this.rightExpression;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/module/FunctionDeclaration.java
+++ b/src/main/java/org/rumbledb/expressions/module/FunctionDeclaration.java
@@ -68,6 +68,7 @@ public class FunctionDeclaration extends Node {
      * @param buffer a string buffer to write to
      * @param indent the current level of indentation
      */
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/module/LibraryModule.java
+++ b/src/main/java/org/rumbledb/expressions/module/LibraryModule.java
@@ -41,6 +41,7 @@ public class LibraryModule extends Module {
         this.namespace = namespace;
     }
 
+    @Override
     public StaticContext getStaticContext() {
         return this.staticContext;
     }
@@ -71,6 +72,7 @@ public class LibraryModule extends Module {
         return visitor.visitLibraryModule(this, argument);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/module/MainModule.java
+++ b/src/main/java/org/rumbledb/expressions/module/MainModule.java
@@ -48,6 +48,7 @@ public class MainModule extends Module {
         this.program = program;
     }
 
+    @Override
     public StaticContext getStaticContext() {
         return this.staticContext;
     }

--- a/src/main/java/org/rumbledb/expressions/module/TypeDeclaration.java
+++ b/src/main/java/org/rumbledb/expressions/module/TypeDeclaration.java
@@ -56,6 +56,7 @@ public class TypeDeclaration extends Node {
      * @param buffer a string buffer to write to
      * @param indent the current level of indentation
      */
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/module/VariableDeclaration.java
+++ b/src/main/java/org/rumbledb/expressions/module/VariableDeclaration.java
@@ -129,6 +129,7 @@ public class VariableDeclaration extends Node {
         this.variableHighestStorageMode = mode;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/postfix/DynamicFunctionCallExpression.java
+++ b/src/main/java/org/rumbledb/expressions/postfix/DynamicFunctionCallExpression.java
@@ -76,6 +76,7 @@ public class DynamicFunctionCallExpression extends Expression {
         return this.mainExpression;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/primary/BooleanLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/BooleanLiteralExpression.java
@@ -52,6 +52,7 @@ public class BooleanLiteralExpression extends Expression {
         return new ArrayList<>();
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/primary/DecimalLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/DecimalLiteralExpression.java
@@ -57,6 +57,7 @@ public class DecimalLiteralExpression extends Expression {
         return new ArrayList<>();
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/primary/DoubleLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/DoubleLiteralExpression.java
@@ -52,6 +52,7 @@ public class DoubleLiteralExpression extends Expression {
         return new ArrayList<>();
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/primary/FunctionCallExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/FunctionCallExpression.java
@@ -88,6 +88,7 @@ public class FunctionCallExpression extends Expression {
         return visitor.visitFunctionCall(this, argument);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/primary/InlineFunctionExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/InlineFunctionExpression.java
@@ -181,6 +181,7 @@ public class InlineFunctionExpression extends Expression {
         return visitor.visitInlineFunctionExpr(this, argument);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/primary/IntegerLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/IntegerLiteralExpression.java
@@ -52,6 +52,7 @@ public class IntegerLiteralExpression extends Expression {
         return new ArrayList<>();
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/primary/NamedFunctionReferenceExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/NamedFunctionReferenceExpression.java
@@ -54,6 +54,7 @@ public class NamedFunctionReferenceExpression extends Expression {
         return visitor.visitNamedFunctionRef(this, argument);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/primary/StringLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/StringLiteralExpression.java
@@ -53,6 +53,7 @@ public class StringLiteralExpression extends Expression {
         return new ArrayList<>();
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/primary/VariableReferenceExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/VariableReferenceExpression.java
@@ -68,6 +68,7 @@ public class VariableReferenceExpression extends Expression {
         return new ArrayList<>();
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/typing/CastExpression.java
+++ b/src/main/java/org/rumbledb/expressions/typing/CastExpression.java
@@ -48,6 +48,7 @@ public class CastExpression extends Expression {
         return Collections.singletonList(this.mainExpression);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/typing/CastableExpression.java
+++ b/src/main/java/org/rumbledb/expressions/typing/CastableExpression.java
@@ -48,6 +48,7 @@ public class CastableExpression extends Expression {
         return Collections.singletonList(this.mainExpression);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/typing/InstanceOfExpression.java
+++ b/src/main/java/org/rumbledb/expressions/typing/InstanceOfExpression.java
@@ -67,6 +67,7 @@ public class InstanceOfExpression extends Expression {
         return Collections.singletonList(this.mainExpression);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/typing/IsStaticallyExpression.java
+++ b/src/main/java/org/rumbledb/expressions/typing/IsStaticallyExpression.java
@@ -45,6 +45,7 @@ public class IsStaticallyExpression extends Expression {
         return Collections.singletonList(this.mainExpression);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/typing/TreatExpression.java
+++ b/src/main/java/org/rumbledb/expressions/typing/TreatExpression.java
@@ -55,6 +55,7 @@ public class TreatExpression extends Expression {
         return Collections.singletonList(this.mainExpression);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/expressions/typing/ValidateTypeExpression.java
+++ b/src/main/java/org/rumbledb/expressions/typing/ValidateTypeExpression.java
@@ -54,6 +54,7 @@ public class ValidateTypeExpression extends Expression {
         return Collections.singletonList(this.mainExpression);
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");

--- a/src/main/java/org/rumbledb/items/DecimalItem.java
+++ b/src/main/java/org/rumbledb/items/DecimalItem.java
@@ -97,22 +97,27 @@ public class DecimalItem implements Item {
         return !(this.getDecimalValue().compareTo(BigDecimal.ZERO) == 0);
     }
 
+    @Override
     public double castToDoubleValue() {
         return getDecimalValue().doubleValue();
     }
 
+    @Override
     public float castToFloatValue() {
         return getDecimalValue().floatValue();
     }
 
+    @Override
     public BigDecimal castToDecimalValue() {
         return getDecimalValue();
     }
 
+    @Override
     public int castToIntValue() {
         return getDecimalValue().intValue();
     }
 
+    @Override
     public BigInteger castToIntegerValue() {
         return getDecimalValue().toBigInteger();
     }
@@ -149,6 +154,7 @@ public class DecimalItem implements Item {
         return new NativeClauseContext(context, this.value.toString(), SequenceType.createSequenceType("decimal"));
     }
 
+    @Override
     public boolean isNumeric() {
         return true;
     }

--- a/src/main/java/org/rumbledb/items/DoubleItem.java
+++ b/src/main/java/org/rumbledb/items/DoubleItem.java
@@ -148,6 +148,7 @@ public class DoubleItem implements Item {
         return (float) this.value;
     }
 
+    @Override
     public BigDecimal castToDecimalValue() {
         if (Double.isNaN(this.value) || Double.isInfinite(this.value)) {
             throw new IteratorFlowException("Cannot call castToDecimal on non numeric");
@@ -155,10 +156,12 @@ public class DoubleItem implements Item {
         return BigDecimal.valueOf(getDoubleValue());
     }
 
+    @Override
     public int castToIntValue() {
         return Double.valueOf(this.value).intValue();
     }
 
+    @Override
     public BigInteger castToIntegerValue() {
         return BigDecimal.valueOf(this.value).toBigInteger();
     }

--- a/src/main/java/org/rumbledb/items/DurationItem.java
+++ b/src/main/java/org/rumbledb/items/DurationItem.java
@@ -79,6 +79,7 @@ public class DurationItem implements Item {
         return false;
     }
 
+    @Override
     public Duration getDurationValue() {
         if (Objects.isNull(this.durationValue) && Objects.isNull(this.periodValue)) {
             return Duration.ZERO;
@@ -91,6 +92,7 @@ public class DurationItem implements Item {
             .plus(Objects.isNull(this.durationValue) ? Duration.ofDays(0) : this.durationValue);
     }
 
+    @Override
     public Period getPeriodValue() {
         return this.periodValue;
     }

--- a/src/main/java/org/rumbledb/items/FloatItem.java
+++ b/src/main/java/org/rumbledb/items/FloatItem.java
@@ -138,6 +138,7 @@ public class FloatItem implements Item {
         return this.value;
     }
 
+    @Override
     public BigDecimal castToDecimalValue() {
         if (Float.isNaN(this.value) || Float.isInfinite(this.value)) {
             throw new IteratorFlowException("Cannot call castToDecimal on non numeric");
@@ -145,10 +146,12 @@ public class FloatItem implements Item {
         return BigDecimal.valueOf(this.value);
     }
 
+    @Override
     public int castToIntValue() {
         return Float.valueOf(this.value).intValue();
     }
 
+    @Override
     public BigInteger castToIntegerValue() {
         return BigDecimal.valueOf(this.value).toBigInteger();
     }

--- a/src/main/java/org/rumbledb/items/FunctionItem.java
+++ b/src/main/java/org/rumbledb/items/FunctionItem.java
@@ -209,22 +209,27 @@ public class FunctionItem implements Item {
         return this.signature;
     }
 
+    @Override
     public DynamicContext getModuleDynamicContext() {
         return this.dynamicModuleContext;
     }
 
+    @Override
     public RuntimeIterator getBodyIterator() {
         return this.bodyIterator;
     }
 
+    @Override
     public Map<Name, List<Item>> getLocalVariablesInClosure() {
         return this.localVariablesInClosure;
     }
 
+    @Override
     public Map<Name, JavaRDD<Item>> getRDDVariablesInClosure() {
         return this.RDDVariablesInClosure;
     }
 
+    @Override
     public Map<Name, JSoundDataFrame> getDFVariablesInClosure() {
         return this.dataFrameVariablesInClosure;
     }

--- a/src/main/java/org/rumbledb/items/IntItem.java
+++ b/src/main/java/org/rumbledb/items/IntItem.java
@@ -102,22 +102,27 @@ public class IntItem implements Item {
         return String.valueOf(this.value);
     }
 
+    @Override
     public double castToDoubleValue() {
         return Integer.valueOf(this.value).doubleValue();
     }
 
+    @Override
     public float castToFloatValue() {
         return Integer.valueOf(this.value).floatValue();
     }
 
+    @Override
     public BigDecimal castToDecimalValue() {
         return BigDecimal.valueOf(this.value);
     }
 
+    @Override
     public BigInteger castToIntegerValue() {
         return BigInteger.valueOf(this.value);
     }
 
+    @Override
     public int castToIntValue() {
         return this.value;
     }
@@ -166,6 +171,7 @@ public class IntItem implements Item {
         return new NativeClauseContext(context, "" + this.value, SequenceType.createSequenceType("int"));
     }
 
+    @Override
     public boolean isNumeric() {
         return true;
     }

--- a/src/main/java/org/rumbledb/items/IntegerItem.java
+++ b/src/main/java/org/rumbledb/items/IntegerItem.java
@@ -155,6 +155,7 @@ public class IntegerItem implements Item {
         return new NativeClauseContext(context, this.value.toString(), SequenceType.createSequenceType("integer"));
     }
 
+    @Override
     public boolean isNumeric() {
         return true;
     }

--- a/src/main/java/org/rumbledb/items/ItemComparator.java
+++ b/src/main/java/org/rumbledb/items/ItemComparator.java
@@ -57,6 +57,7 @@ public class ItemComparator implements Comparator<Item>, Serializable {
      *
      * @return -1 if v1 &lt; v2; 0 if v1 == v2; 1 if v1 &gt; v2;
      */
+    @Override
     public int compare(Item v1, Item v2) {
         if (this.compareMin) {
             if (

--- a/src/main/java/org/rumbledb/items/MapItem.java
+++ b/src/main/java/org/rumbledb/items/MapItem.java
@@ -214,10 +214,12 @@ public class MapItem implements Item {
         return this.keys.size();
     }
 
+    @Override
     public boolean hasKey(String key) throws UnsupportedOperationException {
         return hasKey(ItemFactory.getInstance().createStringItem(key));
     }
 
+    @Override
     public boolean hasKey(Item key) throws UnsupportedOperationException {
         return this.keyToIndex.containsKey(key);
     }

--- a/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
@@ -130,6 +130,7 @@ public class MapWithAdditionalEntryItem implements Item {
         return this.original.getSize() + 1;
     }
 
+    @Override
     public boolean hasKey(String key) throws UnsupportedOperationException {
         if (this.additionalKey.isString() && this.additionalKey.getStringValue().equals(key)) {
             return true;
@@ -137,6 +138,7 @@ public class MapWithAdditionalEntryItem implements Item {
         return this.original.hasKey(key);
     }
 
+    @Override
     public boolean hasKey(Item key) throws UnsupportedOperationException {
         if (this.itemSameKeyComparator.compare(this.additionalKey, key) == 0) {
             return true;

--- a/src/main/java/org/rumbledb/items/ObjectItem.java
+++ b/src/main/java/org/rumbledb/items/ObjectItem.java
@@ -218,10 +218,12 @@ public class ObjectItem implements Item {
         return this.keys.size();
     }
 
+    @Override
     public boolean hasKey(String key) throws UnsupportedOperationException {
         return this.keyStringToIndex.containsKey(key);
     }
 
+    @Override
     public boolean hasKey(Item key) throws UnsupportedOperationException {
         if (key == null || !(key.isString() || key.isAnyURI() || key.isUntypedAtomic())) {
             return false;

--- a/src/main/java/org/rumbledb/items/StringItem.java
+++ b/src/main/java/org/rumbledb/items/StringItem.java
@@ -86,6 +86,7 @@ public class StringItem implements Item {
         return getStringValue();
     }
 
+    @Override
     public double castToDoubleValue() {
         String trimmedValue = this.value.trim();
         if (trimmedValue.equals("INF") || trimmedValue.equals("+INF")) {
@@ -100,6 +101,7 @@ public class StringItem implements Item {
         return Double.parseDouble(this.getValue());
     }
 
+    @Override
     public float castToFloatValue() {
         String trimmedValue = this.value.trim();
         if (trimmedValue.equals("INF") || trimmedValue.equals("+INF")) {
@@ -117,14 +119,17 @@ public class StringItem implements Item {
         return Float.parseFloat(this.getValue());
     }
 
+    @Override
     public BigDecimal castToDecimalValue() {
         return new BigDecimal(this.value.trim());
     }
 
+    @Override
     public BigInteger castToIntegerValue() {
         return new BigInteger(this.value.trim());
     }
 
+    @Override
     public int castToIntValue() {
         return Integer.parseInt(this.value.trim());
     }
@@ -134,6 +139,7 @@ public class StringItem implements Item {
         return true;
     }
 
+    @Override
     public boolean getEffectiveBooleanValue() {
         return !this.getStringValue().isEmpty();
     }

--- a/src/main/java/org/rumbledb/items/TimeItem.java
+++ b/src/main/java/org/rumbledb/items/TimeItem.java
@@ -163,6 +163,7 @@ public class TimeItem implements Item {
         return this.value.getOffset().getTotalSeconds() / 60;
     }
 
+    @Override
     public OffsetTime getTimeValue() {
         return this.value;
     }

--- a/src/main/java/org/rumbledb/items/UntypedAtomicItem.java
+++ b/src/main/java/org/rumbledb/items/UntypedAtomicItem.java
@@ -120,6 +120,7 @@ public class UntypedAtomicItem implements Item {
         return false;
     }
 
+    @Override
     public boolean getEffectiveBooleanValue() {
         return !this.getStringValue().isEmpty();
     }

--- a/src/main/java/org/rumbledb/items/YearMonthDurationItem.java
+++ b/src/main/java/org/rumbledb/items/YearMonthDurationItem.java
@@ -121,6 +121,7 @@ public class YearMonthDurationItem implements Item {
         return Duration.between(anchor, target);
     }
 
+    @Override
     public Period getPeriodValue() {
         return this.value;
     }

--- a/src/main/java/org/rumbledb/items/gDayItem.java
+++ b/src/main/java/org/rumbledb/items/gDayItem.java
@@ -88,6 +88,7 @@ public class gDayItem implements Item {
         return false;
     }
 
+    @Override
     public String getStringValue() {
         if (this.hasTimeZone) {
             return String.format("---%02d", this.day) + this.offset;

--- a/src/main/java/org/rumbledb/items/gMonthItem.java
+++ b/src/main/java/org/rumbledb/items/gMonthItem.java
@@ -89,6 +89,7 @@ public class gMonthItem implements Item {
         return false;
     }
 
+    @Override
     public String getStringValue() {
         return String.format("--%02d%s", this.month.getValue(), this.hasTimeZone ? this.offset : "");
     }

--- a/src/main/java/org/rumbledb/items/gYearItem.java
+++ b/src/main/java/org/rumbledb/items/gYearItem.java
@@ -87,6 +87,7 @@ public class gYearItem implements Item {
         return false;
     }
 
+    @Override
     public String getStringValue() {
         return String.format(
             "%s%04d%s",

--- a/src/main/java/org/rumbledb/items/xml/AttributeItem.java
+++ b/src/main/java/org/rumbledb/items/xml/AttributeItem.java
@@ -280,6 +280,7 @@ public class AttributeItem implements Item {
         );
     }
 
+    @Override
     public void setSchemaType(ItemType typeAnnotation) {
         this.typeAnnotation = typeAnnotation;
     }

--- a/src/main/java/org/rumbledb/items/xml/ElementItem.java
+++ b/src/main/java/org/rumbledb/items/xml/ElementItem.java
@@ -377,6 +377,7 @@ public class ElementItem implements Item {
         return this.atomizedValue();
     }
 
+    @Override
     public void setSchemaType(ItemType typeAnnotation) {
         this.typeAnnotation = typeAnnotation;
     }

--- a/src/main/java/org/rumbledb/items/xml/TextItem.java
+++ b/src/main/java/org/rumbledb/items/xml/TextItem.java
@@ -72,6 +72,7 @@ public class TextItem implements Item {
         return this.content;
     }
 
+    @Override
     public boolean getEffectiveBooleanValue() {
         return !this.content.isEmpty();
     }

--- a/src/main/java/org/rumbledb/runtime/AtMostOneItemLocalRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/AtMostOneItemLocalRuntimeIterator.java
@@ -59,6 +59,7 @@ public abstract class AtMostOneItemLocalRuntimeIterator extends RuntimeIterator 
         }
     }
 
+    @Override
     public JavaRDD<Item> getRDD(DynamicContext context) {
         Item i = materializeFirstItemOrNull(context);
         List<Item> result = new ArrayList<>();
@@ -68,6 +69,7 @@ public abstract class AtMostOneItemLocalRuntimeIterator extends RuntimeIterator 
         return SparkSessionManager.getInstance().getJavaSparkContext().parallelize(result);
     }
 
+    @Override
     public abstract Item materializeFirstItemOrNull(
             DynamicContext context
     );
@@ -101,6 +103,7 @@ public abstract class AtMostOneItemLocalRuntimeIterator extends RuntimeIterator 
         this.result = null;
     }
 
+    @Override
     public Item materializeExactlyOneItem(
             DynamicContext dynamicContext
     )
@@ -113,6 +116,7 @@ public abstract class AtMostOneItemLocalRuntimeIterator extends RuntimeIterator 
         return result;
     }
 
+    @Override
     public Item materializeAtMostOneItemOrNull(
             DynamicContext dynamicContext
     )
@@ -120,6 +124,7 @@ public abstract class AtMostOneItemLocalRuntimeIterator extends RuntimeIterator 
         return materializeFirstItemOrNull(dynamicContext);
     }
 
+    @Override
     public void materialize(DynamicContext dynamicContext, List<Item> result) {
         result.clear();
         Item item = materializeFirstItemOrNull(dynamicContext);
@@ -128,6 +133,7 @@ public abstract class AtMostOneItemLocalRuntimeIterator extends RuntimeIterator 
         }
     }
 
+    @Override
     public void materializeNFirstItems(DynamicContext dynamicContext, List<Item> result, int n) {
         result.clear();
         if (n == 0) {

--- a/src/main/java/org/rumbledb/runtime/CommaExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/CommaExpressionIterator.java
@@ -238,6 +238,7 @@ public class CommaExpressionIterator extends HybridRuntimeIterator {
         return this.children;
     }
 
+    @Override
     public PendingUpdateList getPendingUpdateList(DynamicContext context) {
         if (!isUpdating()) {
             return new PendingUpdateList();

--- a/src/main/java/org/rumbledb/runtime/HybridRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/HybridRuntimeIterator.java
@@ -190,6 +190,7 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
         }
     }
 
+    @Override
     public void materialize(DynamicContext context, List<Item> result) {
         if (!isRDDOrDataFrame()) {
             super.materialize(context, result);
@@ -201,6 +202,7 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
         result.addAll(collectedItems);
     }
 
+    @Override
     public void materializeNFirstItems(DynamicContext context, List<Item> result, int n) {
         if (!isRDDOrDataFrame()) {
             super.materializeNFirstItems(context, result, n);
@@ -211,6 +213,7 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
         result.addAll(items.take(n));
     }
 
+    @Override
     public Item materializeFirstItemOrNull(
             DynamicContext context
     ) {
@@ -226,6 +229,7 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
         }
     }
 
+    @Override
     public Item materializeExactlyOneItem(
             DynamicContext context
     )
@@ -245,6 +249,7 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
         throw new MoreThanOneItemException();
     }
 
+    @Override
     public Item materializeAtMostOneItemOrNull(
             DynamicContext context
     )

--- a/src/main/java/org/rumbledb/runtime/RDDRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RDDRuntimeIterator.java
@@ -41,6 +41,7 @@ public abstract class RDDRuntimeIterator extends HybridRuntimeIterator {
         super(children, staticContext);
     }
 
+    @Override
     protected JavaRDD<Item> getRDDAux(DynamicContext context) {
         throw new OurBadException("RDDs are not implemented for the iterator", getMetadata());
     }

--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -213,6 +213,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
         return this.getEffectiveBooleanValueOrCheckPosition(dynamicContext, null);
     }
 
+    @Override
     public void open(DynamicContext context) {
         if (context == null) {
             throw new IteratorFlowException(
@@ -228,10 +229,12 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
         this.currentDynamicContextForLocalExecution = context;
     }
 
+    @Override
     public void close() {
         this.isOpen = false;
     }
 
+    @Override
     public void reset(DynamicContext context) {
         this.hasNext = true;
         this.currentDynamicContextForLocalExecution = context;
@@ -254,6 +257,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
         // TODO serializer other fields
     }
 
+    @Override
     public boolean hasNext() {
         return this.hasNext;
     }
@@ -417,6 +421,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
         return this.isSequential;
     }
 
+    @Override
     public abstract Item next();
 
     public List<Item> materialize(DynamicContext context) {

--- a/src/main/java/org/rumbledb/runtime/RuntimeTupleIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeTupleIterator.java
@@ -76,6 +76,7 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
         return this.child;
     }
 
+    @Override
     public void open(DynamicContext context) {
         if (this.isOpen) {
             throw new IteratorFlowException(
@@ -88,11 +89,13 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
         this.currentDynamicContext = context;
     }
 
+    @Override
     public void close() {
         this.isOpen = false;
         this.child.close();
     }
 
+    @Override
     public void reset(DynamicContext context) {
         this.hasNext = true;
         this.currentDynamicContext = context;
@@ -119,10 +122,12 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
         return this.isOpen;
     }
 
+    @Override
     public boolean hasNext() {
         return this.hasNext;
     }
 
+    @Override
     public abstract FlworTuple next();
 
     public ExceptionMetadata getMetadata() {

--- a/src/main/java/org/rumbledb/runtime/arithmetics/AdditiveOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/arithmetics/AdditiveOperationIterator.java
@@ -69,6 +69,7 @@ public class AdditiveOperationIterator extends AtMostOneItemLocalRuntimeIterator
         this.isMinus = isMinus;
     }
 
+    @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
         try {
             this.left = this.leftIterator.materializeAtMostOneItemOrNull(dynamicContext);

--- a/src/main/java/org/rumbledb/runtime/control/TypeswitchRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/control/TypeswitchRuntimeIterator.java
@@ -221,6 +221,7 @@ public class TypeswitchRuntimeIterator extends HybridRuntimeIterator {
         return this.defaultCase.getReturnIterator().getPendingUpdateList(context);
     }
 
+    @Override
     protected boolean implementsDataFrames() {
         return true;
     }

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/CountClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/CountClauseIterator.java
@@ -186,6 +186,7 @@ public class CountClauseIterator extends RuntimeTupleIterator {
         return dfWithIndex;
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getDynamicContextVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result =
             new TreeMap<Name, DynamicContext.VariableDependency>();
@@ -193,6 +194,7 @@ public class CountClauseIterator extends RuntimeTupleIterator {
         return result;
     }
 
+    @Override
     public Set<Name> getOutputTupleVariableNames() {
         Set<Name> result = new HashSet<>();
         result.addAll(this.child.getOutputTupleVariableNames());
@@ -200,6 +202,7 @@ public class CountClauseIterator extends RuntimeTupleIterator {
         return result;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         super.print(buffer, indent);
         for (int i = 0; i < indent + 1; ++i) {
@@ -209,6 +212,7 @@ public class CountClauseIterator extends RuntimeTupleIterator {
         buffer.append("\n");
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getInputTupleVariableDependencies(
             Map<Name, DynamicContext.VariableDependency> parentProjection
     ) {
@@ -224,6 +228,7 @@ public class CountClauseIterator extends RuntimeTupleIterator {
         return projection;
     }
 
+    @Override
     public boolean containsClause(FLWOR_CLAUSES kind) {
         if (kind == FLWOR_CLAUSES.COUNT) {
             return true;

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/ForClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/ForClauseIterator.java
@@ -1284,6 +1284,7 @@ public class ForClauseIterator extends RuntimeTupleIterator {
         }
     }
 
+    @Override
     public boolean containsClause(FLWOR_CLAUSES kind) {
         if (kind == FLWOR_CLAUSES.FOR) {
             return true;
@@ -1418,6 +1419,7 @@ public class ForClauseIterator extends RuntimeTupleIterator {
      *         it is not possible
      * @param nativeClauseContext context information to generate the native query
      */
+    @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
         if (this.allowingEmpty) {
             return NativeClauseContext.NoNativeQuery;

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/GroupByClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/GroupByClauseIterator.java
@@ -500,6 +500,7 @@ public class GroupByClauseIterator extends RuntimeTupleIterator {
         return new FlworDataFrame(result);
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getDynamicContextVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result = new TreeMap<>();
         for (GroupByClauseSparkIteratorExpression iterator : this.groupingExpressions) {
@@ -516,6 +517,7 @@ public class GroupByClauseIterator extends RuntimeTupleIterator {
         return result;
     }
 
+    @Override
     public Set<Name> getOutputTupleVariableNames() {
         Set<Name> result = new HashSet<>();
         for (GroupByClauseSparkIteratorExpression iterator : this.groupingExpressions) {
@@ -525,6 +527,7 @@ public class GroupByClauseIterator extends RuntimeTupleIterator {
         return result;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         super.print(buffer, indent);
         for (GroupByClauseSparkIteratorExpression iterator : this.groupingExpressions) {
@@ -538,6 +541,7 @@ public class GroupByClauseIterator extends RuntimeTupleIterator {
         }
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getInputTupleVariableDependencies(
             Map<Name, DynamicContext.VariableDependency> parentProjection
     ) {
@@ -683,6 +687,7 @@ public class GroupByClauseIterator extends RuntimeTupleIterator {
             );
     }
 
+    @Override
     public boolean containsClause(FLWOR_CLAUSES kind) {
         if (kind == FLWOR_CLAUSES.GROUP_BY) {
             return true;

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/JoinClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/JoinClauseIterator.java
@@ -436,6 +436,7 @@ public class JoinClauseIterator extends RuntimeTupleIterator {
         return null;
     }
 
+    @Override
     public boolean containsClause(FLWOR_CLAUSES kind) {
         return false;
     }

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/LetClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/LetClauseIterator.java
@@ -534,6 +534,7 @@ public class LetClauseIterator extends RuntimeTupleIterator {
         return intersection.isEmpty();
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getDynamicContextVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result =
             new TreeMap<>(this.assignmentIterator.getVariableDependencies());
@@ -546,6 +547,7 @@ public class LetClauseIterator extends RuntimeTupleIterator {
         return result;
     }
 
+    @Override
     public Set<Name> getOutputTupleVariableNames() {
         Set<Name> result = new HashSet<>();
         if (this.child != null && this.evaluationDepthLimit != 0) {
@@ -555,6 +557,7 @@ public class LetClauseIterator extends RuntimeTupleIterator {
         return result;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         super.print(buffer, indent);
         for (int i = 0; i < indent + 1; ++i) {
@@ -564,6 +567,7 @@ public class LetClauseIterator extends RuntimeTupleIterator {
         this.assignmentIterator.print(buffer, indent + 1);
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getInputTupleVariableDependencies(
             Map<Name, DynamicContext.VariableDependency> parentProjection
     ) {
@@ -903,6 +907,7 @@ public class LetClauseIterator extends RuntimeTupleIterator {
             );
     }
 
+    @Override
     public boolean containsClause(FLWOR_CLAUSES kind) {
         if (kind == FLWOR_CLAUSES.LET) {
             return true;

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/OrderByClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/OrderByClauseIterator.java
@@ -460,6 +460,7 @@ public class OrderByClauseIterator extends RuntimeTupleIterator {
         );
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getDynamicContextVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result = new TreeMap<>();
         for (OrderByClauseAnnotatedChildIterator expressionWithIterator : this.expressionsWithIterator) {
@@ -472,10 +473,12 @@ public class OrderByClauseIterator extends RuntimeTupleIterator {
         return result;
     }
 
+    @Override
     public Set<Name> getOutputTupleVariableNames() {
         return new HashSet<>(this.child.getOutputTupleVariableNames());
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         super.print(buffer, indent);
         for (OrderByClauseAnnotatedChildIterator iterator : this.expressionsWithIterator) {
@@ -483,6 +486,7 @@ public class OrderByClauseIterator extends RuntimeTupleIterator {
         }
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getInputTupleVariableDependencies(
             Map<Name, DynamicContext.VariableDependency> parentProjection
     ) {
@@ -637,6 +641,7 @@ public class OrderByClauseIterator extends RuntimeTupleIterator {
         return new NativeClauseContext(orderContext, null, orderContext.getResultingType());
     }
 
+    @Override
     public boolean containsClause(FLWOR_CLAUSES kind) {
         if (kind == FLWOR_CLAUSES.ORDER_BY) {
             return true;

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/ReturnClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/ReturnClauseIterator.java
@@ -318,6 +318,7 @@ public class ReturnClauseIterator extends HybridRuntimeIterator {
         setNextResult();
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result =
             new TreeMap<>(this.expression.getVariableDependencies());
@@ -328,6 +329,7 @@ public class ReturnClauseIterator extends HybridRuntimeIterator {
         return result;
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         for (int i = 0; i < indent; ++i) {
             buffer.append("  ");
@@ -589,6 +591,7 @@ public class ReturnClauseIterator extends HybridRuntimeIterator {
         return new NativeClauseContext(nativeClauseContext, resultColumnName, resultType);
     }
 
+    @Override
     public PendingUpdateList getPendingUpdateList(DynamicContext context) {
         if (!isUpdating()) {
             return new PendingUpdateList();

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/WhereClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/WhereClauseIterator.java
@@ -366,6 +366,7 @@ public class WhereClauseIterator extends RuntimeTupleIterator {
 
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getDynamicContextVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result = new TreeMap<>(
                 this.expression.getVariableDependencies()
@@ -377,15 +378,18 @@ public class WhereClauseIterator extends RuntimeTupleIterator {
         return result;
     }
 
+    @Override
     public Set<Name> getOutputTupleVariableNames() {
         return new HashSet<>(this.child.getOutputTupleVariableNames());
     }
 
+    @Override
     public void print(StringBuilder buffer, int indent) {
         super.print(buffer, indent);
         this.expression.print(buffer, indent + 1);
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getInputTupleVariableDependencies(
             Map<Name, DynamicContext.VariableDependency> parentProjection
     ) {
@@ -472,6 +476,7 @@ public class WhereClauseIterator extends RuntimeTupleIterator {
         );
     }
 
+    @Override
     public boolean containsClause(FLWOR_CLAUSES kind) {
         if (kind == FLWOR_CLAUSES.WHERE) {
             return true;

--- a/src/main/java/org/rumbledb/runtime/flwor/expression/SimpleMapExpressionClosure.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/expression/SimpleMapExpressionClosure.java
@@ -53,6 +53,7 @@ public class SimpleMapExpressionClosure implements FlatMapFunction<Item, Item> {
         this.dynamicContext = new DynamicContext(dynamicContext);
     }
 
+    @Override
     public Iterator<Item> call(Item item) throws Exception {
         List<Item> currentItems = new ArrayList<>();
 

--- a/src/main/java/org/rumbledb/runtime/flwor/expression/SimpleMapExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/expression/SimpleMapExpressionIterator.java
@@ -178,6 +178,7 @@ public class SimpleMapExpressionIterator extends HybridRuntimeIterator {
         return mapValuesRaw;
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result =
             new TreeMap<Name, DynamicContext.VariableDependency>();
@@ -187,6 +188,7 @@ public class SimpleMapExpressionIterator extends HybridRuntimeIterator {
         return result;
     }
 
+    @Override
     protected boolean implementsDataFrames() {
         return true;
     }

--- a/src/main/java/org/rumbledb/runtime/functions/DynamicFunctionCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/DynamicFunctionCallIterator.java
@@ -291,6 +291,7 @@ public class DynamicFunctionCallIterator extends HybridRuntimeIterator {
         this.encounteredExitStatement = false;
     }
 
+    @Override
     protected boolean implementsDataFrames() {
         return true;
     }

--- a/src/main/java/org/rumbledb/runtime/functions/StaticUserDefinedFunctionCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/StaticUserDefinedFunctionCallIterator.java
@@ -74,6 +74,7 @@ public class StaticUserDefinedFunctionCallIterator extends HybridRuntimeIterator
         this.tailCallOptimizationCandidate = tailCallOptimization;
     }
 
+    @Override
     protected boolean implementsDataFrames() {
         return true;
     }
@@ -218,6 +219,7 @@ public class StaticUserDefinedFunctionCallIterator extends HybridRuntimeIterator
         }
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result =
             new TreeMap<>(super.getVariableDependencies());

--- a/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayDescendantClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayDescendantClosure.java
@@ -16,6 +16,7 @@ public class ArrayDescendantClosure implements FlatMapFunction<Item, Item> {
     public ArrayDescendantClosure() {
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<Item>();
         List<Item> innerValues;

--- a/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayFlattenClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayFlattenClosure.java
@@ -16,6 +16,7 @@ public class ArrayFlattenClosure implements FlatMapFunction<Item, Item> {
     public ArrayFlattenClosure() {
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<Item>();
 

--- a/src/main/java/org/rumbledb/runtime/functions/context/LastFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/context/LastFunctionIterator.java
@@ -55,6 +55,7 @@ public class LastFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         return result;
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result =
             new TreeMap<Name, DynamicContext.VariableDependency>();

--- a/src/main/java/org/rumbledb/runtime/functions/context/PositionFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/context/PositionFunctionIterator.java
@@ -55,6 +55,7 @@ public class PositionFunctionIterator extends AtMostOneItemLocalRuntimeIterator 
         return result;
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result =
             new TreeMap<Name, DynamicContext.VariableDependency>();

--- a/src/main/java/org/rumbledb/runtime/functions/dataframe/DropColumnsIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/dataframe/DropColumnsIterator.java
@@ -51,6 +51,7 @@ public class DropColumnsIterator extends HybridRuntimeIterator {
         return null;
     }
 
+    @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
         JSoundDataFrame dataFrame = this.children.get(0).getDataFrame(context);
         List<Item> columnsToDropItems = this.children.get(1).materialize(context);

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/FormatIntegerFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/FormatIntegerFunctionIterator.java
@@ -20,6 +20,7 @@ public class FormatIntegerFunctionIterator extends AtMostOneItemLocalRuntimeIter
         super(arguments, staticContext);
     }
 
+    @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
         Item valueItem = this.children.get(0).materializeFirstItemOrNull(context);
         Item pictureItem = this.children.get(1).materializeFirstItemOrNull(context);

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectDescendantClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectDescendantClosure.java
@@ -16,6 +16,7 @@ public class ObjectDescendantClosure implements FlatMapFunction<Item, Item> {
     public ObjectDescendantClosure() {
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<Item>();
         List<Item> innerValues;

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectIntersectMapClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectIntersectMapClosure.java
@@ -41,6 +41,7 @@ public class ObjectIntersectMapClosure implements Function<Item, Item> {
         this.mutable = mutable;
     }
 
+    @Override
     public Item call(Item arg0) throws Exception {
         if (!arg0.isObject())
             return arg0;

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectKeysClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectKeysClosure.java
@@ -38,6 +38,7 @@ public class ObjectKeysClosure implements FlatMapFunction<Item, Item> {
     public ObjectKeysClosure() {
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<Item>();
 

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectProjectClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectProjectClosure.java
@@ -23,6 +23,7 @@ public class ObjectProjectClosure implements FlatMapFunction<Item, Item> {
         this.itemMetadata = itemMetadata;
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<>();
         List<String> keys = new ArrayList<>();

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectRemoveKeysClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectRemoveKeysClosure.java
@@ -22,6 +22,7 @@ public class ObjectRemoveKeysClosure implements FlatMapFunction<Item, Item> {
         this.itemMetadata = itemMetadata;
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<>();
         List<String> keys = new ArrayList<>();

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectValuesClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectValuesClosure.java
@@ -37,6 +37,7 @@ public class ObjectValuesClosure implements FlatMapFunction<Item, Item> {
     public ObjectValuesClosure() {
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<Item>();
 

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -79,6 +79,7 @@ public class AvgFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         return this.item;
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         if (this.children.get(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result =

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/CountFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/CountFunctionIterator.java
@@ -143,6 +143,7 @@ public class CountFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         if (this.children.get(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result = new TreeMap<>();

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/MaxFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/MaxFunctionIterator.java
@@ -514,6 +514,7 @@ public class MaxFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         if (this.children.get(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result =

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/MinFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/MinFunctionIterator.java
@@ -494,6 +494,7 @@ public class MinFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         return this.result;
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         if (this.children.get(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result =

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/SumFunctionIterator.java
@@ -189,6 +189,7 @@ public class SumFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         return summedDF.getExactlyOneItem();
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         if (this.children.get(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result =

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/AtomizationClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/AtomizationClosure.java
@@ -14,6 +14,7 @@ public class AtomizationClosure implements FlatMapFunction<Item, Item> {
     public AtomizationClosure() {
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         return arg0.atomizedValue().iterator();
     }

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/value/DistinctValuesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/value/DistinctValuesFunctionIterator.java
@@ -63,6 +63,7 @@ public class DistinctValuesFunctionIterator extends HybridRuntimeIterator {
         }
     }
 
+    @Override
     public Item nextLocal() {
         if (this.hasNext) {
             Item result = this.nextResult; // save the result to be returned

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/value/SameElementsAndLengthClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/value/SameElementsAndLengthClosure.java
@@ -37,6 +37,7 @@ public class SameElementsAndLengthClosure implements FlatMapFunction2<Iterator<I
     public SameElementsAndLengthClosure() {
     }
 
+    @Override
     public Iterator<Boolean> call(Iterator<Item> iterator1, Iterator<Item> iterator2) throws Exception {
         List<Boolean> list = new ArrayList<>();
         while (iterator1.hasNext() && iterator2.hasNext()) {

--- a/src/main/java/org/rumbledb/runtime/misc/RangeOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/misc/RangeOperationIterator.java
@@ -152,6 +152,7 @@ public class RangeOperationIterator extends HybridRuntimeIterator {
         return null;
     }
 
+    @Override
     protected boolean implementsDataFrames() {
         return true;
     }

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupClosure.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupClosure.java
@@ -38,6 +38,7 @@ public class ArrayLookupClosure implements FlatMapFunction<Item, Item> {
         this.lookup = lookup;
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<Item>();
 

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupIterator.java
@@ -260,6 +260,7 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
         return newContext;
     }
 
+    @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
         JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
         initLookupPosition(context);

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayMembersClosure.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayMembersClosure.java
@@ -16,6 +16,7 @@ public class ArrayMembersClosure implements FlatMapFunction<Item, Item> {
     public ArrayMembersClosure() {
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<Item>();
 

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayUnboxingClosure.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayUnboxingClosure.java
@@ -37,6 +37,7 @@ public class ArrayUnboxingClosure implements FlatMapFunction<Item, Item> {
     public ArrayUnboxingClosure() {
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         if (!(arg0.isArray())) {
             return Collections.emptyIterator();

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayUnboxingIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayUnboxingIterator.java
@@ -192,6 +192,7 @@ public class ArrayUnboxingIterator extends HybridRuntimeIterator {
         return this.iterator.generateNativeQuery(nativeClauseContext);
     }
 
+    @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
         JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
         String array = FlworDataFrameUtils.createTempView(childDataFrame.getDataFrame());

--- a/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupClosure.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupClosure.java
@@ -38,6 +38,7 @@ public class ObjectLookupClosure implements FlatMapFunction<Item, Item> {
         this.key = key;
     }
 
+    @Override
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<Item>();
 

--- a/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupIterator.java
@@ -388,6 +388,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
         return newContext;
     }
 
+    @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
         JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
         initLookupKey(context);

--- a/src/main/java/org/rumbledb/runtime/navigation/PredicateIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/PredicateIterator.java
@@ -263,6 +263,7 @@ public class PredicateIterator extends HybridRuntimeIterator {
         return true;
     }
 
+    @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
         JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
         RuntimeIterator filter = this.children.get(1);
@@ -365,6 +366,7 @@ public class PredicateIterator extends HybridRuntimeIterator {
 
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result =
             new TreeMap<Name, DynamicContext.VariableDependency>();

--- a/src/main/java/org/rumbledb/runtime/primary/ArrayRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/ArrayRuntimeIterator.java
@@ -76,6 +76,7 @@ public class ArrayRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
         }
     }
 
+    @Override
     public Item materializeFirstItemOrNull(
             DynamicContext dynamicContext
     ) {

--- a/src/main/java/org/rumbledb/runtime/primary/ContextExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/ContextExpressionIterator.java
@@ -70,6 +70,7 @@ public class ContextExpressionIterator extends AtMostOneItemLocalRuntimeIterator
         return items.get(0);
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result = new TreeMap<>();
         result.put(Name.CONTEXT_ITEM, DynamicContext.VariableDependency.FULL);

--- a/src/main/java/org/rumbledb/runtime/primary/VariableReferenceIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/VariableReferenceIterator.java
@@ -171,6 +171,7 @@ public class VariableReferenceIterator extends HybridRuntimeIterator {
         return this.variableName;
     }
 
+    @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
         Map<Name, DynamicContext.VariableDependency> result = new TreeMap<>();
         result.put(this.variableName, DynamicContext.VariableDependency.FULL);

--- a/src/main/java/org/rumbledb/runtime/typing/CastIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/CastIterator.java
@@ -45,6 +45,7 @@ public class CastIterator extends AtMostOneItemLocalRuntimeIterator {
         this.sequenceType = sequenceType;
     }
 
+    @Override
     public Item materializeFirstItemOrNull(
             DynamicContext dynamicContext
     ) {

--- a/src/main/java/org/rumbledb/runtime/typing/InstanceOfIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/InstanceOfIterator.java
@@ -58,6 +58,7 @@ public class InstanceOfIterator extends AtMostOneItemLocalRuntimeIterator {
         this.sequenceType = sequenceType;
     }
 
+    @Override
     public Item materializeFirstItemOrNull(
             DynamicContext dynamicContext
     ) {

--- a/src/main/java/org/rumbledb/runtime/xml/SlashExprClosure.java
+++ b/src/main/java/org/rumbledb/runtime/xml/SlashExprClosure.java
@@ -24,6 +24,7 @@ public class SlashExprClosure implements FlatMapFunction<Item, Item> {
         this.dynamicContext = new DynamicContext(dynamicContext);
     }
 
+    @Override
     public Iterator<Item> call(Item item) throws Exception {
         List<Item> currentItems = new ArrayList<>();
         currentItems.add(item);

--- a/src/main/java/org/rumbledb/runtime/xml/SlashExprClosureZipped.java
+++ b/src/main/java/org/rumbledb/runtime/xml/SlashExprClosureZipped.java
@@ -38,6 +38,7 @@ public class SlashExprClosureZipped implements FlatMapFunction<Tuple2<Item, Long
         this.contextSize = contextSize;
     }
 
+    @Override
     public Iterator<Item> call(Tuple2<Item, Long> itemWithIndex) {
         List<Item> currentItems = new ArrayList<>();
         currentItems.add(itemWithIndex._1());

--- a/src/main/java/org/rumbledb/runtime/xml/axis/forward/ChildAxisIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/axis/forward/ChildAxisIterator.java
@@ -18,6 +18,7 @@ public class ChildAxisIterator extends AxisIterator {
         super(staticContext);
     }
 
+    @Override
     protected void setNextResult() {
         if (this.results == null) {
             this.results = new ArrayList<>();

--- a/src/main/java/org/rumbledb/types/ItemItemType.java
+++ b/src/main/java/org/rumbledb/types/ItemItemType.java
@@ -25,6 +25,7 @@ public class ItemItemType implements ItemType {
         this.name = name;
     }
 
+    @Override
     public boolean isTopmostItemType() {
         return true;
     }

--- a/src/main/java/org/rumbledb/types/ItemTypeReference.java
+++ b/src/main/java/org/rumbledb/types/ItemTypeReference.java
@@ -42,10 +42,12 @@ public class ItemTypeReference implements ItemType {
         this.resolvedItemType = (ItemType) kryo.readClassAndObject(input);
     }
 
+    @Override
     public boolean isResolved() {
         return this.resolvedItemType != null;
     }
 
+    @Override
     public void resolve(DynamicContext context, ExceptionMetadata metadata) {
         if (!context.getInScopeSchemaTypes().checkInScopeSchemaTypeExists(this.name)) {
             throw new UndefinedTypeException("Type undefined: " + this.name, metadata);
@@ -58,6 +60,7 @@ public class ItemTypeReference implements ItemType {
 
 
 
+    @Override
     public void resolve(StaticContext context, ExceptionMetadata metadata) {
 
         Name renamed = renameAtomic(context, this.name);
@@ -124,6 +127,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.equals(other);
     }
 
+    @Override
     public boolean isAtomicItemType() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -131,6 +135,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isAtomicItemType();
     }
 
+    @Override
     public boolean isObjectItemType() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -138,6 +143,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isObjectItemType();
     }
 
+    @Override
     public boolean isArrayItemType() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -145,6 +151,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isArrayItemType();
     }
 
+    @Override
     public boolean isJsonItemType() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -152,6 +159,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isJsonItemType();
     }
 
+    @Override
     public boolean isUnionType() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -159,6 +167,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isUnionType();
     }
 
+    @Override
     public boolean isFunctionItemType() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -166,6 +175,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isFunctionItemType();
     }
 
+    @Override
     public boolean isNumeric() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -173,11 +183,13 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isNumeric();
     }
 
+    @Override
     public boolean hasName() {
         return true;
     }
 
 
+    @Override
     public Name getName() {
         if (this.resolvedItemType != null) {
             return this.resolvedItemType.getName();
@@ -185,6 +197,7 @@ public class ItemTypeReference implements ItemType {
         return this.name;
     }
 
+    @Override
     public FunctionSignature getSignature() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -192,6 +205,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getSignature();
     }
 
+    @Override
     public boolean isSubtypeOf(ItemType superType) {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -199,6 +213,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isSubtypeOf(superType);
     }
 
+    @Override
     public ItemType findLeastCommonSuperTypeWith(ItemType other) {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -206,6 +221,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.findLeastCommonSuperTypeWith(other);
     }
 
+    @Override
     public ItemType findLeastCommonSuperTypeLax(ItemType other) {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -213,6 +229,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.findLeastCommonSuperTypeLax(other);
     }
 
+    @Override
     public boolean isStaticallyCastableAs(ItemType other) {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -220,6 +237,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isStaticallyCastableAs(other);
     }
 
+    @Override
     public boolean canBePromotedTo(ItemType itemType) {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -227,6 +245,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.canBePromotedTo(itemType);
     }
 
+    @Override
     public boolean isUserDefined() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -234,6 +253,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isUserDefined();
     }
 
+    @Override
     public boolean isPrimitive() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -241,6 +261,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.isPrimitive();
     }
 
+    @Override
     public ItemType getPrimitiveType() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -248,6 +269,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getPrimitiveType();
     }
 
+    @Override
     public List<Item> getEnumerationFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -255,6 +277,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getEnumerationFacet();
     }
 
+    @Override
     public List<String> getConstraintsFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -262,6 +285,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getConstraintsFacet();
     }
 
+    @Override
     public Integer getMinLengthFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -269,6 +293,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getMinLengthFacet();
     }
 
+    @Override
     public Integer getLengthFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -276,6 +301,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getLengthFacet();
     }
 
+    @Override
     public Integer getMaxLengthFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -283,6 +309,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getMaxLengthFacet();
     }
 
+    @Override
     public Item getMinExclusiveFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -290,6 +317,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getMinExclusiveFacet();
     }
 
+    @Override
     public Item getMinInclusiveFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -297,6 +325,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getMinInclusiveFacet();
     }
 
+    @Override
     public Item getMaxExclusiveFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -304,6 +333,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getMaxExclusiveFacet();
     }
 
+    @Override
     public Item getMaxInclusiveFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -311,6 +341,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getMaxInclusiveFacet();
     }
 
+    @Override
     public Integer getTotalDigitsFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -318,6 +349,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getTotalDigitsFacet();
     }
 
+    @Override
     public Integer getFractionDigitsFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -325,6 +357,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getFractionDigitsFacet();
     }
 
+    @Override
     public TimezoneFacet getExplicitTimezoneFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -332,6 +365,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getExplicitTimezoneFacet();
     }
 
+    @Override
     public WhitespaceFacet getWhitespaceFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -339,6 +373,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getWhitespaceFacet();
     }
 
+    @Override
     public List<String> getPatternFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -346,6 +381,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getPatternFacet();
     }
 
+    @Override
     public OrderedFacetValue getOrderedFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -353,6 +389,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getOrderedFacet();
     }
 
+    @Override
     public Boolean getBoundedFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -360,6 +397,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getBoundedFacet();
     }
 
+    @Override
     public CardinalityFacetValue getCardinalityFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -367,6 +405,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getCardinalityFacet();
     }
 
+    @Override
     public Boolean getNumericFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -374,6 +413,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getNumericFacet();
     }
 
+    @Override
     public List<String> getObjectKeysFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -381,6 +421,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getObjectKeysFacet();
     }
 
+    @Override
     public FieldDescriptor getObjectContentFacet(String key) {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -388,6 +429,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getObjectContentFacet(key);
     }
 
+    @Override
     public List<FieldDescriptor> getObjectContentFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -403,6 +445,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getObjectContentFacetAsUnorderedMap();
     }
 
+    @Override
     public boolean getClosedFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -410,6 +453,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getClosedFacet();
     }
 
+    @Override
     public ItemType getArrayContentFacet() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -417,6 +461,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getArrayContentFacet();
     }
 
+    @Override
     public List<ItemType> getTypes() {
         if (this.resolvedItemType == null) {
             throw new OurBadException("Unresolved type: " + this.name);
@@ -424,6 +469,7 @@ public class ItemTypeReference implements ItemType {
         return this.resolvedItemType.getTypes();
     }
 
+    @Override
     public String getIdentifierString() {
         if (!this.hasName()) {
             return "<anonymous>";

--- a/src/main/java/sparksoniq/spark/ml/BinaryClassificationMetricsFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/BinaryClassificationMetricsFunctionIterator.java
@@ -110,6 +110,7 @@ public class BinaryClassificationMetricsFunctionIterator extends AtMostOneItemLo
                 @Serial
                 private static final long serialVersionUID = 1L;
 
+                @Override
                 public Item call(Tuple2<Object, Object> a) {
                     List<String> keys = new ArrayList<>();
                     keys.add(key1);


### PR DESCRIPTION
Annotating methods with @java.lang.Override improves code readability since it shows the intent. In addition, the compiler **emits an error when a signature of the overridden method doesn't match the superclass method.**

https://docs.oracle.com/javase/8/docs/api/java/lang/Override.html