### PR TITLE
Move `staticURI` from RuntimeIterator to RuntimeStaticContext

### DIFF
--- a/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
@@ -308,7 +308,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.isUpdating(),
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
-            runtimeIterator.setStaticContext(expression.getStaticContext());
             return runtimeIterator;
         }
     }
@@ -342,7 +341,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     .metadata(returnClause.getMetadata())
                     .build()
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
         return runtimeIterator;
     }
 
@@ -459,7 +457,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getVariableName(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
         return runtimeIterator;
     }
     // endregion
@@ -477,7 +474,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 lookupIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
 
         return runtimeIterator;
     }
@@ -495,7 +491,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 nameIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
 
         return runtimeIterator;
     }
@@ -513,7 +508,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 replacerIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
 
         return runtimeIterator;
     }
@@ -533,7 +527,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 positionIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
 
         return runtimeIterator;
     }
@@ -549,7 +542,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 toAppendIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
 
         return runtimeIterator;
     }
@@ -573,7 +565,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getMutabilityLevel(),
                 expression.isInSequentialBlock() || expression.getStaticContext().isQuerySideEffecting()
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
 
         return runtimeIterator;
     }
@@ -593,7 +584,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 mode,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
 
         return runtimeIterator;
     }
@@ -625,7 +615,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         }
-        runtimeIterator.setStaticContext(expression.getStaticContext());
 
         return runtimeIterator;
     }
@@ -640,7 +629,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 contentIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -657,7 +646,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 contentIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -694,7 +683,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         }
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -713,7 +702,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 isBefore,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -729,7 +718,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 mode,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -806,7 +795,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 filterIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -820,7 +809,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 n,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        iterator.setStaticContext(expression.getStaticContext());
+
         return iterator;
     }
 
@@ -833,7 +822,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 lookupIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -846,7 +835,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 lookupIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -864,7 +853,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 lookupIterator,
                 staticContextForRuntime
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
         return runtimeIterator;
     }
 
@@ -880,7 +868,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 lookupIterator,
                 staticContextForRuntime
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -903,7 +891,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 arguments,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -914,7 +902,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 mainIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -945,7 +933,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.isInSequentialBlock() || expression.getStaticContext().isQuerySideEffecting()
             );
         }
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -961,7 +949,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig),
                     expression.isInSequentialBlock() || expression.getStaticContext().isQuerySideEffecting()
             );
-            runtimeIterator.setStaticContext(expression.getStaticContext());
+
             return runtimeIterator;
         } else {
             List<RuntimeIterator> keys = expression.getKeys()
@@ -978,7 +966,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig),
                     expression.isInSequentialBlock() || expression.getStaticContext().isQuerySideEffecting()
             );
-            runtimeIterator.setStaticContext(expression.getStaticContext());
+
             return runtimeIterator;
         }
     }
@@ -1015,7 +1003,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig),
                     expression.isInSequentialBlock() || expression.getStaticContext().isQuerySideEffecting()
             );
-            runtimeIterator.setStaticContext(expression.getStaticContext());
+
             return runtimeIterator;
         }
         RuntimeIterator runtimeIterator = new MapConstructorRuntimeIterator(
@@ -1024,7 +1012,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig),
                 expression.isInSequentialBlock() || expression.getStaticContext().isQuerySideEffecting()
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1043,7 +1031,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getNamespaceDeclarations(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1064,7 +1052,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 contentIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1097,7 +1085,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         }
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1113,7 +1101,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 contentIterator,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1150,7 +1138,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         }
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1184,7 +1172,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         }
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1221,7 +1209,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         }
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1238,7 +1226,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 ),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        result.setStaticContext(expression.getStaticContext());
+
         return result;
     }
 
@@ -1251,7 +1239,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getContent(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        result.setStaticContext(expression.getStaticContext());
+
         return result;
     }
 
@@ -1269,7 +1257,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 ),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        result.setStaticContext(expression.getStaticContext());
+
         return result;
     }
 
@@ -1279,7 +1267,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getContent(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1300,7 +1288,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 atomizedValues,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1313,7 +1301,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getContent(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1322,7 +1310,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
         RuntimeIterator runtimeIterator = new ContextExpressionIterator(
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1342,7 +1330,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig),
                 expression.isUpdating()
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1382,7 +1370,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.isTailCallOptimization()
             );
         }
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1395,7 +1383,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getIdentifier(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
     // endregion
@@ -1407,7 +1395,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getLexicalValue(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1417,7 +1405,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getValue(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1427,7 +1415,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getValue(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1437,7 +1425,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getValue(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1446,7 +1434,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
         RuntimeIterator runtimeIterator = new NullRuntimeIterator(
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1456,7 +1444,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getValue(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
     // endregion
@@ -1493,7 +1481,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.isMinus(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1528,7 +1516,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getMultiplicativeOperator(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1550,7 +1538,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 right,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1572,7 +1560,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 right,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1594,7 +1582,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 right,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1604,7 +1592,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 this.visit(expression.getMainExpression(), argument),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1616,7 +1604,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.isNegated(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1629,7 +1617,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 right,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1643,7 +1631,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getOperator(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1674,7 +1662,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getComparisonOperator(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1688,7 +1676,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getOperator(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1701,7 +1689,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 right,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1713,7 +1701,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getSequenceType(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1726,14 +1714,14 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.isValidate(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         RuntimeIterator resultIterator = new TreatIterator(
                 runtimeIterator,
                 new SequenceType(BuiltinTypesCatalogue.item, expression.getSequenceType().getArity()),
                 ErrorCode.InvalidInstance,
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        resultIterator.setStaticContext(expression.getStaticContext());
+
         return resultIterator;
     }
 
@@ -1747,7 +1735,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.errorCodeThatShouldBeThrown(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1759,7 +1747,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getSequenceType(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1771,7 +1759,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.getSequenceType(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
     // endregion
@@ -1803,7 +1791,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     expression.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
         }
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1823,7 +1811,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 this.visit(expression.getDefaultExpression(), argument),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
     // endregion
@@ -1853,7 +1841,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 expression.isUpdating(),
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -1999,7 +1987,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 this.visit(statement.getDefaultStatement(), argument),
                 statement.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(statement.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -2027,7 +2015,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 defaultCase,
                 statement.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(statement.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -2109,7 +2097,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 statement.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
 
-        runtimeIterator.setStaticContext(statement.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -2133,7 +2121,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     .metadata(returnClause.getMetadata())
                     .build()
         );
-        runtimeIterator.setStaticContext(statement.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -2152,7 +2140,6 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                     ErrorCode.UnexpectedNode,
                     slashExpr.getStaticContextForRuntime(this.config, this.visitorConfig)
             );
-            left.setStaticContext(leftExpression.getStaticContext());
         }
         RuntimeIterator right = this.visit(
             rightExpression,
@@ -2164,7 +2151,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
                 right,
                 slashExpr.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(slashExpr.getStaticContext());
+
         return runtimeIterator;
     }
 
@@ -2199,7 +2186,7 @@ public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator>
         RuntimeIterator runtimeIterator = new PathRootRuntimeIterator(
                 expression.getStaticContextForRuntime(this.config, this.visitorConfig)
         );
-        runtimeIterator.setStaticContext(expression.getStaticContext());
+
         return runtimeIterator;
     }
 

--- a/src/main/java/org/rumbledb/context/RuntimeStaticContext.java
+++ b/src/main/java/org/rumbledb/context/RuntimeStaticContext.java
@@ -2,6 +2,7 @@ package org.rumbledb.context;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -21,6 +22,8 @@ import org.rumbledb.types.SequenceType;
 public class RuntimeStaticContext implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
+
+    private final URI staticURI;
 
     /**
      * Query language associated with this context, which is used for error reporting and to determine the
@@ -122,6 +125,7 @@ public class RuntimeStaticContext implements Serializable {
      */
     public static RuntimeStaticContextBuilder fromStaticContext(@NonNull StaticContext staticContext) {
         return builder()
+            .staticURI(staticContext.getStaticBaseURI())
             .queryLanguage(staticContext.getQueryLanguage())
             .staticallyKnownNamespaces(staticContext.getInScopeNamespaceBindings())
             .staticallyKnownCollations(staticContext.getStaticallyKnownCollations())

--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -34,7 +34,6 @@ import org.rumbledb.config.RumbleRuntimeConfiguration;
 import org.rumbledb.context.DynamicContext;
 import org.rumbledb.context.Name;
 import org.rumbledb.context.RuntimeStaticContext;
-import org.rumbledb.context.StaticContext;
 import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.InvalidArgumentTypeException;
 import org.rumbledb.exceptions.IteratorFlowException;
@@ -87,15 +86,6 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
         if (children != null && !children.isEmpty()) {
             this.children.addAll(children);
         }
-    }
-
-    // For performance reasons, and as only the static URI is really needed at the moment, we only store it.
-    // This avoids the deserialization of many static context copies at runtime.
-    public void setStaticContext(StaticContext staticContext) {
-        if (this.staticURI != null) {
-            throw new OurBadException("Static context already consumed.");
-        }
-        this.staticURI = staticContext.getStaticBaseURI();
     }
 
     /**

--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -23,7 +23,6 @@ package org.rumbledb.runtime;
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,8 +71,6 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
     protected List<RuntimeIterator> children;
     protected transient DynamicContext currentDynamicContextForLocalExecution;
     protected RuntimeStaticContext staticContext;
-    protected URI staticURI;
-    // private StaticContext staticContext;
 
     protected RuntimeIterator(List<RuntimeIterator> children, RuntimeStaticContext staticContext) {
         this.staticContext = staticContext;

--- a/src/main/java/org/rumbledb/runtime/functions/input/AvroFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/AvroFileFunctionIterator.java
@@ -56,7 +56,7 @@ public class AvroFileFunctionIterator extends DataFrameRuntimeIterator {
         Item stringItem = this.children.get(0)
             .materializeFirstItemOrNull(context);
         String url = stringItem.getStringValue();
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }
@@ -72,7 +72,7 @@ public class AvroFileFunctionIterator extends DataFrameRuntimeIterator {
                     if (value.isString()) {
                         if (keys.get(i).equals("avroSchema")) {
                             URI schemaURI = FileSystemUtil.resolveFileSystemURI(
-                                this.staticURI,
+                                this.staticContext.getStaticURI(),
                                 value.getStringValue(),
                                 getMetadata()
                             );

--- a/src/main/java/org/rumbledb/runtime/functions/input/CSVFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/CSVFileFunctionIterator.java
@@ -58,7 +58,7 @@ public class CSVFileFunctionIterator extends DataFrameRuntimeIterator {
         Item stringItem = this.children.get(0)
             .materializeFirstItemOrNull(context);
         String url = stringItem.getStringValue();
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/DeltaFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/DeltaFileFunctionIterator.java
@@ -32,7 +32,7 @@ public class DeltaFileFunctionIterator extends DataFrameRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/JsonLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/JsonLinesFunctionIterator.java
@@ -65,7 +65,7 @@ public class JsonLinesFunctionIterator extends HybridRuntimeIterator {
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
         String url = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
 
         int partitions = -1;
         if (this.children.size() > 1) {
@@ -129,7 +129,7 @@ public class JsonLinesFunctionIterator extends HybridRuntimeIterator {
     protected void init() {
         try {
             URI uri = FileSystemUtil.resolveFileSystemURI(
-                this.staticURI,
+                this.staticContext.getStaticURI(),
                 this.path.getStringValue(),
                 getMetadata()
             );

--- a/src/main/java/org/rumbledb/runtime/functions/input/LibSVMFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/LibSVMFileFunctionIterator.java
@@ -54,7 +54,7 @@ public class LibSVMFileFunctionIterator extends DataFrameRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/ParquetFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/ParquetFileFunctionIterator.java
@@ -53,7 +53,7 @@ public class ParquetFileFunctionIterator extends DataFrameRuntimeIterator {
 
         String url = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
 
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/RootFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/RootFileFunctionIterator.java
@@ -62,7 +62,7 @@ public class RootFileFunctionIterator extends DataFrameRuntimeIterator {
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/StructuredJsonLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/StructuredJsonLinesFunctionIterator.java
@@ -56,7 +56,7 @@ public class StructuredJsonLinesFunctionIterator extends DataFrameRuntimeIterato
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
@@ -58,7 +58,7 @@ public class TextFileFunctionIterator extends RDDRuntimeIterator {
                 .getJavaSparkContext()
                 .emptyRDD();
         }
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url.getStringValue(), getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url.getStringValue(), getMetadata());
         int partitions = MIN_PARTITIONS;
         if (this.children.size() > 1) {
             Item partitionsItem = this.children.get(1).materializeFirstItemOrNull(context);

--- a/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
@@ -58,7 +58,11 @@ public class TextFileFunctionIterator extends RDDRuntimeIterator {
                 .getJavaSparkContext()
                 .emptyRDD();
         }
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url.getStringValue(), getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(
+            this.staticContext.getStaticURI(),
+            url.getStringValue(),
+            getMetadata()
+        );
         int partitions = MIN_PARTITIONS;
         if (this.children.size() > 1) {
             Item partitionsItem = this.children.get(1).materializeFirstItemOrNull(context);

--- a/src/main/java/org/rumbledb/runtime/functions/input/XmlFilesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/XmlFilesFunctionIterator.java
@@ -61,7 +61,7 @@ public class XmlFilesFunctionIterator extends RDDRuntimeIterator {
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
         String url = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
 
         int partitions = 32;
         if (this.children.size() > 1) {

--- a/src/main/java/org/rumbledb/runtime/functions/io/CollectionFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/CollectionFunctionIterator.java
@@ -38,7 +38,7 @@ public class CollectionFunctionIterator extends DataFrameRuntimeIterator {
             throw new CannotRetrieveResourceException("No default collection is defined.", getMetadata());
         }
         String url = stringItem.getStringValue();
-        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, url, getMetadata());
+        URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/io/DocAvailableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/DocAvailableFunctionIterator.java
@@ -32,7 +32,11 @@ public class DocAvailableFunctionIterator extends AtMostOneItemLocalRuntimeItera
             return ItemFactory.getInstance().createBooleanItem(false);
         }
         try {
-            URI uri = FileSystemUtil.resolveURI(this.staticContext.getStaticURI(), uriItem.getStringValue(), getMetadata());
+            URI uri = FileSystemUtil.resolveURI(
+                this.staticContext.getStaticURI(),
+                uriItem.getStringValue(),
+                getMetadata()
+            );
             InputStream xmlFileStream = FileSystemUtil.getDataInputStream(uri, getConfiguration(), getMetadata());
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
             documentBuilderFactory.setNamespaceAware(true);

--- a/src/main/java/org/rumbledb/runtime/functions/io/DocAvailableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/DocAvailableFunctionIterator.java
@@ -32,7 +32,7 @@ public class DocAvailableFunctionIterator extends AtMostOneItemLocalRuntimeItera
             return ItemFactory.getInstance().createBooleanItem(false);
         }
         try {
-            URI uri = FileSystemUtil.resolveURI(this.staticURI, uriItem.getStringValue(), getMetadata());
+            URI uri = FileSystemUtil.resolveURI(this.staticContext.getStaticURI(), uriItem.getStringValue(), getMetadata());
             InputStream xmlFileStream = FileSystemUtil.getDataInputStream(uri, getConfiguration(), getMetadata());
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
             documentBuilderFactory.setNamespaceAware(true);

--- a/src/main/java/org/rumbledb/runtime/functions/io/DocFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/DocFunctionIterator.java
@@ -50,7 +50,7 @@ public class DocFunctionIterator extends LocalFunctionCallIterator {
             this.hasNext = false;
             Item path = this.pathIterator.materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
             try {
-                URI uri = FileSystemUtil.resolveURI(this.staticURI, path.getStringValue(), getMetadata());
+                URI uri = FileSystemUtil.resolveURI(this.staticContext.getStaticURI(), path.getStringValue(), getMetadata());
                 DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
                 documentBuilderFactory.setNamespaceAware(true);
                 DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();

--- a/src/main/java/org/rumbledb/runtime/functions/io/DocFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/DocFunctionIterator.java
@@ -50,7 +50,11 @@ public class DocFunctionIterator extends LocalFunctionCallIterator {
             this.hasNext = false;
             Item path = this.pathIterator.materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
             try {
-                URI uri = FileSystemUtil.resolveURI(this.staticContext.getStaticURI(), path.getStringValue(), getMetadata());
+                URI uri = FileSystemUtil.resolveURI(
+                    this.staticContext.getStaticURI(),
+                    path.getStringValue(),
+                    getMetadata()
+                );
                 DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
                 documentBuilderFactory.setNamespaceAware(true);
                 DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();

--- a/src/main/java/org/rumbledb/runtime/functions/io/LocalTextFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/LocalTextFileFunctionIterator.java
@@ -64,7 +64,7 @@ public class LocalTextFileFunctionIterator extends LocalFunctionCallIterator {
             );
         }
         URI uri = FileSystemUtil.resolveFileSystemURI(
-            this.staticURI,
+            this.staticContext.getStaticURI(),
             path.getStringValue(),
             getMetadata()
         );

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextAvailableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextAvailableFunctionIterator.java
@@ -34,7 +34,7 @@ public class UnparsedTextAvailableFunctionIterator extends AtMostOneItemLocalRun
         }
         try {
             UnparsedTextReader.read(
-                this.staticURI,
+                this.staticContext.getStaticURI(),
                 hrefItem.getStringValue(),
                 encoding,
                 context.getRumbleRuntimeConfiguration(),

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextFunctionIterator.java
@@ -56,7 +56,7 @@ public class UnparsedTextFunctionIterator extends AtMostOneItemLocalRuntimeItera
         }
 
         String result = UnparsedTextReader.read(
-            this.staticURI,
+            this.staticContext.getStaticURI(),
             hrefItem.getStringValue(),
             encoding,
             context.getRumbleRuntimeConfiguration(),

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextLinesFunctionIterator.java
@@ -44,7 +44,7 @@ public class UnparsedTextLinesFunctionIterator extends RDDRuntimeIterator {
         }
 
         String text = UnparsedTextReader.read(
-            this.staticURI,
+            this.staticContext.getStaticURI(),
             hrefItem.getStringValue(),
             encoding,
             context.getRumbleRuntimeConfiguration(),

--- a/src/main/java/org/rumbledb/runtime/functions/io/YamlDocFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/YamlDocFunctionIterator.java
@@ -65,7 +65,7 @@ public class YamlDocFunctionIterator extends LocalFunctionCallIterator {
         Item path = this.iterator.materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
         try {
             URI uri = FileSystemUtil.resolveURI(
-                this.staticURI,
+                this.staticContext.getStaticURI(),
                 path.getStringValue(),
                 getMetadata()
             );

--- a/src/main/java/org/rumbledb/runtime/functions/json/JsonDocFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/json/JsonDocFunctionIterator.java
@@ -62,7 +62,7 @@ public class JsonDocFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
             getMetadata()
         );
 
-        URI uri = resolveJsonDocURI(pathItem.getStringValue(), this.staticURI, getMetadata());
+        URI uri = resolveJsonDocURI(pathItem.getStringValue(), this.staticContext.getStaticURI(), getMetadata());
 
         String jsonText = readJsonResource(uri, context.getRumbleRuntimeConfiguration(), getMetadata());
 

--- a/src/main/java/org/rumbledb/runtime/functions/strings/ResolveURIFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/ResolveURIFunctionIterator.java
@@ -35,7 +35,7 @@ public class ResolveURIFunctionIterator extends AtMostOneItemLocalRuntimeIterato
         if (this.children.size() == 2) {
             base = this.children.get(1).materializeFirstItemOrNull(context);
         } else {
-            base = ItemFactory.getInstance().createAnyURIItem(this.staticURI.toString());
+            base = ItemFactory.getInstance().createAnyURIItem(this.staticContext.getStaticURI().toString());
         }
         if (base == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/strings/StaticBaseURIFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/StaticBaseURIFunctionIterator.java
@@ -25,6 +25,6 @@ public class StaticBaseURIFunctionIterator extends AtMostOneItemLocalRuntimeIter
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        return ItemFactory.getInstance().createAnyURIItem(this.staticURI.toString());
+        return ItemFactory.getInstance().createAnyURIItem(this.staticContext.getStaticURI().toString());
     }
 }

--- a/src/main/java/org/rumbledb/runtime/update/expression/CreateCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/CreateCollectionIterator.java
@@ -107,7 +107,11 @@ public class CreateCollectionIterator extends HybridRuntimeIterator {
         Mode mode = this.mode;
         // If it is a delta-file() call we need to resolve the path to an absolute path.
         if (mode == Mode.DELTA) {
-            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), logicalPath, getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(
+                this.staticContext.getStaticURI(),
+                logicalPath,
+                getMetadata()
+            );
             logicalPath = FileSystemUtil.convertURIToStringForSpark(uri);
         }
 

--- a/src/main/java/org/rumbledb/runtime/update/expression/CreateCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/CreateCollectionIterator.java
@@ -107,7 +107,7 @@ public class CreateCollectionIterator extends HybridRuntimeIterator {
         Mode mode = this.mode;
         // If it is a delta-file() call we need to resolve the path to an absolute path.
         if (mode == Mode.DELTA) {
-            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, logicalPath, getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), logicalPath, getMetadata());
             logicalPath = FileSystemUtil.convertURIToStringForSpark(uri);
         }
 

--- a/src/main/java/org/rumbledb/runtime/update/expression/InsertIndexIntoCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/InsertIndexIntoCollectionIterator.java
@@ -137,7 +137,11 @@ public class InsertIndexIntoCollectionIterator extends HybridRuntimeIterator {
         String logicalPath = targetItem.getStringValue();
         Mode mode = this.mode;
         if (mode == Mode.DELTA) {
-            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), logicalPath, getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(
+                this.staticContext.getStaticURI(),
+                logicalPath,
+                getMetadata()
+            );
             logicalPath = FileSystemUtil.convertURIToStringForSpark(uri);
         }
 

--- a/src/main/java/org/rumbledb/runtime/update/expression/InsertIndexIntoCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/InsertIndexIntoCollectionIterator.java
@@ -137,7 +137,7 @@ public class InsertIndexIntoCollectionIterator extends HybridRuntimeIterator {
         String logicalPath = targetItem.getStringValue();
         Mode mode = this.mode;
         if (mode == Mode.DELTA) {
-            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, logicalPath, getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), logicalPath, getMetadata());
             logicalPath = FileSystemUtil.convertURIToStringForSpark(uri);
         }
 

--- a/src/main/java/org/rumbledb/runtime/update/expression/TruncateCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/TruncateCollectionIterator.java
@@ -97,7 +97,7 @@ public class TruncateCollectionIterator extends HybridRuntimeIterator {
         String logicalPath = collectionNameItem.getStringValue();
         Mode mode = this.mode;
         if (mode == Mode.DELTA) {
-            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticURI, logicalPath, getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), logicalPath, getMetadata());
             if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
                 throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
             }

--- a/src/main/java/org/rumbledb/runtime/update/expression/TruncateCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/TruncateCollectionIterator.java
@@ -97,7 +97,11 @@ public class TruncateCollectionIterator extends HybridRuntimeIterator {
         String logicalPath = collectionNameItem.getStringValue();
         Mode mode = this.mode;
         if (mode == Mode.DELTA) {
-            URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), logicalPath, getMetadata());
+            URI uri = FileSystemUtil.resolveFileSystemURI(
+                this.staticContext.getStaticURI(),
+                logicalPath,
+                getMetadata()
+            );
             if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
                 throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
             }


### PR DESCRIPTION
This helps dropping the `setStaticContext(StaticContext staticContext)` from RuntimeIterator, which only sets the staticURI field of iterator.

Remove a lot of lines because we previously had this pattern during iterator creation:

```java
            RuntimeIterator runtimeIterator = new CommaExpressionIterator(
                    result,
                    expression.isUpdating(),
                    expression.getStaticContextForRuntime(this.config, this.visitorConfig)
            );
            runtimeIterator.setStaticContext(expression.getStaticContext());
            return runtimeIterator;
```

Now with `staticURI` inside RuntimeStaticContext, `getStaticContextForRuntime` should already provide this information from the beginning.