### PR TITLE
Make `children` field in RuntimeIterator private

### DIFF
--- a/src/main/java/org/rumbledb/runtime/CommaExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/CommaExpressionIterator.java
@@ -130,6 +130,12 @@ public class CommaExpressionIterator extends HybridRuntimeIterator {
         }
     }
 
+    public List<RuntimeIterator> getOperands() {
+        // This method is currently used in SequenceLookupIterator and ObjectConstructorRuntimeIterator
+        // Because getChildren is protected and not visible from there
+        return getChildren();
+    }
+
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
         if (!this.getChildren().isEmpty()) {

--- a/src/main/java/org/rumbledb/runtime/CommaExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/CommaExpressionIterator.java
@@ -78,8 +78,8 @@ public class CommaExpressionIterator extends HybridRuntimeIterator {
     private void startLocal() {
         this.childIndex = 0;
 
-        if (this.children.size() >= 1) {
-            this.currentChild = this.children.get(this.childIndex);
+        if (this.getChildren().size() >= 1) {
+            this.currentChild = this.getChild(this.childIndex);
             this.currentChild.open(this.currentDynamicContextForLocalExecution);
         } else {
             this.currentChild = null;
@@ -106,11 +106,11 @@ public class CommaExpressionIterator extends HybridRuntimeIterator {
                 this.nextResult = this.currentChild.next();
             } else {
                 this.currentChild.close();
-                if (++this.childIndex == this.children.size()) {
+                if (++this.childIndex == this.getChildren().size()) {
                     this.currentChild = null;
                     break;
                 }
-                this.currentChild = this.children.get(this.childIndex);
+                this.currentChild = this.getChild(this.childIndex);
                 this.currentChild.open(this.currentDynamicContextForLocalExecution);
             }
         }
@@ -132,15 +132,15 @@ public class CommaExpressionIterator extends HybridRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
-        if (!this.children.isEmpty()) {
+        if (!this.getChildren().isEmpty()) {
             this.childIndex = 0;
-            this.currentChild = this.children.get(this.childIndex);
+            this.currentChild = this.getChild(this.childIndex);
 
             JavaRDD<Item> childRDD = this.currentChild.getRDD(dynamicContext);
             this.childIndex++;
 
-            while (this.childIndex < this.children.size()) {
-                this.currentChild = this.children.get(this.childIndex);
+            while (this.childIndex < this.getChildren().size()) {
+                this.currentChild = this.getChild(this.childIndex);
                 JavaRDD<Item> nextChildRDD = this.currentChild.getRDD(dynamicContext);
                 childRDD = childRDD.union(nextChildRDD);
                 this.childIndex++;
@@ -155,7 +155,7 @@ public class CommaExpressionIterator extends HybridRuntimeIterator {
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
         List<NativeClauseContext> childClauses = new ArrayList<>();
-        for (RuntimeIterator iterator : this.children) {
+        for (RuntimeIterator iterator : this.getChildren()) {
             NativeClauseContext childContext = iterator.generateNativeQuery(nativeClauseContext);
             if (childContext == NativeClauseContext.NoNativeQuery) {
                 return NativeClauseContext.NoNativeQuery;
@@ -229,10 +229,6 @@ public class CommaExpressionIterator extends HybridRuntimeIterator {
         );
     }
 
-    public List<RuntimeIterator> getChildren() {
-        return this.children;
-    }
-
     @Override
     public PendingUpdateList getPendingUpdateList(DynamicContext context) {
         if (!isUpdating()) {
@@ -240,7 +236,7 @@ public class CommaExpressionIterator extends HybridRuntimeIterator {
         }
 
         PendingUpdateList pul = new PendingUpdateList();
-        for (RuntimeIterator child : this.children) {
+        for (RuntimeIterator child : this.getChildren()) {
             pul.mergeUpdates(child.getPendingUpdateList(context), this.getMetadata());
         }
         return pul;

--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -23,10 +23,7 @@ package org.rumbledb.runtime;
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 import lombok.NonNull;
 import org.apache.spark.api.java.JavaRDD;
@@ -82,7 +79,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
         this.isOpen = false;
         this.isUpdating = false;
         this.isSequential = false;
-        this.children = children;
+        this.children = List.copyOf(Objects.requireNonNullElse(children, Collections.emptyList()));
     }
 
     /**

--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -67,7 +67,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
     protected transient boolean isOpen;
     protected boolean isUpdating;
     protected transient boolean isSequential;
-    protected List<RuntimeIterator> children;
+    private final List<RuntimeIterator> children;
     protected transient DynamicContext currentDynamicContextForLocalExecution;
     protected RuntimeStaticContext staticContext;
 
@@ -82,10 +82,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
         this.isUpdating = false;
         this.isSequential = false;
 
-        this.children = new ArrayList<>();
-        if (children != null && !children.isEmpty()) {
-            this.children.addAll(children);
-        }
+        this.children = List.copyOf(children);
     }
 
     /**
@@ -241,6 +238,18 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
 
     public boolean isOpen() {
         return this.isOpen;
+    }
+
+    protected final RuntimeIterator getChild(int index) {
+        return this.children.get(index);
+    }
+
+    protected final List<RuntimeIterator> getChildren() {
+        return this.children;
+    }
+
+    protected final int getNumberOfChildren() {
+        return this.children.size();
     }
 
     public ExceptionMetadata getMetadata() {

--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -72,7 +72,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
     protected transient DynamicContext currentDynamicContextForLocalExecution;
     protected RuntimeStaticContext staticContext;
 
-    protected RuntimeIterator(@NonNull List<RuntimeIterator> children, @NonNull RuntimeStaticContext staticContext) {
+    protected RuntimeIterator(List<RuntimeIterator> children, @NonNull RuntimeStaticContext staticContext) {
         this.staticContext = staticContext;
         if (this.staticContext.getStaticType() == null) {
             throw new OurBadException(
@@ -82,8 +82,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
         this.isOpen = false;
         this.isUpdating = false;
         this.isSequential = false;
-
-        this.children = List.copyOf(children);
+        this.children = children;
     }
 
     /**

--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -67,7 +67,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
     protected transient boolean isOpen;
     protected boolean isUpdating;
     protected transient boolean isSequential;
-    private final List<RuntimeIterator> children;
+    private List<RuntimeIterator> children;
     protected transient DynamicContext currentDynamicContextForLocalExecution;
     protected RuntimeStaticContext staticContext;
 

--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import lombok.NonNull;
 import org.apache.spark.api.java.JavaRDD;
 import org.rumbledb.api.Item;
 import org.rumbledb.config.RumbleRuntimeConfiguration;
@@ -71,7 +72,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
     protected transient DynamicContext currentDynamicContextForLocalExecution;
     protected RuntimeStaticContext staticContext;
 
-    protected RuntimeIterator(List<RuntimeIterator> children, RuntimeStaticContext staticContext) {
+    protected RuntimeIterator(@NonNull List<RuntimeIterator> children, @NonNull RuntimeStaticContext staticContext) {
         this.staticContext = staticContext;
         if (this.staticContext.getStaticType() == null) {
             throw new OurBadException(

--- a/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeIterator.java
@@ -248,10 +248,6 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface<Item>,
         return this.children;
     }
 
-    protected final int getNumberOfChildren() {
-        return this.children.size();
-    }
-
     public ExceptionMetadata getMetadata() {
         return this.staticContext.getMetadata();
     }

--- a/src/main/java/org/rumbledb/runtime/control/AtMostOneItemIfRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/control/AtMostOneItemIfRuntimeIterator.java
@@ -51,28 +51,28 @@ public class AtMostOneItemIfRuntimeIterator extends AtMostOneItemLocalRuntimeIte
     public Item materializeFirstItemOrNull(
             DynamicContext dynamicContext
     ) {
-        RuntimeIterator condition = this.children.get(0);
+        RuntimeIterator condition = this.getChild(0);
         boolean effectiveBooleanValue = condition.getEffectiveBooleanValue(dynamicContext);
 
         if (effectiveBooleanValue) {
-            return this.children.get(1).materializeFirstItemOrNull(dynamicContext);
+            return this.getChild(1).materializeFirstItemOrNull(dynamicContext);
         } else {
-            return this.children.get(2).materializeFirstItemOrNull(dynamicContext);
+            return this.getChild(2).materializeFirstItemOrNull(dynamicContext);
         }
     }
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext conditionResult = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext conditionResult = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (conditionResult == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }
-        NativeClauseContext thenResult = this.children.get(1)
+        NativeClauseContext thenResult = this.getChild(1)
             .generateNativeQuery(new NativeClauseContext(conditionResult, null, null));
         if (thenResult == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }
-        NativeClauseContext elseResult = this.children.get(2)
+        NativeClauseContext elseResult = this.getChild(2)
             .generateNativeQuery(new NativeClauseContext(thenResult, null, null));
         if (elseResult == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;

--- a/src/main/java/org/rumbledb/runtime/control/IfRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/control/IfRuntimeIterator.java
@@ -31,6 +31,7 @@ import org.rumbledb.runtime.RuntimeIterator;
 import org.rumbledb.runtime.update.PendingUpdateList;
 
 import java.io.Serial;
+import java.util.List;
 
 public class IfRuntimeIterator extends HybridRuntimeIterator {
 
@@ -46,10 +47,10 @@ public class IfRuntimeIterator extends HybridRuntimeIterator {
             boolean isUpdating,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        this.children.add(condition);
-        this.children.add(branch);
-        this.children.add(elseBranch);
+        super(
+            List.of(condition, branch, elseBranch),
+            staticContext
+        );
         this.isUpdating = isUpdating;
     }
 
@@ -90,12 +91,12 @@ public class IfRuntimeIterator extends HybridRuntimeIterator {
     }
 
     public RuntimeIterator selectApplicableIterator(DynamicContext dynamicContext) {
-        RuntimeIterator condition = this.children.get(0);
+        RuntimeIterator condition = this.getChild(0);
         boolean effectiveBooleanValue = condition.getEffectiveBooleanValue(dynamicContext);
         if (effectiveBooleanValue) {
-            return this.children.get(1);
+            return this.getChild(1);
         } else {
-            return this.children.get(2);
+            return this.getChild(2);
         }
     }
 

--- a/src/main/java/org/rumbledb/runtime/control/SwitchRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/control/SwitchRuntimeIterator.java
@@ -51,11 +51,13 @@ public class SwitchRuntimeIterator extends HybridRuntimeIterator {
             RuntimeIterator defaultReturn,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        this.children.add(test);
-        this.children.addAll(cases.keySet());
-        this.children.addAll(cases.values());
-        this.children.add(defaultReturn);
+        super(
+            Stream.concat(
+                Stream.concat(Stream.of(test), cases.keySet().stream()),
+                Stream.concat(cases.values().stream(), Stream.of(defaultReturn))
+            ).toList(),
+            staticContext
+        );
         this.testField = test;
         this.cases = cases;
         this.defaultReturn = defaultReturn;

--- a/src/main/java/org/rumbledb/runtime/control/SwitchRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/control/SwitchRuntimeIterator.java
@@ -34,6 +34,7 @@ import org.rumbledb.runtime.misc.ComparisonIterator;
 
 import java.io.Serial;
 import java.util.Map;
+import java.util.stream.Stream;
 
 
 public class SwitchRuntimeIterator extends HybridRuntimeIterator {

--- a/src/main/java/org/rumbledb/runtime/control/TryCatchRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/control/TryCatchRuntimeIterator.java
@@ -53,10 +53,10 @@ public class TryCatchRuntimeIterator extends LocalRuntimeIterator {
             Map<CatchPattern, RuntimeIterator> catchExpressions,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        this.children.add(tryExpression);
-        for (RuntimeIterator value : catchExpressions.values())
-            this.children.add(value);
+        super(
+            Stream.concat(Stream.of(tryExpression), catchExpressions.values().stream()).toList(),
+            staticContext
+        );
         this.tryExpression = tryExpression;
         this.catchExpressions = catchExpressions;
     }

--- a/src/main/java/org/rumbledb/runtime/control/TryCatchRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/control/TryCatchRuntimeIterator.java
@@ -29,6 +29,7 @@ import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.rumbledb.api.Item;
 import org.rumbledb.context.DynamicContext;

--- a/src/main/java/org/rumbledb/runtime/control/TypeswitchRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/control/TypeswitchRuntimeIterator.java
@@ -15,6 +15,8 @@ import org.rumbledb.types.SequenceType;
 import java.io.Serial;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 public class TypeswitchRuntimeIterator extends HybridRuntimeIterator {
 
@@ -34,12 +36,14 @@ public class TypeswitchRuntimeIterator extends HybridRuntimeIterator {
             boolean isUpdating,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        this.children.add(test);
-        for (TypeswitchRuntimeIteratorCase typeSwitchCase : cases) {
-            this.children.add(typeSwitchCase.getReturnIterator());
-        }
-        this.children.add(defaultCase.getReturnIterator());
+        super(
+            Stream.of(
+                Stream.of(test),
+                cases.stream().map(TypeswitchRuntimeIteratorCase::getReturnIterator),
+                Stream.of(defaultCase.getReturnIterator())
+            ).flatMap(Function.identity()).toList(),
+            staticContext
+        );
 
         this.testField = test;
         this.cases = cases;

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/ReturnClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/ReturnClauseIterator.java
@@ -97,7 +97,7 @@ public class ReturnClauseIterator extends HybridRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
-        RuntimeIterator expression = this.children.get(0);
+        RuntimeIterator expression = this.getChild(0);
         if (expression.isRDDOrDataFrame()) {
             if (this.child.isDataFrame())
                 throw new JobWithinAJobException(
@@ -158,7 +158,7 @@ public class ReturnClauseIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        RuntimeIterator expression = this.children.get(0);
+        RuntimeIterator expression = this.getChild(0);
         if (expression.isRDDOrDataFrame()) {
             if (this.child.isDataFrame())
                 throw new JobWithinAJobException(
@@ -607,7 +607,7 @@ public class ReturnClauseIterator extends HybridRuntimeIterator {
             // execution reaches here when there are no more results
         }
 
-        RuntimeIterator expression = this.children.get(0);
+        RuntimeIterator expression = this.getChild(0);
         if (expression.isRDDOrDataFrame()) {
             if (this.child.isDataFrame())
                 throw new JobWithinAJobException(

--- a/src/main/java/org/rumbledb/runtime/flwor/expression/SimpleMapExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/expression/SimpleMapExpressionIterator.java
@@ -79,7 +79,7 @@ public class SimpleMapExpressionIterator extends HybridRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
-        JavaRDD<Item> childRDD = this.children.get(0).getRDD(dynamicContext);
+        JavaRDD<Item> childRDD = this.getChild(0).getRDD(dynamicContext);
         JavaPairRDD<Item, Long> zippedChildRDD = childRDD.zipWithIndex();
         long count = childRDD.count();
         FlatMapFunction<Tuple2<Item, Long>, Item> transformation = new SimpleMapExpressionClosureZipped(

--- a/src/main/java/org/rumbledb/runtime/functions/BuiltinFunctionItemCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/BuiltinFunctionItemCallIterator.java
@@ -50,12 +50,11 @@ public class BuiltinFunctionItemCallIterator extends HybridRuntimeIterator {
             List<RuntimeIterator> functionArguments,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        for (RuntimeIterator arg : functionArguments) {
-            if (arg != null) {
-                this.children.add(arg);
-            }
-        }
+        super(
+            functionArguments.stream().filter(arg -> arg != null).toList(),
+            staticContext
+        );
+
         this.functionItem = functionItem;
         this.functionArguments = functionArguments;
         this.isUpdating = functionItem.getSignature().isUpdating();

--- a/src/main/java/org/rumbledb/runtime/functions/DynamicFunctionCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/DynamicFunctionCallIterator.java
@@ -22,6 +22,7 @@ package org.rumbledb.runtime.functions;
 
 import java.io.Serial;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.rumbledb.api.Item;
@@ -74,19 +75,19 @@ public class DynamicFunctionCallIterator extends HybridRuntimeIterator {
             List<RuntimeIterator> functionArguments,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        this.isPartialApplication = false;
+        super(
+            Stream.concat(
+                functionArguments.stream().filter(arg -> arg != null),
+                functionArguments.contains(functionItemIterator)
+                    ? Stream.empty()
+                    : Stream.of(functionItemIterator)
+            ).toList(),
+            staticContext
+        );
+
+        this.isPartialApplication = functionArguments.stream().anyMatch(arg -> arg == null);
         this.nextExitStatementResult = 0;
-        for (RuntimeIterator arg : functionArguments) {
-            if (arg != null) {
-                this.children.add(arg);
-            } else {
-                this.isPartialApplication = true;
-            }
-        }
-        if (!this.children.contains(functionItemIterator)) {
-            this.children.add(functionItemIterator);
-        }
+
         this.functionItemIterator = functionItemIterator;
         this.functionArguments = functionArguments;
     }

--- a/src/main/java/org/rumbledb/runtime/functions/FunctionItemCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/FunctionItemCallIterator.java
@@ -72,14 +72,11 @@ public class FunctionItemCallIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext,
             boolean isTailOptimization
     ) {
-        super(null, staticContext);
-        for (RuntimeIterator arg : functionArguments) {
-            if (arg == null) {
-                this.isPartialApplication = true;
-            } else {
-                this.children.add(arg);
-            }
-        }
+        super(
+            functionArguments.stream().filter(arg -> arg != null).toList(),
+            staticContext
+        );
+        this.isPartialApplication = functionArguments.stream().anyMatch(arg -> arg == null);
         if (isTailOptimization) {
             this.isPartialApplication = true;
             this.isTailOptimization = true;

--- a/src/main/java/org/rumbledb/runtime/functions/FunctionLookupFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/FunctionLookupFunctionIterator.java
@@ -47,7 +47,7 @@ public class FunctionLookupFunctionIterator extends AtMostOneItemLocalRuntimeIte
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item nameItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item nameItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (!nameItem.isQName()) {
             throw new UnexpectedTypeException(
                     "function-lookup: first argument must be xs:QName",
@@ -56,7 +56,7 @@ public class FunctionLookupFunctionIterator extends AtMostOneItemLocalRuntimeIte
         }
         Name fnName = nameItem.getQNameValue();
 
-        Item arityItem = this.children.get(1).materializeFirstItemOrNull(context);
+        Item arityItem = this.getChild(1).materializeFirstItemOrNull(context);
         if (arityItem == null) {
             throw new UnexpectedTypeException(
                     "function-lookup: second argument must be xs:integer",

--- a/src/main/java/org/rumbledb/runtime/functions/QNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/QNameFunctionIterator.java
@@ -47,10 +47,10 @@ public class QNameFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item uriItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item uriItem = this.getChild(0).materializeFirstItemOrNull(context);
         String uriString = uriItem == null ? null : uriItem.getStringValue();
 
-        Item lexicalItem = this.children.get(1).materializeFirstItemOrNull(context);
+        Item lexicalItem = this.getChild(1).materializeFirstItemOrNull(context);
         if (lexicalItem == null) {
             throw new UnexpectedTypeException(
                     "fn:QName: second argument must be xs:string (got empty sequence).",

--- a/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayMembersFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayMembersFunctionIterator.java
@@ -48,7 +48,7 @@ public class ArrayMembersFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(arguments, staticContext);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
         this.nextResults = new LinkedList<>();
     }
 

--- a/src/main/java/org/rumbledb/runtime/functions/arrays/ArraySizeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/arrays/ArraySizeFunctionIterator.java
@@ -48,7 +48,7 @@ public class ArraySizeFunctionIterator extends AtMostOneItemLocalRuntimeIterator
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item array = this.children.get(0).materializeFirstItemOrNull(context);
+        Item array = this.getChild(0).materializeFirstItemOrNull(context);
         if (array == null) {
             return null;
         }
@@ -57,7 +57,7 @@ public class ArraySizeFunctionIterator extends AtMostOneItemLocalRuntimeIterator
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext nativeChildQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext nativeChildQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (nativeChildQuery != NativeClauseContext.NoNativeQuery) {
             return new NativeClauseContext(
                     nativeClauseContext,

--- a/src/main/java/org/rumbledb/runtime/functions/base/ApplyFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/base/ApplyFunctionIterator.java
@@ -87,8 +87,8 @@ public class ApplyFunctionIterator extends HybridRuntimeIterator {
         Item functionItem;
         Item argumentsArray;
         try {
-            functionItem = this.children.get(0).materializeAtMostOneItemOrNull(context);
-            argumentsArray = this.children.get(1).materializeAtMostOneItemOrNull(context);
+            functionItem = this.getChild(0).materializeAtMostOneItemOrNull(context);
+            argumentsArray = this.getChild(1).materializeAtMostOneItemOrNull(context);
         } catch (MoreThanOneItemException e) {
             throw new UnexpectedTypeException(
                     "fn:apply expects exactly one function item and exactly one array item.",

--- a/src/main/java/org/rumbledb/runtime/functions/booleans/BooleanFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/booleans/BooleanFunctionIterator.java
@@ -44,7 +44,7 @@ public class BooleanFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        RuntimeIterator iterator = this.children.get(0);
+        RuntimeIterator iterator = this.getChild(0);
         boolean effectiveBooleanValue = iterator.getEffectiveBooleanValue(
             context
         );

--- a/src/main/java/org/rumbledb/runtime/functions/booleans/NotFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/booleans/NotFunctionIterator.java
@@ -44,7 +44,7 @@ public class NotFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        RuntimeIterator iterator = this.children.get(0);
+        RuntimeIterator iterator = this.getChild(0);
         boolean effectiveBooleanValue = iterator.getEffectiveBooleanValue(
             context
         );

--- a/src/main/java/org/rumbledb/runtime/functions/context/EnvironmentVariableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/context/EnvironmentVariableFunctionIterator.java
@@ -23,7 +23,7 @@ public class EnvironmentVariableFunctionIterator extends AtMostOneItemLocalRunti
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item nameItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item nameItem = this.getChild(0).materializeFirstItemOrNull(context);
         String value = System.getenv(nameItem.getStringValue());
         if (value == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/dataframe/DropColumnsIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/dataframe/DropColumnsIterator.java
@@ -48,8 +48,8 @@ public class DropColumnsIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        JSoundDataFrame dataFrame = this.children.get(0).getDataFrame(context);
-        List<Item> columnsToDropItems = this.children.get(1).materialize(context);
+        JSoundDataFrame dataFrame = this.getChild(0).getDataFrame(context);
+        List<Item> columnsToDropItems = this.getChild(1).materialize(context);
         if (columnsToDropItems.isEmpty()) {
             throw new InvalidSelectorException(
                     "Invalid drop-columns parameter; drop-columns can't be performed without string columns to be removed.",

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/DateTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/DateTimeFunctionIterator.java
@@ -25,8 +25,8 @@ public class DateTimeFunctionIterator extends AtMostOneItemLocalRuntimeIterator 
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateItem = this.children.get(0).materializeFirstItemOrNull(context);
-        Item timeItem = this.children.get(1).materializeFirstItemOrNull(context);
+        Item dateItem = this.getChild(0).materializeFirstItemOrNull(context);
+        Item timeItem = this.getChild(1).materializeFirstItemOrNull(context);
         if (dateItem == null || timeItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/ParseIETFDateFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/ParseIETFDateFunctionIterator.java
@@ -127,7 +127,7 @@ public class ParseIETFDateFunctionIterator extends AtMostOneItemLocalRuntimeIter
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item inputItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item inputItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (inputItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustDateTimeToTimezone.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustDateTimeToTimezone.java
@@ -27,13 +27,13 @@ public class AdjustDateTimeToTimezone extends AtMostOneItemLocalRuntimeIterator 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
         Item timeItem = this.getChild(0).materializeFirstItemOrNull(context);
-        if (this.getNumberOfChildren() == 2) {
+        if (this.getChildren().size() == 2) {
             this.timezone = this.getChild(1).materializeFirstItemOrNull(context);
         }
         if (timeItem == null) {
             return null;
         }
-        if (this.timezone == null && this.getNumberOfChildren() == 1) {
+        if (this.timezone == null && this.getChildren().size() == 1) {
             return ItemFactory.getInstance()
                 .createDateTimeItem(timeItem.getDateTimeValue().withOffsetSameInstant(ZoneOffset.UTC), true);
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustDateTimeToTimezone.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustDateTimeToTimezone.java
@@ -26,14 +26,14 @@ public class AdjustDateTimeToTimezone extends AtMostOneItemLocalRuntimeIterator 
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item timeItem = this.children.get(0).materializeFirstItemOrNull(context);
-        if (this.children.size() == 2) {
-            this.timezone = this.children.get(1).materializeFirstItemOrNull(context);
+        Item timeItem = this.getChild(0).materializeFirstItemOrNull(context);
+        if (this.getNumberOfChildren() == 2) {
+            this.timezone = this.getChild(1).materializeFirstItemOrNull(context);
         }
         if (timeItem == null) {
             return null;
         }
-        if (this.timezone == null && this.children.size() == 1) {
+        if (this.timezone == null && this.getNumberOfChildren() == 1) {
             return ItemFactory.getInstance()
                 .createDateTimeItem(timeItem.getDateTimeValue().withOffsetSameInstant(ZoneOffset.UTC), true);
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustDateToTimezone.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustDateToTimezone.java
@@ -26,14 +26,14 @@ public class AdjustDateToTimezone extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateItem = this.children.get(0).materializeFirstItemOrNull(context);
-        if (this.children.size() == 2) {
-            this.timezone = this.children.get(1).materializeFirstItemOrNull(context);
+        Item dateItem = this.getChild(0).materializeFirstItemOrNull(context);
+        if (this.getChildren().size() == 2) {
+            this.timezone = this.getChild(1).materializeFirstItemOrNull(context);
         }
         if (dateItem == null) {
             return null;
         }
-        if (this.timezone == null && this.children.size() == 1) {
+        if (this.timezone == null && this.getChildren().size() == 1) {
             return ItemFactory.getInstance()
                 .createDateItem(dateItem.getDateTimeValue().withOffsetSameInstant(ZoneOffset.UTC), true);
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustTimeToTimezone.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustTimeToTimezone.java
@@ -30,10 +30,10 @@ public class AdjustTimeToTimezone extends AtMostOneItemLocalRuntimeIterator {
         if (timeItem == null) {
             return null;
         }
-        if (this.getNumberOfChildren() == 2) {
+        if (this.getChildren().size() == 2) {
             this.timezone = this.getChild(1).materializeFirstItemOrNull(context);
         }
-        if (this.timezone == null && this.getNumberOfChildren() == 1) {
+        if (this.timezone == null && this.getChildren().size() == 1) {
             return ItemFactory.getInstance()
                 .createTimeItem(timeItem.getTimeValue().withOffsetSameInstant(ZoneOffset.UTC), true);
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustTimeToTimezone.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/AdjustTimeToTimezone.java
@@ -26,14 +26,14 @@ public class AdjustTimeToTimezone extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item timeItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item timeItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (timeItem == null) {
             return null;
         }
-        if (this.children.size() == 2) {
-            this.timezone = this.children.get(1).materializeFirstItemOrNull(context);
+        if (this.getNumberOfChildren() == 2) {
+            this.timezone = this.getChild(1).materializeFirstItemOrNull(context);
         }
-        if (this.timezone == null && this.children.size() == 1) {
+        if (this.timezone == null && this.getNumberOfChildren() == 1) {
             return ItemFactory.getInstance()
                 .createTimeItem(timeItem.getTimeValue().withOffsetSameInstant(ZoneOffset.UTC), true);
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/DayFromDateFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/DayFromDateFunctionIterator.java
@@ -24,7 +24,7 @@ public class DayFromDateFunctionIterator extends AtMostOneItemLocalRuntimeIterat
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item dateItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (dateItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/DayFromDateTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/DayFromDateTimeFunctionIterator.java
@@ -24,7 +24,7 @@ public class DayFromDateTimeFunctionIterator extends AtMostOneItemLocalRuntimeIt
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateTimeItem = this.children.get(0)
+        Item dateTimeItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (dateTimeItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/HoursFromDateTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/HoursFromDateTimeFunctionIterator.java
@@ -24,7 +24,7 @@ public class HoursFromDateTimeFunctionIterator extends AtMostOneItemLocalRuntime
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateTimeItem = this.children.get(0)
+        Item dateTimeItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (dateTimeItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/HoursFromTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/HoursFromTimeFunctionIterator.java
@@ -24,7 +24,7 @@ public class HoursFromTimeFunctionIterator extends AtMostOneItemLocalRuntimeIter
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item timeItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item timeItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (timeItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/MinutesFromDateTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/MinutesFromDateTimeFunctionIterator.java
@@ -24,7 +24,7 @@ public class MinutesFromDateTimeFunctionIterator extends AtMostOneItemLocalRunti
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateTimeItem = this.children.get(0)
+        Item dateTimeItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (dateTimeItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/MinutesFromTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/MinutesFromTimeFunctionIterator.java
@@ -24,7 +24,7 @@ public class MinutesFromTimeFunctionIterator extends AtMostOneItemLocalRuntimeIt
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item timeItem = this.children.get(0)
+        Item timeItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (timeItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/MonthFromDateFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/MonthFromDateFunctionIterator.java
@@ -24,7 +24,7 @@ public class MonthFromDateFunctionIterator extends AtMostOneItemLocalRuntimeIter
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item dateItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (dateItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/MonthFromDateTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/MonthFromDateTimeFunctionIterator.java
@@ -24,7 +24,7 @@ public class MonthFromDateTimeFunctionIterator extends AtMostOneItemLocalRuntime
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateTimeItem = this.children.get(0)
+        Item dateTimeItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (dateTimeItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/SecondsFromDateTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/SecondsFromDateTimeFunctionIterator.java
@@ -25,7 +25,7 @@ public class SecondsFromDateTimeFunctionIterator extends AtMostOneItemLocalRunti
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateTimeItem = this.children.get(0)
+        Item dateTimeItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (dateTimeItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/SecondsFromTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/SecondsFromTimeFunctionIterator.java
@@ -25,7 +25,7 @@ public class SecondsFromTimeFunctionIterator extends AtMostOneItemLocalRuntimeIt
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item timeItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item timeItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (timeItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/TimezoneFromDateFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/TimezoneFromDateFunctionIterator.java
@@ -25,7 +25,7 @@ public class TimezoneFromDateFunctionIterator extends AtMostOneItemLocalRuntimeI
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item dateItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (dateItem == null || !dateItem.hasTimeZone()) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/TimezoneFromDateTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/TimezoneFromDateTimeFunctionIterator.java
@@ -25,7 +25,7 @@ public class TimezoneFromDateTimeFunctionIterator extends AtMostOneItemLocalRunt
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateTimeItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item dateTimeItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (dateTimeItem == null || !dateTimeItem.hasTimeZone()) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/TimezoneFromTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/TimezoneFromTimeFunctionIterator.java
@@ -25,7 +25,7 @@ public class TimezoneFromTimeFunctionIterator extends AtMostOneItemLocalRuntimeI
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item timeItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item timeItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (timeItem == null || !timeItem.hasTimeZone()) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/YearFromDateFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/YearFromDateFunctionIterator.java
@@ -24,7 +24,7 @@ public class YearFromDateFunctionIterator extends AtMostOneItemLocalRuntimeItera
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item dateItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (dateItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/components/YearFromDateTimeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/components/YearFromDateTimeFunctionIterator.java
@@ -24,7 +24,7 @@ public class YearFromDateTimeFunctionIterator extends AtMostOneItemLocalRuntimeI
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item dateTimeItem = this.children.get(0)
+        Item dateTimeItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (dateTimeItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/datetime/dateformatting/DateFormattingFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/datetime/dateformatting/DateFormattingFunctionIterator.java
@@ -24,17 +24,17 @@ abstract class DateFormattingFunctionIterator extends AtMostOneItemLocalRuntimeI
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item valueItem = this.children.get(0).materializeFirstItemOrNull(context);
-        Item pictureItem = this.children.get(1).materializeFirstItemOrNull(context);
+        Item valueItem = this.getChild(0).materializeFirstItemOrNull(context);
+        Item pictureItem = this.getChild(1).materializeFirstItemOrNull(context);
 
-        Item languageItem = this.children.size() > 2
-            ? this.children.get(2).materializeFirstItemOrNull(context)
+        Item languageItem = this.getChildren().size() > 2
+            ? this.getChild(2).materializeFirstItemOrNull(context)
             : null;
-        Item calendarItem = this.children.size() > 3
-            ? this.children.get(3).materializeFirstItemOrNull(context)
+        Item calendarItem = this.getChildren().size() > 3
+            ? this.getChild(3).materializeFirstItemOrNull(context)
             : null;
-        Item placeItem = this.children.size() > 4
-            ? this.children.get(4).materializeFirstItemOrNull(context)
+        Item placeItem = this.getChildren().size() > 4
+            ? this.getChild(4).materializeFirstItemOrNull(context)
             : null;
 
         // If $value is the empty sequence, the functions return the empty sequence

--- a/src/main/java/org/rumbledb/runtime/functions/durations/components/DaysFromDurationFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/durations/components/DaysFromDurationFunctionIterator.java
@@ -24,7 +24,7 @@ public class DaysFromDurationFunctionIterator extends AtMostOneItemLocalRuntimeI
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item durationItem = this.children.get(0)
+        Item durationItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (durationItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/durations/components/HoursFromDurationFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/durations/components/HoursFromDurationFunctionIterator.java
@@ -24,7 +24,7 @@ public class HoursFromDurationFunctionIterator extends AtMostOneItemLocalRuntime
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item durationItem = this.children.get(0)
+        Item durationItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (durationItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/durations/components/MinutesFromDurationFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/durations/components/MinutesFromDurationFunctionIterator.java
@@ -24,7 +24,7 @@ public class MinutesFromDurationFunctionIterator extends AtMostOneItemLocalRunti
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item durationItem = this.children.get(0)
+        Item durationItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (durationItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/durations/components/MonthsFromDurationFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/durations/components/MonthsFromDurationFunctionIterator.java
@@ -24,7 +24,7 @@ public class MonthsFromDurationFunctionIterator extends AtMostOneItemLocalRuntim
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item durationItem = this.children.get(0)
+        Item durationItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (durationItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/durations/components/SecondsFromDurationFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/durations/components/SecondsFromDurationFunctionIterator.java
@@ -25,7 +25,7 @@ public class SecondsFromDurationFunctionIterator extends AtMostOneItemLocalRunti
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item durationItem = this.children.get(0)
+        Item durationItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (durationItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/durations/components/YearsFromDurationFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/durations/components/YearsFromDurationFunctionIterator.java
@@ -24,7 +24,7 @@ public class YearsFromDurationFunctionIterator extends AtMostOneItemLocalRuntime
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item durationItem = this.children.get(0)
+        Item durationItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (durationItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/error/ThrowErrorIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/error/ThrowErrorIterator.java
@@ -22,7 +22,7 @@ public class ThrowErrorIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.isEmpty() || this.children.get(0).materializeFirstItemOrNull(context) == null) {
+        if (this.getChildren().isEmpty() || this.getChild(0).materializeFirstItemOrNull(context) == null) {
             // No argument case.
             throw new RumbleException(
                     "An error has been raised without an error description or code.",
@@ -31,23 +31,23 @@ public class ThrowErrorIterator extends AtMostOneItemLocalRuntimeIterator {
             );
         }
 
-        Name errorCode = this.children.get(0).materializeFirstItemOrNull(context).getQNameValue();
+        Name errorCode = this.getChild(0).materializeFirstItemOrNull(context).getQNameValue();
 
-        if (this.children.size() == 1) {
+        if (this.getChildren().size() == 1) {
             // Error code argument case.
             throw new RumbleException(
                     "An error has been raised without an error description.",
                     new ErrorCode(errorCode),
                     this.getMetadata()
             );
-        } else if (this.children.size() == 2) {
+        } else if (this.getChildren().size() == 2) {
             // Error code and description arguments case.
-            String description = this.children.get(1).materializeFirstItemOrNull(context).getStringValue();
+            String description = this.getChild(1).materializeFirstItemOrNull(context).getStringValue();
             throw new RumbleException(description, new ErrorCode(errorCode), this.getMetadata());
         } else {
             // Error code, description, and object case.
-            String description = this.children.get(1).materializeFirstItemOrNull(context).getStringValue();
-            List<Item> value = this.children.get(2).materialize(context);
+            String description = this.getChild(1).materializeFirstItemOrNull(context).getStringValue();
+            List<Item> value = this.getChild(2).materialize(context);
             String message = description;
 
             throw new RumbleException(message, new ErrorCode(errorCode), this.getMetadata(), value);

--- a/src/main/java/org/rumbledb/runtime/functions/input/AvroFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/AvroFileFunctionIterator.java
@@ -53,7 +53,7 @@ public class AvroFileFunctionIterator extends DataFrameRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         String url = stringItem.getStringValue();
         URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
@@ -63,7 +63,7 @@ public class AvroFileFunctionIterator extends DataFrameRuntimeIterator {
         Item optionsObjectItem;
         DataFrameReader dfr = SparkSessionManager.getInstance().getOrCreateSession().read();
         try {
-            if (this.children.size() > 1 && ((optionsObjectItem = getObjectItem(context)) != null)) {
+            if (this.getChildren().size() > 1 && ((optionsObjectItem = getObjectItem(context)) != null)) {
                 ObjectItem options = (ObjectItem) optionsObjectItem;
                 List<String> keys = options.getStringKeys();
                 List<Item> values = options.getItemValues();
@@ -111,6 +111,6 @@ public class AvroFileFunctionIterator extends DataFrameRuntimeIterator {
     }
 
     private Item getObjectItem(DynamicContext context) {
-        return this.children.get(1).materializeFirstItemOrNull(context);
+        return this.getChild(1).materializeFirstItemOrNull(context);
     }
 }

--- a/src/main/java/org/rumbledb/runtime/functions/input/CSVFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/CSVFileFunctionIterator.java
@@ -55,7 +55,7 @@ public class CSVFileFunctionIterator extends DataFrameRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         String url = stringItem.getStringValue();
         URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
@@ -65,7 +65,7 @@ public class CSVFileFunctionIterator extends DataFrameRuntimeIterator {
         Item optionsObjectItem;
         try {
             DataFrameReader dfr = SparkSessionManager.getInstance().getOrCreateSession().read();
-            if (this.children.size() > 1 && ((optionsObjectItem = getObjectItem(context)) != null)) {
+            if (this.getChildren().size() > 1 && ((optionsObjectItem = getObjectItem(context)) != null)) {
                 ObjectItem options = (ObjectItem) optionsObjectItem;
                 List<String> keys = options.getStringKeys();
                 List<Item> values = options.getItemValues();
@@ -105,6 +105,6 @@ public class CSVFileFunctionIterator extends DataFrameRuntimeIterator {
     }
 
     private Item getObjectItem(DynamicContext context) {
-        return this.children.get(1).materializeFirstItemOrNull(context);
+        return this.getChild(1).materializeFirstItemOrNull(context);
     }
 }

--- a/src/main/java/org/rumbledb/runtime/functions/input/DeltaFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/DeltaFileFunctionIterator.java
@@ -28,7 +28,7 @@ public class DeltaFileFunctionIterator extends DataFrameRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        RuntimeIterator urlIterator = this.children.get(0);
+        RuntimeIterator urlIterator = this.getChild(0);
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();

--- a/src/main/java/org/rumbledb/runtime/functions/input/DeltaTableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/DeltaTableFunctionIterator.java
@@ -30,7 +30,7 @@ public class DeltaTableFunctionIterator extends DataFrameRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        RuntimeIterator collectionNameIterator = this.children.get(0);
+        RuntimeIterator collectionNameIterator = this.getChild(0);
         String collectionName = collectionNameIterator.materializeFirstItemOrNull(context).getStringValue();
 
         Dataset<Row> dataFrame = SparkSessionManager.getInstance().getOrCreateSession().table(collectionName);

--- a/src/main/java/org/rumbledb/runtime/functions/input/IcebergTableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/IcebergTableFunctionIterator.java
@@ -29,7 +29,7 @@ public class IcebergTableFunctionIterator extends DataFrameRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        RuntimeIterator collectionNameIterator = this.children.get(0);
+        RuntimeIterator collectionNameIterator = this.getChild(0);
         String collectionName = collectionNameIterator.materializeFirstItemOrNull(context).getStringValue();
 
         String metadataName = qualifyForMetadata(collectionName);

--- a/src/main/java/org/rumbledb/runtime/functions/input/JsonLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/JsonLinesFunctionIterator.java
@@ -56,7 +56,7 @@ public class JsonLinesFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(arguments, staticContext);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
         this.reader = null;
         this.nextItem = null;
         this.path = null;
@@ -64,12 +64,12 @@ public class JsonLinesFunctionIterator extends HybridRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
-        String url = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
+        String url = this.getChild(0).materializeFirstItemOrNull(context).getStringValue();
         URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
 
         int partitions = -1;
-        if (this.children.size() > 1) {
-            partitions = this.children.get(1).materializeFirstItemOrNull(context).getIntValue();
+        if (this.getChildren().size() > 1) {
+            partitions = this.getChild(1).materializeFirstItemOrNull(context).getIntValue();
         }
 
         JavaRDD<String> strings;

--- a/src/main/java/org/rumbledb/runtime/functions/input/LibSVMFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/LibSVMFileFunctionIterator.java
@@ -50,7 +50,7 @@ public class LibSVMFileFunctionIterator extends DataFrameRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        RuntimeIterator urlIterator = this.children.get(0);
+        RuntimeIterator urlIterator = this.getChild(0);
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();

--- a/src/main/java/org/rumbledb/runtime/functions/input/MongoDBCollectionFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/MongoDBCollectionFunctionIterator.java
@@ -50,12 +50,12 @@ public class MongoDBCollectionFunctionIterator extends DataFrameRuntimeIterator 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
 
-        String uri = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
-        String collection = this.children.get(1).materializeFirstItemOrNull(context).getStringValue();
+        String uri = this.getChild(0).materializeFirstItemOrNull(context).getStringValue();
+        String collection = this.getChild(1).materializeFirstItemOrNull(context).getStringValue();
 
         int partitions = -1;
-        if (this.children.size() > 2) {
-            partitions = this.children.get(2).materializeFirstItemOrNull(context).getIntValue();
+        if (this.getChildren().size() > 2) {
+            partitions = this.getChild(2).materializeFirstItemOrNull(context).getIntValue();
         }
 
         try {

--- a/src/main/java/org/rumbledb/runtime/functions/input/ParallelizeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/ParallelizeFunctionIterator.java
@@ -47,7 +47,7 @@ public class ParallelizeFunctionIterator extends HybridRuntimeIterator {
         super(parameters, staticContext);
         this.sequenceIterator = this.getChild(0);
         this.partitionsIterator = null;
-        if (this.getNumberOfChildren() > 1) {
+        if (this.getChildren().size() > 1) {
             this.partitionsIterator = this.getChild(1);
         }
     }
@@ -59,14 +59,14 @@ public class ParallelizeFunctionIterator extends HybridRuntimeIterator {
         if (this.sequenceIterator.isDataFrame()) {
             JSoundDataFrame dataFrame = this.sequenceIterator.getDataFrame(context);
             rdd = dataFrameToRDDOfItems(dataFrame, this.getMetadata());
-            if (this.getNumberOfChildren() == 1) {
+            if (this.getChildren().size() == 1) {
                 return rdd;
             } else {
                 return rdd.repartition(getNumberOfPartitions(context).getIntValue());
             }
         }
         this.sequenceIterator.materialize(context, contents);
-        if (this.getNumberOfChildren() == 1) {
+        if (this.getChildren().size() == 1) {
             rdd = SparkSessionManager.getInstance().getJavaSparkContext().parallelize(contents);
         } else {
             Item partitions = getNumberOfPartitions(context);
@@ -108,7 +108,7 @@ public class ParallelizeFunctionIterator extends HybridRuntimeIterator {
     @Override
     protected void openLocal() {
         this.getChild(0).open(this.currentDynamicContextForLocalExecution);
-        if (this.getNumberOfChildren() > 1) {
+        if (this.getChildren().size() > 1) {
             getNumberOfPartitions(this.currentDynamicContextForLocalExecution);
         }
     }

--- a/src/main/java/org/rumbledb/runtime/functions/input/ParallelizeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/ParallelizeFunctionIterator.java
@@ -45,10 +45,10 @@ public class ParallelizeFunctionIterator extends HybridRuntimeIterator {
 
     public ParallelizeFunctionIterator(List<RuntimeIterator> parameters, RuntimeStaticContext staticContext) {
         super(parameters, staticContext);
-        this.sequenceIterator = this.children.get(0);
+        this.sequenceIterator = this.getChild(0);
         this.partitionsIterator = null;
-        if (this.children.size() > 1) {
-            this.partitionsIterator = this.children.get(1);
+        if (this.getNumberOfChildren() > 1) {
+            this.partitionsIterator = this.getChild(1);
         }
     }
 
@@ -59,14 +59,14 @@ public class ParallelizeFunctionIterator extends HybridRuntimeIterator {
         if (this.sequenceIterator.isDataFrame()) {
             JSoundDataFrame dataFrame = this.sequenceIterator.getDataFrame(context);
             rdd = dataFrameToRDDOfItems(dataFrame, this.getMetadata());
-            if (this.children.size() == 1) {
+            if (this.getNumberOfChildren() == 1) {
                 return rdd;
             } else {
                 return rdd.repartition(getNumberOfPartitions(context).getIntValue());
             }
         }
         this.sequenceIterator.materialize(context, contents);
-        if (this.children.size() == 1) {
+        if (this.getNumberOfChildren() == 1) {
             rdd = SparkSessionManager.getInstance().getJavaSparkContext().parallelize(contents);
         } else {
             Item partitions = getNumberOfPartitions(context);
@@ -107,24 +107,24 @@ public class ParallelizeFunctionIterator extends HybridRuntimeIterator {
 
     @Override
     protected void openLocal() {
-        this.children.get(0).open(this.currentDynamicContextForLocalExecution);
-        if (this.children.size() > 1) {
+        this.getChild(0).open(this.currentDynamicContextForLocalExecution);
+        if (this.getNumberOfChildren() > 1) {
             getNumberOfPartitions(this.currentDynamicContextForLocalExecution);
         }
     }
 
     @Override
     protected void closeLocal() {
-        this.children.get(0).close();
+        this.getChild(0).close();
     }
 
     @Override
     protected boolean hasNextLocal() {
-        return this.children.get(0).hasNext();
+        return this.getChild(0).hasNext();
     }
 
     @Override
     protected Item nextLocal() {
-        return this.children.get(0).next();
+        return this.getChild(0).next();
     }
 }

--- a/src/main/java/org/rumbledb/runtime/functions/input/ParquetFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/ParquetFileFunctionIterator.java
@@ -58,7 +58,7 @@ public class ParquetFileFunctionIterator extends DataFrameRuntimeIterator {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }
         int partitions = -1;
-        if (this.getNumberOfChildren() > 1) {
+        if (this.getChildren().size() > 1) {
             partitions = this.getChild(1).materializeFirstItemOrNull(context).getIntValue();
         }
         try {

--- a/src/main/java/org/rumbledb/runtime/functions/input/ParquetFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/ParquetFileFunctionIterator.java
@@ -51,15 +51,15 @@ public class ParquetFileFunctionIterator extends DataFrameRuntimeIterator {
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
 
-        String url = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
+        String url = this.getChild(0).materializeFirstItemOrNull(context).getStringValue();
 
         URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
         if (!FileSystemUtil.exists(uri, context.getRumbleRuntimeConfiguration(), getMetadata())) {
             throw new CannotRetrieveResourceException("File " + uri + " not found.", getMetadata());
         }
         int partitions = -1;
-        if (this.children.size() > 1) {
-            partitions = this.children.get(1).materializeFirstItemOrNull(context).getIntValue();
+        if (this.getNumberOfChildren() > 1) {
+            partitions = this.getChild(1).materializeFirstItemOrNull(context).getIntValue();
         }
         try {
             Dataset<Row> dataFrame = SparkSessionManager.getInstance()

--- a/src/main/java/org/rumbledb/runtime/functions/input/PostgreSQLTableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/PostgreSQLTableFunctionIterator.java
@@ -51,11 +51,11 @@ public class PostgreSQLTableFunctionIterator extends DataFrameRuntimeIterator {
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
 
-        String connectionString = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
-        String table = this.children.get(1).materializeFirstItemOrNull(context).getStringValue();
+        String connectionString = this.getChild(0).materializeFirstItemOrNull(context).getStringValue();
+        String table = this.getChild(1).materializeFirstItemOrNull(context).getStringValue();
         int partitions = -1;
-        if (this.children.size() > 2) {
-            partitions = this.children.get(2).materializeFirstItemOrNull(context).getIntValue();
+        if (this.getChildren().size() > 2) {
+            partitions = this.getChild(2).materializeFirstItemOrNull(context).getIntValue();
         }
 
         try {

--- a/src/main/java/org/rumbledb/runtime/functions/input/RepartitionFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/RepartitionFunctionIterator.java
@@ -71,7 +71,7 @@ public class RepartitionFunctionIterator extends HybridRuntimeIterator {
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
         JavaRDD<Item> childRDD = this.iterator.getRDD(dynamicContext);
-        this.numberPartitions = this.children.get(1).materializeFirstItemOrNull(dynamicContext).getIntValue();
+        this.numberPartitions = this.getChild(1).materializeFirstItemOrNull(dynamicContext).getIntValue();
         JavaRDD<Item> resultRDD = childRDD.repartition(this.numberPartitions);
         return resultRDD;
     }
@@ -88,8 +88,8 @@ public class RepartitionFunctionIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
-        this.numberPartitions = this.children.get(1).materializeFirstItemOrNull(context).getIntValue();
+        JSoundDataFrame childDataFrame = this.getChild(0).getDataFrame(context);
+        this.numberPartitions = this.getChild(1).materializeFirstItemOrNull(context).getIntValue();
         JSoundDataFrame result = childDataFrame.repartition(this.numberPartitions);
         return result;
     }

--- a/src/main/java/org/rumbledb/runtime/functions/input/RootFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/RootFileFunctionIterator.java
@@ -52,10 +52,10 @@ public class RootFileFunctionIterator extends DataFrameRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        RuntimeIterator urlIterator = this.children.get(0);
+        RuntimeIterator urlIterator = this.getChild(0);
         String path = null;
-        if (this.children.size() > 1) {
-            RuntimeIterator pathIterator = this.children.get(1);
+        if (this.getChildren().size() > 1) {
+            RuntimeIterator pathIterator = this.getChild(1);
             Item pathItem = pathIterator.materializeFirstItemOrNull(context);
             path = pathItem.getStringValue();
         }

--- a/src/main/java/org/rumbledb/runtime/functions/input/StructuredJsonLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/StructuredJsonLinesFunctionIterator.java
@@ -52,7 +52,7 @@ public class StructuredJsonLinesFunctionIterator extends DataFrameRuntimeIterato
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        RuntimeIterator urlIterator = this.children.get(0);
+        RuntimeIterator urlIterator = this.getChild(0);
         urlIterator.open(context);
         String url = urlIterator.next().getStringValue();
         urlIterator.close();

--- a/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/TextFileFunctionIterator.java
@@ -51,7 +51,7 @@ public class TextFileFunctionIterator extends RDDRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
-        RuntimeIterator urlIterator = this.children.get(0);
+        RuntimeIterator urlIterator = this.getChild(0);
         Item url = urlIterator.materializeFirstItemOrNull(context);
         if (url == null) {
             return SparkSessionManager.getInstance()
@@ -64,8 +64,8 @@ public class TextFileFunctionIterator extends RDDRuntimeIterator {
             getMetadata()
         );
         int partitions = MIN_PARTITIONS;
-        if (this.children.size() > 1) {
-            Item partitionsItem = this.children.get(1).materializeFirstItemOrNull(context);
+        if (this.getChildren().size() > 1) {
+            Item partitionsItem = this.getChild(1).materializeFirstItemOrNull(context);
             if (partitionsItem != null) {
                 partitions = partitionsItem.getIntValue();
             }

--- a/src/main/java/org/rumbledb/runtime/functions/input/XmlFilesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/XmlFilesFunctionIterator.java
@@ -52,7 +52,7 @@ public class XmlFilesFunctionIterator extends RDDRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(arguments, staticContext);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
         this.reader = null;
         this.nextItem = null;
         this.path = null;
@@ -60,12 +60,12 @@ public class XmlFilesFunctionIterator extends RDDRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
-        String url = this.children.get(0).materializeFirstItemOrNull(context).getStringValue();
+        String url = this.getChild(0).materializeFirstItemOrNull(context).getStringValue();
         URI uri = FileSystemUtil.resolveFileSystemURI(this.staticContext.getStaticURI(), url, getMetadata());
 
         int partitions = 32;
-        if (this.children.size() > 1) {
-            partitions = this.children.get(1).materializeFirstItemOrNull(context).getIntValue();
+        if (this.getChildren().size() > 1) {
+            partitions = this.getChild(1).materializeFirstItemOrNull(context).getIntValue();
         }
 
         JavaPairRDD<String, String> strings;

--- a/src/main/java/org/rumbledb/runtime/functions/io/CollectionFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/CollectionFunctionIterator.java
@@ -29,10 +29,10 @@ public class CollectionFunctionIterator extends DataFrameRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        if (this.children.isEmpty()) {
+        if (this.getChildren().isEmpty()) {
             throw new CannotRetrieveResourceException("No default collection is defined.", getMetadata());
         }
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (stringItem == null) {
             throw new CannotRetrieveResourceException("No default collection is defined.", getMetadata());

--- a/src/main/java/org/rumbledb/runtime/functions/io/DocAvailableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/DocAvailableFunctionIterator.java
@@ -27,7 +27,7 @@ public class DocAvailableFunctionIterator extends AtMostOneItemLocalRuntimeItera
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item uriItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item uriItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (uriItem == null) {
             return ItemFactory.getInstance().createBooleanItem(false);
         }

--- a/src/main/java/org/rumbledb/runtime/functions/io/DocFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/DocFunctionIterator.java
@@ -38,7 +38,7 @@ public class DocFunctionIterator extends LocalFunctionCallIterator {
     @Override
     public void open(DynamicContext context) {
         super.open(context);
-        this.pathIterator = this.children.get(0);
+        this.pathIterator = this.getChild(0);
         this.pathIterator.open(this.currentDynamicContextForLocalExecution);
         this.hasNext = this.pathIterator.hasNext();
         this.pathIterator.close();

--- a/src/main/java/org/rumbledb/runtime/functions/io/LocalTextFileFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/LocalTextFileFunctionIterator.java
@@ -55,7 +55,7 @@ public class LocalTextFileFunctionIterator extends LocalFunctionCallIterator {
     @Override
     public void open(DynamicContext context) {
         super.open(context);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
         Item path = this.iterator.materializeFirstItemOrNull(context);
         if (path == null) {
             throw new IteratorFlowException(

--- a/src/main/java/org/rumbledb/runtime/functions/io/TraceFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/TraceFunctionIterator.java
@@ -55,9 +55,9 @@ public class TraceFunctionIterator extends LocalFunctionCallIterator {
     @Override
     public void open(DynamicContext context) {
         super.open(context);
-        this.valueIterator = this.children.get(0);
-        if (this.children.size() == 2) {
-            this.labelIterator = this.children.get(1);
+        this.valueIterator = this.getChild(0);
+        if (this.getChildren().size() == 2) {
+            this.labelIterator = this.getChild(1);
             this.label = this.labelIterator.materializeFirstItemOrNull(context).getStringValue();
         } else {
             this.label = "";

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextAvailableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextAvailableFunctionIterator.java
@@ -23,13 +23,13 @@ public class UnparsedTextAvailableFunctionIterator extends AtMostOneItemLocalRun
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item hrefItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item hrefItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (hrefItem == null) {
             return ItemFactory.getInstance().createBooleanItem(false);
         }
         String encoding = null;
-        if (this.children.size() == 2) {
-            Item encodingItem = this.children.get(1).materializeFirstItemOrNull(context);
+        if (this.getNumberOfChildren() == 2) {
+            Item encodingItem = this.getChild(1).materializeFirstItemOrNull(context);
             encoding = encodingItem.getStringValue();
         }
         try {

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextAvailableFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextAvailableFunctionIterator.java
@@ -28,7 +28,7 @@ public class UnparsedTextAvailableFunctionIterator extends AtMostOneItemLocalRun
             return ItemFactory.getInstance().createBooleanItem(false);
         }
         String encoding = null;
-        if (this.getNumberOfChildren() == 2) {
+        if (this.getChildren().size() == 2) {
             Item encodingItem = this.getChild(1).materializeFirstItemOrNull(context);
             encoding = encodingItem.getStringValue();
         }

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextFunctionIterator.java
@@ -45,13 +45,13 @@ public class UnparsedTextFunctionIterator extends AtMostOneItemLocalRuntimeItera
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item hrefItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item hrefItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (hrefItem == null) {
             return null;
         }
         String encoding = null;
-        if (this.children.size() == 2) {
-            Item encodingItem = this.children.get(1).materializeFirstItemOrNull(context);
+        if (this.getChildren().size() == 2) {
+            Item encodingItem = this.getChild(1).materializeFirstItemOrNull(context);
             encoding = encodingItem.getStringValue();
         }
 

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextLinesFunctionIterator.java
@@ -38,7 +38,7 @@ public class UnparsedTextLinesFunctionIterator extends RDDRuntimeIterator {
                 .emptyRDD();
         }
         String encoding = null;
-        if (this.getNumberOfChildren() == 2) {
+        if (this.getChildren().size() == 2) {
             Item encodingItem = this.getChild(1).materializeFirstItemOrNull(context);
             encoding = encodingItem.getStringValue();
         }

--- a/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/UnparsedTextLinesFunctionIterator.java
@@ -30,7 +30,7 @@ public class UnparsedTextLinesFunctionIterator extends RDDRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
-        RuntimeIterator hrefIterator = this.children.get(0);
+        RuntimeIterator hrefIterator = this.getChild(0);
         Item hrefItem = hrefIterator.materializeFirstItemOrNull(context);
         if (hrefItem == null) {
             return SparkSessionManager.getInstance()
@@ -38,8 +38,8 @@ public class UnparsedTextLinesFunctionIterator extends RDDRuntimeIterator {
                 .emptyRDD();
         }
         String encoding = null;
-        if (this.children.size() == 2) {
-            Item encodingItem = this.children.get(1).materializeFirstItemOrNull(context);
+        if (this.getNumberOfChildren() == 2) {
+            Item encodingItem = this.getChild(1).materializeFirstItemOrNull(context);
             encoding = encodingItem.getStringValue();
         }
 

--- a/src/main/java/org/rumbledb/runtime/functions/io/YamlDocFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/io/YamlDocFunctionIterator.java
@@ -61,7 +61,7 @@ public class YamlDocFunctionIterator extends LocalFunctionCallIterator {
     @Override
     public void open(DynamicContext context) {
         super.open(context);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
         Item path = this.iterator.materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
         try {
             URI uri = FileSystemUtil.resolveURI(

--- a/src/main/java/org/rumbledb/runtime/functions/json/JsonDocFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/json/JsonDocFunctionIterator.java
@@ -40,8 +40,8 @@ public class JsonDocFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        RuntimeIterator pathIterator = this.children.get(0);
-        RuntimeIterator optionsIterator = this.children.size() > 1 ? this.children.get(1) : null;
+        RuntimeIterator pathIterator = this.getChild(0);
+        RuntimeIterator optionsIterator = this.getChildren().size() > 1 ? this.getChild(1) : null;
 
         Item pathItem = pathIterator.materializeFirstItemOrNull(context);
         Item optionsItem = optionsIterator != null

--- a/src/main/java/org/rumbledb/runtime/functions/json/ParseJsonFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/json/ParseJsonFunctionIterator.java
@@ -49,8 +49,10 @@ public class ParseJsonFunctionIterator extends AtMostOneItemLocalRuntimeIterator
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item stringItem = this.children.get(0).materializeFirstItemOrNull(context);
-        Item optionsItem = this.children.size() > 1 ? this.children.get(1).materializeFirstItemOrNull(context) : null;
+        Item stringItem = this.getChild(0).materializeFirstItemOrNull(context);
+        Item optionsItem = this.getChildren().size() > 1
+            ? this.getChild(1).materializeFirstItemOrNull(context)
+            : null;
         if (stringItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/maps/MapContainsFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/maps/MapContainsFunctionIterator.java
@@ -44,8 +44,8 @@ public class MapContainsFunctionIterator extends AtMostOneItemLocalRuntimeIterat
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item map = this.children.get(0).materializeFirstItemOrNull(context);
-        Item key = this.children.get(1).materializeFirstItemOrNull(context);
+        Item map = this.getChild(0).materializeFirstItemOrNull(context);
+        Item key = this.getChild(1).materializeFirstItemOrNull(context);
         boolean contains = map.getSequenceByKey(key) != null;
         return ItemFactory.getInstance().createBooleanItem(contains);
     }

--- a/src/main/java/org/rumbledb/runtime/functions/maps/MapSizeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/maps/MapSizeFunctionIterator.java
@@ -43,7 +43,7 @@ public class MapSizeFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item map = this.children.get(0).materializeFirstItemOrNull(context);
+        Item map = this.getChild(0).materializeFirstItemOrNull(context);
         if (map == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/nullable/IsNullIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/nullable/IsNullIterator.java
@@ -20,7 +20,7 @@ public class IsNullIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        List<Item> materializedItems = this.children.get(0).materialize(context);
+        List<Item> materializedItems = this.getChild(0).materialize(context);
         if (materializedItems == null || materializedItems.isEmpty()) {
             return ItemFactory.getInstance().createBooleanItem(true);
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/AbsFunctionIterator.java
@@ -48,7 +48,7 @@ public class AbsFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -79,7 +79,7 @@ public class AbsFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext nativeChildQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext nativeChildQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (nativeChildQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/CeilingFunctionIterator.java
@@ -51,7 +51,7 @@ public class CeilingFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(context);
+        Item value = this.getChild(0).materializeFirstItemOrNull(context);
         if (value == null) {
             return null;
         }
@@ -103,7 +103,7 @@ public class CeilingFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext value = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext value = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (value == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/FloorFunctionIterator.java
@@ -51,7 +51,7 @@ public class FloorFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(context);
+        Item value = this.getChild(0).materializeFirstItemOrNull(context);
         if (value == null) {
             return null;
         }
@@ -102,7 +102,7 @@ public class FloorFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext value = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext value = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (value == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/FormatIntegerFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/FormatIntegerFunctionIterator.java
@@ -22,11 +22,11 @@ public class FormatIntegerFunctionIterator extends AtMostOneItemLocalRuntimeIter
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item valueItem = this.children.get(0).materializeFirstItemOrNull(context);
-        Item pictureItem = this.children.get(1).materializeFirstItemOrNull(context);
+        Item valueItem = this.getChild(0).materializeFirstItemOrNull(context);
+        Item pictureItem = this.getChild(1).materializeFirstItemOrNull(context);
 
-        Item languageItem = this.children.size() > 2
-            ? this.children.get(2).materializeFirstItemOrNull(context)
+        Item languageItem = this.getChildren().size() > 2
+            ? this.getChild(2).materializeFirstItemOrNull(context)
             : null;
 
         String language = languageItem != null && !languageItem.isNull() ? languageItem.getStringValue() : null;

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/FormatNumberFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/FormatNumberFunctionIterator.java
@@ -28,10 +28,10 @@ public class FormatNumberFunctionIterator extends AtMostOneItemLocalRuntimeItera
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item valueItem = this.children.get(0).materializeFirstItemOrNull(context);
-        Item pictureItem = this.children.get(1).materializeFirstItemOrNull(context);
-        Item decimalFormatNameItem = this.children.size() > 2
-            ? this.children.get(2).materializeFirstItemOrNull(context)
+        Item valueItem = this.getChild(0).materializeFirstItemOrNull(context);
+        Item pictureItem = this.getChild(1).materializeFirstItemOrNull(context);
+        Item decimalFormatNameItem = this.getChildren().size() > 2
+            ? this.getChild(2).materializeFirstItemOrNull(context)
             : null;
 
         if (valueItem == null) {

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/NumberFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/NumberFunctionIterator.java
@@ -47,7 +47,7 @@ public class NumberFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 0) {
+        if (this.getChildren().size() == 0) {
             List<Item> items = context.getVariableValues().getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata());
             return CastIterator.castItemToType(
                 items.get(0),
@@ -57,7 +57,7 @@ public class NumberFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
             );
         }
 
-        Item anyItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item anyItem = this.getChild(0).materializeFirstItemOrNull(context);
         if (anyItem == null) {
             return ItemFactory.getInstance().createDoubleItem(Double.NaN);
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/RoundFunctionIterator.java
@@ -51,7 +51,7 @@ public class RoundFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -74,8 +74,8 @@ public class RoundFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
             return value;
         }
         int precision;
-        if (this.children.size() > 1) {
-            precision = this.children.get(1)
+        if (this.getChildren().size() > 1) {
+            precision = this.getChild(1)
                 .materializeFirstItemOrNull(dynamicContext)
                 .getIntValue();
         }
@@ -142,7 +142,7 @@ public class RoundFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext value = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext value = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (value == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -49,7 +49,7 @@ public class RoundHalfToEvenFunctionIterator extends AtMostOneItemLocalRuntimeIt
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(context);
+        Item value = this.getChild(0).materializeFirstItemOrNull(context);
         if (value == null) {
             return null;
         }
@@ -73,8 +73,8 @@ public class RoundHalfToEvenFunctionIterator extends AtMostOneItemLocalRuntimeIt
         }
 
         int precision;
-        if (this.children.size() > 1) {
-            precision = this.children.get(1)
+        if (this.getChildren().size() > 1) {
+            precision = this.getChild(1)
                 .materializeFirstItemOrNull(context)
                 .getIntValue();
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -48,7 +48,7 @@ public class Exp10FunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item exponent = this.children.get(0).materializeFirstItemOrNull(context);
+        Item exponent = this.getChild(0).materializeFirstItemOrNull(context);
         if (exponent == null) {
             return null;
         }
@@ -57,7 +57,7 @@ public class Exp10FunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext powerQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext powerQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (powerQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/ExpFunctionIterator.java
@@ -47,7 +47,7 @@ public class ExpFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -56,7 +56,7 @@ public class ExpFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/Log10FunctionIterator.java
@@ -48,7 +48,7 @@ public class Log10FunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(context);
+        Item value = this.getChild(0).materializeFirstItemOrNull(context);
         if (value == null) {
             return null;
         }
@@ -61,7 +61,7 @@ public class Log10FunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/LogFunctionIterator.java
@@ -47,7 +47,7 @@ public class LogFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -56,7 +56,7 @@ public class LogFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/PowFunctionIterator.java
@@ -49,11 +49,11 @@ public class PowFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item base = this.children.get(0).materializeFirstItemOrNull(context);
+        Item base = this.getChild(0).materializeFirstItemOrNull(context);
         if (base == null) {
             return null;
         }
-        Item exponent = this.children.get(1)
+        Item exponent = this.getChild(1)
             .materializeFirstItemOrNull(context);
         if (exponent == null) {
             return null;
@@ -82,11 +82,11 @@ public class PowFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext baseQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext baseQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (baseQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }
-        NativeClauseContext exponentQuery = this.children.get(1)
+        NativeClauseContext exponentQuery = this.getChild(1)
             .generateNativeQuery(new NativeClauseContext(baseQuery, null, null));
         if (exponentQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -47,7 +47,7 @@ public class SqrtFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -60,7 +60,7 @@ public class SqrtFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -47,7 +47,7 @@ public class ACosFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -60,7 +60,7 @@ public class ACosFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -48,7 +48,7 @@ public class ASinFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -61,7 +61,7 @@ public class ASinFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -47,8 +47,8 @@ public class ATan2FunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item valuey = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
-        Item valuex = this.children.get(1).materializeFirstItemOrNull(dynamicContext);
+        Item valuey = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
+        Item valuex = this.getChild(1).materializeFirstItemOrNull(dynamicContext);
         double y = valuey.getDoubleValue();
         double x = valuex.getDoubleValue();
         if (Double.isNaN(x) || Double.isNaN(y)) {
@@ -59,11 +59,11 @@ public class ATan2FunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext yQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext yQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (yQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }
-        NativeClauseContext xQuery = this.children.get(1)
+        NativeClauseContext xQuery = this.getChild(1)
             .generateNativeQuery(new NativeClauseContext(yQuery, null, null));
         if (xQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -48,7 +48,7 @@ public class ATanFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -61,7 +61,7 @@ public class ATanFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -47,7 +47,7 @@ public class CosFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -60,7 +60,7 @@ public class CosFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/CoshFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/CoshFunctionIterator.java
@@ -48,7 +48,7 @@ public class CoshFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -61,7 +61,7 @@ public class CoshFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -47,7 +47,7 @@ public class SinFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -60,7 +60,7 @@ public class SinFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/SinhFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/SinhFunctionIterator.java
@@ -48,7 +48,7 @@ public class SinhFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item value = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (value == null) {
             return null;
         }
@@ -61,7 +61,7 @@ public class SinhFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -48,7 +48,7 @@ public class TanFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item value = this.children.get(0).materializeFirstItemOrNull(context);
+        Item value = this.getChild(0).materializeFirstItemOrNull(context);
         if (value == null) {
             return null;
         }
@@ -62,7 +62,7 @@ public class TanFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectAccumulateFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectAccumulateFunctionIterator.java
@@ -51,7 +51,7 @@ public class ObjectAccumulateFunctionIterator extends AtMostOneItemLocalRuntimeI
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        RuntimeIterator iterator = this.children.get(0);
+        RuntimeIterator iterator = this.getChild(0);
 
         if (!iterator.isDataFrame()) {
             if (this.hasNext) {

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectDescendantPairsFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectDescendantPairsFunctionIterator.java
@@ -54,7 +54,7 @@ public class ObjectDescendantPairsFunctionIterator extends LocalFunctionCallIter
     public void open(DynamicContext context) {
         super.open(context);
 
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
         this.iterator.open(context);
         this.nextResults = new LinkedList<>();
 

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectIntersectFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectIntersectFunctionIterator.java
@@ -50,7 +50,7 @@ public class ObjectIntersectFunctionIterator extends AtMostOneItemLocalRuntimeIt
             RuntimeStaticContext staticContext
     ) {
         super(children, staticContext);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectProjectFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectProjectFunctionIterator.java
@@ -59,7 +59,7 @@ public class ObjectProjectFunctionIterator extends HybridRuntimeIterator {
     @Override
     public void openLocal() {
         this.iterator.open(this.currentDynamicContextForLocalExecution);
-        this.projectionKeys = this.children.get(1).materialize(this.currentDynamicContextForLocalExecution);
+        this.projectionKeys = this.getChild(1).materialize(this.currentDynamicContextForLocalExecution);
         if (this.projectionKeys.isEmpty()) {
             throw new InvalidSelectorException(
                     "Invalid Projection Key; Object projection can't be performed with zero keys: ",
@@ -130,7 +130,7 @@ public class ObjectProjectFunctionIterator extends HybridRuntimeIterator {
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
         JavaRDD<Item> childRDD = this.iterator.getRDD(context);
-        this.projectionKeys = this.children.get(1).materialize(context);
+        this.projectionKeys = this.getChild(1).materialize(context);
         FlatMapFunction<Item, Item> transformation = new ObjectProjectClosure(
                 this.projectionKeys,
                 getMetadata()
@@ -145,7 +145,7 @@ public class ObjectProjectFunctionIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
+        JSoundDataFrame childDataFrame = this.getChild(0).getDataFrame(context);
         String object = FlworDataFrameUtils.createTempView(childDataFrame.getDataFrame());
         if (!childDataFrame.getItemType().isObjectItemType()) {
             return childDataFrame;
@@ -153,7 +153,7 @@ public class ObjectProjectFunctionIterator extends HybridRuntimeIterator {
         List<String> fieldNames = childDataFrame.getKeys();
 
         List<String> keys = new ArrayList<>();
-        this.projectionKeys = this.children.get(1).materialize(context);
+        this.projectionKeys = this.getChild(1).materialize(context);
         for (Item keyItem : this.projectionKeys) {
             String key = keyItem.getStringValue();
             if (fieldNames.contains(key)) {

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectRemoveKeysFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectRemoveKeysFunctionIterator.java
@@ -61,7 +61,7 @@ public class ObjectRemoveKeysFunctionIterator extends HybridRuntimeIterator {
 
     private void startLocal() {
         this.iterator.open(this.currentDynamicContextForLocalExecution);
-        List<Item> removalKeys = this.children.get(1).materialize(this.currentDynamicContextForLocalExecution);
+        List<Item> removalKeys = this.getChild(1).materialize(this.currentDynamicContextForLocalExecution);
         if (removalKeys.isEmpty()) {
             throw new InvalidSelectorException(
                     "Invalid Key Removal Parameter; Object key removal can't be performed with zero keys: ",
@@ -139,7 +139,7 @@ public class ObjectRemoveKeysFunctionIterator extends HybridRuntimeIterator {
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext context) {
         JavaRDD<Item> childRDD = this.iterator.getRDD(context);
-        List<Item> removalKeys = this.children.get(1).materialize(context);
+        List<Item> removalKeys = this.getChild(1).materialize(context);
         if (removalKeys.isEmpty()) {
             throw new InvalidSelectorException(
                     "Invalid Key Removal Parameter; Object key removal can't be performed with zero keys: ",
@@ -165,7 +165,7 @@ public class ObjectRemoveKeysFunctionIterator extends HybridRuntimeIterator {
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
         JSoundDataFrame dataFrame = this.iterator.getDataFrame(context);
-        List<Item> columnsToDropItems = this.children.get(1).materialize(context);
+        List<Item> columnsToDropItems = this.getChild(1).materialize(context);
         if (columnsToDropItems.isEmpty()) {
             throw new InvalidSelectorException(
                     "Invalid drop-columns parameter; drop-columns can't be performed without string columns to be removed.",

--- a/src/main/java/org/rumbledb/runtime/functions/random/RandomSequenceGeneratorIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/random/RandomSequenceGeneratorIterator.java
@@ -30,16 +30,16 @@ public class RandomSequenceGeneratorIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this.children.size() == 2) {
+        if (this.getChildren().size() == 2) {
             // Seed is present as first argument
-            int seed = this.children.get(0).materializeFirstItemOrNull(context).castToIntValue();
-            int sequenceLength = this.children.get(1).materializeFirstItemOrNull(context).castToIntValue();
+            int seed = this.getChild(0).materializeFirstItemOrNull(context).castToIntValue();
+            int sequenceLength = this.getChild(1).materializeFirstItemOrNull(context).castToIntValue();
             this.generatedRandomsIterator = new GeneratedRandomDoublesIterator(
                     sequenceLength,
                     seed
             );
         } else {
-            int sequenceLength = this.children.get(0).materializeFirstItemOrNull(context).castToIntValue();
+            int sequenceLength = this.getChild(0).materializeFirstItemOrNull(context).castToIntValue();
             this.generatedRandomsIterator = new GeneratedRandomDoublesIterator(
                     sequenceLength
             );

--- a/src/main/java/org/rumbledb/runtime/functions/random/RandomSequenceWithBoundsAndSeedIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/random/RandomSequenceWithBoundsAndSeedIterator.java
@@ -25,11 +25,11 @@ public class RandomSequenceWithBoundsAndSeedIterator extends LocalRuntimeIterato
 
     @Override
     public void open(DynamicContext context) {
-        this.low = this.children.get(0).materializeFirstItemOrNull(context);
-        this.high = this.children.get(1).materializeFirstItemOrNull(context);
-        this.size = this.children.get(2).materializeFirstItemOrNull(context).castToIntValue();
-        this.type = this.children.get(3).materializeFirstItemOrNull(context);
-        this.seed = this.children.get(4).materializeFirstItemOrNull(context).castToIntValue();
+        this.low = this.getChild(0).materializeFirstItemOrNull(context);
+        this.high = this.getChild(1).materializeFirstItemOrNull(context);
+        this.size = this.getChild(2).materializeFirstItemOrNull(context).castToIntValue();
+        this.type = this.getChild(3).materializeFirstItemOrNull(context);
+        this.seed = this.getChild(4).materializeFirstItemOrNull(context).castToIntValue();
         this.generatedRandomsIterator = createRandomNumberStream();
     }
 

--- a/src/main/java/org/rumbledb/runtime/functions/random/RandomSequenceWithBoundsIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/random/RandomSequenceWithBoundsIterator.java
@@ -24,10 +24,10 @@ public class RandomSequenceWithBoundsIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        this.low = this.children.get(0).materializeFirstItemOrNull(context);
-        this.high = this.children.get(1).materializeFirstItemOrNull(context);
-        this.size = this.children.get(2).materializeFirstItemOrNull(context).castToIntValue();
-        this.type = this.children.get(3).materializeFirstItemOrNull(context);
+        this.low = this.getChild(0).materializeFirstItemOrNull(context);
+        this.high = this.getChild(1).materializeFirstItemOrNull(context);
+        this.size = this.getChild(2).materializeFirstItemOrNull(context).castToIntValue();
+        this.type = this.getChild(3).materializeFirstItemOrNull(context);
         this.generatedRandomsIterator = createRandomNumberStream();
     }
 

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -54,7 +54,7 @@ public class AvgFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
         Item count = CountFunctionIterator.computeCount(
-            this.children.get(0),
+            this.getChild(0),
             context,
             getMetadata()
         );
@@ -66,7 +66,7 @@ public class AvgFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         }
         Item sum = SumFunctionIterator.computeSum(
             ItemFactory.getInstance().createIntegerItem(BigInteger.ZERO),
-            this.children.get(0),
+            this.getChild(0),
             context,
             getMetadata()
         );
@@ -81,7 +81,7 @@ public class AvgFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
-        if (this.children.get(0) instanceof VariableReferenceIterator expr) {
+        if (this.getChild(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result =
                 new TreeMap<Name, DynamicContext.VariableDependency>();
             result.put(expr.getVariableName(), DynamicContext.VariableDependency.AVERAGE);

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/CountFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/CountFunctionIterator.java
@@ -56,7 +56,7 @@ public class CountFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        RuntimeIterator iterator = this.children.get(0);
+        RuntimeIterator iterator = this.getChild(0);
 
         // the count($x) case is treated separately because we can short-circuit the
         // count, e.g., if it comes from the group-by aggregation of a non-grouping
@@ -145,7 +145,7 @@ public class CountFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
-        if (this.children.get(0) instanceof VariableReferenceIterator expr) {
+        if (this.getChild(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result = new TreeMap<>();
             result.put(expr.getVariableName(), DynamicContext.VariableDependency.COUNT);
             return result;
@@ -156,7 +156,7 @@ public class CountFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext nativeChildQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext nativeChildQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (nativeChildQuery != NativeClauseContext.NoNativeQuery) {
             if (nativeChildQuery.getResultingQuery().trim().startsWith("explode")) {
                 return new NativeClauseContext(

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/MaxFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/MaxFunctionIterator.java
@@ -84,7 +84,7 @@ public class MaxFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(arguments, staticContext);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
         this.comparator = new ItemComparator(
                 false,
                 new InvalidArgumentTypeException(
@@ -96,8 +96,8 @@ public class MaxFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 2) {
-            String collation = this.children.get(1).materializeFirstItemOrNull(context).getStringValue();
+        if (this.getChildren().size() == 2) {
+            String collation = this.getChild(1).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new UnsupportedCollationException("Wrong collation parameter", getMetadata());
             }
@@ -516,7 +516,7 @@ public class MaxFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
-        if (this.children.get(0) instanceof VariableReferenceIterator expr) {
+        if (this.getChild(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result =
                 new TreeMap<>();
             result.put(expr.getVariableName(), DynamicContext.VariableDependency.MAX);
@@ -541,11 +541,11 @@ public class MaxFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        if (this.children.size() > 1) {
+        if (this.getChildren().size() > 1) {
             // for now, only consider max over a sequence
             return NativeClauseContext.NoNativeQuery;
         }
-        NativeClauseContext nativeChildQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext nativeChildQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (nativeChildQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/MinFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/MinFunctionIterator.java
@@ -82,7 +82,7 @@ public class MinFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(arguments, staticContext);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
         this.comparator = new ItemComparator(
                 true,
                 new InvalidArgumentTypeException(
@@ -94,8 +94,8 @@ public class MinFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 2) {
-            String collation = this.children.get(1).materializeFirstItemOrNull(context).getStringValue();
+        if (this.getChildren().size() == 2) {
+            String collation = this.getChild(1).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new UnsupportedCollationException("Wrong collation parameter", getMetadata());
             }
@@ -496,7 +496,7 @@ public class MinFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
-        if (this.children.get(0) instanceof VariableReferenceIterator expr) {
+        if (this.getChild(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result =
                 new TreeMap<>();
             result.put(expr.getVariableName(), DynamicContext.VariableDependency.MIN);
@@ -508,10 +508,10 @@ public class MinFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        if (this.children.size() > 1) {
+        if (this.getChildren().size() > 1) {
             return NativeClauseContext.NoNativeQuery;
         }
-        NativeClauseContext nativeChildQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext nativeChildQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (nativeChildQuery == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/SumFunctionIterator.java
@@ -64,7 +64,7 @@ public class SumFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
     public Item materializeFirstItemOrNull(DynamicContext context) {
         this.item = computeSum(
             zeroElement(context),
-            this.children.get(0),
+            this.getChild(0),
             context,
             getMetadata()
         );
@@ -75,8 +75,8 @@ public class SumFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
     }
 
     private Item zeroElement(DynamicContext context) {
-        if (this.children.size() > 1) {
-            return this.children.get(1).materializeFirstItemOrNull(context);
+        if (this.getChildren().size() > 1) {
+            return this.getChild(1).materializeFirstItemOrNull(context);
         } else {
             return ItemFactory.getInstance().createIntegerItem(BigInteger.ZERO);
         }
@@ -191,7 +191,7 @@ public class SumFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Map<Name, DynamicContext.VariableDependency> getVariableDependencies() {
-        if (this.children.get(0) instanceof VariableReferenceIterator expr) {
+        if (this.getChild(0) instanceof VariableReferenceIterator expr) {
             Map<Name, DynamicContext.VariableDependency> result =
                 new TreeMap<Name, DynamicContext.VariableDependency>();
             result.put(expr.getVariableName(), DynamicContext.VariableDependency.SUM);
@@ -203,7 +203,7 @@ public class SumFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childContext = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childContext = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childContext == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/cardinality/ExactlyOneIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/cardinality/ExactlyOneIterator.java
@@ -48,7 +48,7 @@ public class ExactlyOneIterator extends AtMostOneItemLocalRuntimeIterator {
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
         try {
-            Item value = this.children.get(0).materializeAtMostOneItemOrNull(dynamicContext);
+            Item value = this.getChild(0).materializeAtMostOneItemOrNull(dynamicContext);
             if (value == null) {
                 throw new SequenceExceptionExactlyOne(
                         "fn:exactly-one() called with a sequence that doesn't contain exactly one item",
@@ -67,7 +67,7 @@ public class ExactlyOneIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        return this.children.get(0).generateNativeQuery(nativeClauseContext);
+        return this.getChild(0).generateNativeQuery(nativeClauseContext);
     }
 
 }

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/cardinality/OneOrMoreIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/cardinality/OneOrMoreIterator.java
@@ -45,7 +45,7 @@ public class OneOrMoreIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(arguments, staticContext);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
     }
 
     @Override
@@ -67,7 +67,7 @@ public class OneOrMoreIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
+        JSoundDataFrame childDataFrame = this.getChild(0).getDataFrame(context);
         if (childDataFrame.isEmptySequence()) {
             throw new SequenceExceptionOneOrMore(
                     "fn:one-or-more() called with a sequence containing less than 1 item",

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/cardinality/ZeroOrOneIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/cardinality/ZeroOrOneIterator.java
@@ -46,7 +46,7 @@ public class ZeroOrOneIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        RuntimeIterator sequenceIterator = this.children.get(0);
+        RuntimeIterator sequenceIterator = this.getChild(0);
         Item result = null;
         try {
             result = sequenceIterator.materializeAtMostOneItemOrNull(context);

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/DataFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/DataFunctionIterator.java
@@ -51,8 +51,8 @@ public class DataFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(parameters, staticContext);
-        if (!this.children.isEmpty())
-            this.sequenceIterator = this.children.get(0);
+        if (!this.getChildren().isEmpty())
+            this.sequenceIterator = this.getChild(0);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/EmptyFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/EmptyFunctionIterator.java
@@ -48,11 +48,11 @@ public class EmptyFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        if (this.children.get(0).isRDDOrDataFrame()) {
-            List<Item> i = this.children.get(0).getRDD(dynamicContext).take(1);
+        if (this.getChild(0).isRDDOrDataFrame()) {
+            List<Item> i = this.getChild(0).getRDD(dynamicContext).take(1);
             return ItemFactory.getInstance().createBooleanItem(i.isEmpty());
         }
-        Item first = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item first = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (first == null) {
             return ItemFactory.getInstance().createBooleanItem(true);
         }
@@ -61,7 +61,7 @@ public class EmptyFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childContext = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childContext = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childContext == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/ExistsFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/ExistsFunctionIterator.java
@@ -48,17 +48,17 @@ public class ExistsFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        if (this.children.get(0).isDataFrame()) {
+        if (this.getChild(0).isDataFrame()) {
             return ItemFactory.getInstance()
                 .createBooleanItem(
-                    !this.children.get(0).getDataFrame(dynamicContext).take(1).isEmpty()
+                    !this.getChild(0).getDataFrame(dynamicContext).take(1).isEmpty()
                 );
         }
-        if (this.children.get(0).isRDDOrDataFrame()) {
-            List<Item> i = this.children.get(0).getRDD(dynamicContext).take(1);
+        if (this.getChild(0).isRDDOrDataFrame()) {
+            List<Item> i = this.getChild(0).getRDD(dynamicContext).take(1);
             return ItemFactory.getInstance().createBooleanItem(!i.isEmpty());
         }
-        Item first = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item first = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
         if (first == null) {
             return ItemFactory.getInstance().createBooleanItem(false);
         }
@@ -67,7 +67,7 @@ public class ExistsFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childQuery != NativeClauseContext.NoNativeQuery) {
             if (
                 childQuery.getResultingType().getItemType().isArrayItemType()

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/HeadFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/HeadFunctionIterator.java
@@ -44,13 +44,13 @@ public class HeadFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        if (this.children.get(0).isRDDOrDataFrame()) {
-            List<Item> i = this.children.get(0).getRDD(dynamicContext).take(1);
+        if (this.getChild(0).isRDDOrDataFrame()) {
+            List<Item> i = this.getChild(0).getRDD(dynamicContext).take(1);
             if (i.isEmpty()) {
                 return null;
             }
             return i.get(0);
         }
-        return this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        return this.getChild(0).materializeFirstItemOrNull(dynamicContext);
     }
 }

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/InsertBeforeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/InsertBeforeFunctionIterator.java
@@ -53,9 +53,9 @@ public class InsertBeforeFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(parameters, staticContext);
-        this.sequenceIterator = this.children.get(0);
-        this.positionIterator = this.children.get(1);
-        this.insertIterator = this.children.get(2);
+        this.sequenceIterator = this.getChild(0);
+        this.positionIterator = this.getChild(1);
+        this.insertIterator = this.getChild(2);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/RemoveFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/RemoveFunctionIterator.java
@@ -49,8 +49,8 @@ public class RemoveFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(parameters, staticContext);
-        this.sequenceIterator = this.children.get(0);
-        this.positionIterator = this.children.get(1);
+        this.sequenceIterator = this.getChild(0);
+        this.positionIterator = this.getChild(1);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/ReverseFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/ReverseFunctionIterator.java
@@ -53,7 +53,7 @@ public class ReverseFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(parameters, staticContext);
-        this.sequenceIterator = this.children.get(0);
+        this.sequenceIterator = this.getChild(0);
     }
 
     @Override
@@ -70,7 +70,7 @@ public class ReverseFunctionIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
+        JSoundDataFrame childDataFrame = this.getChild(0).getDataFrame(context);
         String viewName = FlworDataFrameUtils.createTempView(childDataFrame.getDataFrame());
         String selectSQL = childDataFrame.getSQLColumnProjection(false);
         LogManager.getLogger("ReverseFunctioniterator")

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -60,10 +60,10 @@ public class SubsequenceFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(parameters, staticContext);
-        this.sequenceIterator = this.children.get(0);
-        this.positionIterator = this.children.get(1);
-        if (this.children.size() == 3) {
-            this.lengthIterator = this.children.get(2);
+        this.sequenceIterator = this.getChild(0);
+        this.positionIterator = this.getChild(1);
+        if (this.getChildren().size() == 3) {
+            this.lengthIterator = this.getChild(2);
         }
     }
 
@@ -247,7 +247,7 @@ public class SubsequenceFunctionIterator extends HybridRuntimeIterator {
         this.startPosition = (int) Math.round(positionItem.getDoubleValue());
 
         this.length = -1;
-        if (this.children.size() == 3) {
+        if (this.getChildren().size() == 3) {
             Item lengthItem = this.lengthIterator
                 .materializeFirstItemOrNull(context);
             this.length = (int) Math.round(lengthItem.getDoubleValue());

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/TailFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/TailFunctionIterator.java
@@ -45,7 +45,7 @@ public class TailFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(parameters, staticContext);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/UnorderedFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/UnorderedFunctionIterator.java
@@ -45,7 +45,7 @@ public class UnorderedFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(parameters, staticContext);
-        this.iterator = this.children.get(0);
+        this.iterator = this.getChild(0);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/value/DeepEqualFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/value/DeepEqualFunctionIterator.java
@@ -63,10 +63,10 @@ public class DeepEqualFunctionIterator extends AtMostOneItemLocalRuntimeIterator
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        RuntimeIterator sequenceIterator1 = this.children.get(0);
-        RuntimeIterator sequenceIterator2 = this.children.get(1);
-        if (this.children.size() == 3) {
-            String collation = this.children.get(2).materializeFirstItemOrNull(context).getStringValue();
+        RuntimeIterator sequenceIterator1 = this.getChild(0);
+        RuntimeIterator sequenceIterator2 = this.getChild(1);
+        if (this.getChildren().size() == 3) {
+            String collation = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new DefaultCollationException("Wrong collation parameter", getMetadata());
             }

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/value/DistinctValuesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/value/DistinctValuesFunctionIterator.java
@@ -53,8 +53,8 @@ public class DistinctValuesFunctionIterator extends HybridRuntimeIterator {
     }
 
     private void checkCollation(DynamicContext context) {
-        if (this.children.size() == 2) {
-            String collation = this.children.get(1)
+        if (this.getChildren().size() == 2) {
+            String collation = this.getChild(1)
                 .materializeFirstItemOrNull(context)
                 .getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/value/IndexOfFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/value/IndexOfFunctionIterator.java
@@ -51,13 +51,13 @@ public class IndexOfFunctionIterator extends HybridRuntimeIterator {
             RuntimeStaticContext staticContext
     ) {
         super(arguments, staticContext);
-        this.sequenceIterator = this.children.get(0);
-        this.searchIterator = this.children.get(1);
+        this.sequenceIterator = this.getChild(0);
+        this.searchIterator = this.getChild(1);
     }
 
     private void checkCollation(DynamicContext context) {
-        if (this.children.size() == 3) {
-            String collation = this.children.get(2)
+        if (this.getChildren().size() == 3) {
+            String collation = this.getChild(2)
                 .materializeFirstItemOrNull(context)
                 .getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {

--- a/src/main/java/org/rumbledb/runtime/functions/strings/AnalyzeStringFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/AnalyzeStringFunctionIterator.java
@@ -40,13 +40,13 @@ public class AnalyzeStringFunctionIterator extends AtMostOneItemLocalRuntimeIter
     public Item materializeFirstItemOrNull(DynamicContext context) {
         ItemFactory factory = ItemFactory.getInstance();
 
-        Item inputItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item inputItem = this.getChild(0).materializeFirstItemOrNull(context);
         String input = inputItem == null ? "" : inputItem.getStringValue();
 
-        String pattern = this.children.get(1).materializeFirstItemOrNull(context).getStringValue();
+        String pattern = this.getChild(1).materializeFirstItemOrNull(context).getStringValue();
         String flags = null;
-        if (this.children.size() == 3) {
-            Item flagsItem = this.children.get(2).materializeFirstItemOrNull(context);
+        if (this.getChildren().size() == 3) {
+            Item flagsItem = this.getChild(2).materializeFirstItemOrNull(context);
             if (flagsItem != null) {
                 flags = flagsItem.getStringValue();
             }

--- a/src/main/java/org/rumbledb/runtime/functions/strings/CodepointEqualFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/CodepointEqualFunctionIterator.java
@@ -56,9 +56,9 @@ public class CodepointEqualFunctionIterator extends AtMostOneItemLocalRuntimeIte
 
     public void setNextResult(DynamicContext context) {
         if (this.input1 == null || this.input2 == null) {
-            Item operandOneItem = this.children.get(0)
+            Item operandOneItem = this.getChild(0)
                 .materializeFirstItemOrNull(context);
-            Item operandTwoItem = this.children.get(1)
+            Item operandTwoItem = this.getChild(1)
                 .materializeFirstItemOrNull(context);
             if (operandOneItem == null || operandTwoItem == null) {
                 this.hasNext = false;

--- a/src/main/java/org/rumbledb/runtime/functions/strings/CodepointsToStringFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/CodepointsToStringFunctionIterator.java
@@ -48,7 +48,7 @@ public class CodepointsToStringFunctionIterator extends AtMostOneItemLocalRuntim
 
     public Item materializeFirstItemOrNull(DynamicContext context) {
         String xmlVersion = getConfiguration().getXmlVersion();
-        RuntimeIterator argumentIterator = this.children.get(0);
+        RuntimeIterator argumentIterator = this.getChild(0);
 
         argumentIterator.open(context);
         try {
@@ -68,7 +68,7 @@ public class CodepointsToStringFunctionIterator extends AtMostOneItemLocalRuntim
             if (!XMLUtils.isValidXmlCharacter(codepoint, xmlVersion)) {
                 throw new CodepointNotValidException(
                         "Non-XML-conformant codepoint: " + item.getIntegerValue(),
-                        this.children.get(0).getMetadata()
+                        this.getChild(0).getMetadata()
                 );
             }
             sb.appendCodePoint(codepoint);
@@ -82,7 +82,7 @@ public class CodepointsToStringFunctionIterator extends AtMostOneItemLocalRuntim
         } catch (ArithmeticException e) {
             CodepointNotValidException ex = new CodepointNotValidException(
                     "Non-XML-conformant codepoint: " + item.getIntegerValue(),
-                    this.children.get(0).getMetadata()
+                    this.getChild(0).getMetadata()
             );
             ex.initCause(e);
             throw ex;

--- a/src/main/java/org/rumbledb/runtime/functions/strings/CompareFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/CompareFunctionIterator.java
@@ -46,15 +46,15 @@ public class CompareFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 3) {
-            String collation = this.children.get(2).materializeFirstItemOrNull(context).getStringValue();
+        if (this.getChildren().size() == 3) {
+            String collation = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new UnsupportedCollationException("Wrong collation parameter", getMetadata());
             }
         }
-        Item firstStringItem = this.children.get(0)
+        Item firstStringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
-        Item secondStringItem = this.children.get(1)
+        Item secondStringItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
         if (firstStringItem == null || secondStringItem == null) {
             return null;

--- a/src/main/java/org/rumbledb/runtime/functions/strings/ConcatFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/ConcatFunctionIterator.java
@@ -45,7 +45,7 @@ public class ConcatFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
         StringBuilder builder = new StringBuilder();
-        for (RuntimeIterator iterator : this.children) {
+        for (RuntimeIterator iterator : this.getChildren()) {
             Item item = iterator.materializeFirstItemOrNull(context);
             // if not empty sequence
             if (item != null) {

--- a/src/main/java/org/rumbledb/runtime/functions/strings/ContainsFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/ContainsFunctionIterator.java
@@ -45,19 +45,19 @@ public class ContainsFunctionIterator extends AtMostOneItemLocalRuntimeIterator 
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 3) {
-            String collation = this.children.get(2).materializeFirstItemOrNull(context).getStringValue();
+        if (this.getChildren().size() == 3) {
+            String collation = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new UnsupportedCollationException("Wrong collation parameter", getMetadata());
             }
         }
 
-        Item substringItem = this.children.get(1)
+        Item substringItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
         if (substringItem == null || substringItem.getStringValue().isEmpty()) {
             return ItemFactory.getInstance().createBooleanItem(true);
         }
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (stringItem == null || stringItem.getStringValue().isEmpty()) {
             return ItemFactory.getInstance().createBooleanItem(false);

--- a/src/main/java/org/rumbledb/runtime/functions/strings/ContainsTokenFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/ContainsTokenFunctionIterator.java
@@ -24,7 +24,7 @@ public class ContainsTokenFunctionIterator extends AtMostOneItemLocalRuntimeIter
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 3) {
+        if (this.getChildren().size() == 3) {
             throw new UnimplementedFunctionException("fn:contains-token#3", getMetadata());
         }
 
@@ -37,7 +37,7 @@ public class ContainsTokenFunctionIterator extends AtMostOneItemLocalRuntimeIter
     }
 
     private String getNormalizedToken(DynamicContext context) {
-        Item tokenItem = this.children.get(1).materializeFirstItemOrNull(context);
+        Item tokenItem = this.getChild(1).materializeFirstItemOrNull(context);
         return trimXmlWhitespace(tokenItem.getStringValue());
     }
 
@@ -58,7 +58,7 @@ public class ContainsTokenFunctionIterator extends AtMostOneItemLocalRuntimeIter
     }
 
     private boolean inputContainsToken(DynamicContext context, String token) {
-        RuntimeIterator inputIterator = this.children.get(0);
+        RuntimeIterator inputIterator = this.getChild(0);
         inputIterator.open(context);
         try {
             return iteratorContainsToken(inputIterator, token);

--- a/src/main/java/org/rumbledb/runtime/functions/strings/EncodeForURIFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/EncodeForURIFunctionIterator.java
@@ -59,7 +59,7 @@ public class EncodeForURIFunctionIterator extends LocalFunctionCallIterator {
     public Item next() {
         if (this.hasNext) {
             this.hasNext = false;
-            Item inputItem = this.children.get(0)
+            Item inputItem = this.getChild(0)
                 .materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
 
             if (inputItem == null) {

--- a/src/main/java/org/rumbledb/runtime/functions/strings/EndsWithFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/EndsWithFunctionIterator.java
@@ -45,7 +45,7 @@ public class EndsWithFunctionIterator extends AtMostOneItemLocalRuntimeIterator 
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.getNumberOfChildren() == 3) {
+        if (this.getChildren().size() == 3) {
             String collation = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new UnsupportedCollationException("Wrong collation parameter", getMetadata());

--- a/src/main/java/org/rumbledb/runtime/functions/strings/EndsWithFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/EndsWithFunctionIterator.java
@@ -45,18 +45,18 @@ public class EndsWithFunctionIterator extends AtMostOneItemLocalRuntimeIterator 
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 3) {
-            String collation = this.children.get(2).materializeFirstItemOrNull(context).getStringValue();
+        if (this.getNumberOfChildren() == 3) {
+            String collation = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new UnsupportedCollationException("Wrong collation parameter", getMetadata());
             }
         }
-        Item substringItem = this.children.get(1)
+        Item substringItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
         if (substringItem == null || substringItem.getStringValue().isEmpty()) {
             return ItemFactory.getInstance().createBooleanItem(true);
         }
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (stringItem == null || stringItem.getStringValue().isEmpty()) {
             return ItemFactory.getInstance().createBooleanItem(false);

--- a/src/main/java/org/rumbledb/runtime/functions/strings/EscapeHTMLURIFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/EscapeHTMLURIFunctionIterator.java
@@ -24,7 +24,7 @@ public class EscapeHTMLURIFunctionIterator extends AtMostOneItemLocalRuntimeIter
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item item = this.children.get(0).materializeFirstItemOrNull(context);
+        Item item = this.getChild(0).materializeFirstItemOrNull(context);
         if (item == null) {
             return ItemFactory.getInstance().createStringItem("");
         }

--- a/src/main/java/org/rumbledb/runtime/functions/strings/IRIToURIFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/IRIToURIFunctionIterator.java
@@ -25,7 +25,7 @@ public class IRIToURIFunctionIterator extends AtMostOneItemLocalRuntimeIterator 
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item inputItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item inputItem = this.getChild(0).materializeFirstItemOrNull(context);
 
         if (inputItem == null) {
             return ItemFactory.getInstance().createStringItem("");

--- a/src/main/java/org/rumbledb/runtime/functions/strings/LowerCaseFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/LowerCaseFunctionIterator.java
@@ -44,7 +44,7 @@ public class LowerCaseFunctionIterator extends AtMostOneItemLocalRuntimeIterator
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item stringItem = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item stringItem = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
 
         if (stringItem == null) {
             return ItemFactory.getInstance().createStringItem("");

--- a/src/main/java/org/rumbledb/runtime/functions/strings/MatchesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/MatchesFunctionIterator.java
@@ -45,17 +45,17 @@ public class MatchesFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item regexpItem = this.children.get(1)
+        Item regexpItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (stringItem == null) {
             stringItem = ItemFactory.getInstance().createStringItem("");
         }
         String pattern = regexpItem.getStringValue();
         String flags = null;
-        if (this.children.size() == 3) {
-            Item flagsItem = this.children.get(2)
+        if (this.getNumberOfChildren() == 3) {
+            Item flagsItem = this.getChild(2)
                 .materializeFirstItemOrNull(context);
             if (flagsItem != null) {
                 flags = flagsItem.getStringValue();

--- a/src/main/java/org/rumbledb/runtime/functions/strings/MatchesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/MatchesFunctionIterator.java
@@ -54,7 +54,7 @@ public class MatchesFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         }
         String pattern = regexpItem.getStringValue();
         String flags = null;
-        if (this.getNumberOfChildren() == 3) {
+        if (this.getChildren().size() == 3) {
             Item flagsItem = this.getChild(2)
                 .materializeFirstItemOrNull(context);
             if (flagsItem != null) {

--- a/src/main/java/org/rumbledb/runtime/functions/strings/NormalizeSpaceFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/NormalizeSpaceFunctionIterator.java
@@ -46,12 +46,12 @@ public class NormalizeSpaceFunctionIterator extends AtMostOneItemLocalRuntimeIte
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 0) {
+        if (this.getChildren().size() == 0) {
             List<Item> items = context.getVariableValues().getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata());
             return ItemFactory.getInstance()
                 .createStringItem(StringUtils.normalizeSpace(items.get(0).getStringValue()));
         }
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
 
         if (stringItem == null) {

--- a/src/main/java/org/rumbledb/runtime/functions/strings/NormalizeUnicodeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/NormalizeUnicodeFunctionIterator.java
@@ -136,15 +136,15 @@ public class NormalizeUnicodeFunctionIterator extends AtMostOneItemLocalRuntimeI
     public Item materializeFirstItemOrNull(DynamicContext context) {
         boolean fullyNormalized = false;
         Normalizer.Form normalizationForm = Normalizer.Form.NFC;
-        Item inputItem = this.children.get(0)
+        Item inputItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
 
         if (inputItem == null) {
             return ItemFactory.getInstance().createStringItem("");
         }
 
-        if (this.children.size() > 1) {
-            Item normalizationFormItem = this.children.get(1)
+        if (this.getChildren().size() > 1) {
+            Item normalizationFormItem = this.getChild(1)
                 .materializeFirstItemOrNull(context);
 
             String normalizationFormRaw = normalizationFormItem.getStringValue();

--- a/src/main/java/org/rumbledb/runtime/functions/strings/ReplaceFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/ReplaceFunctionIterator.java
@@ -48,9 +48,9 @@ public class ReplaceFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
-        Item patternStringItem = this.children.get(1)
+        Item patternStringItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
 
         if (patternStringItem == null) {
@@ -58,8 +58,8 @@ public class ReplaceFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
         }
         String pattern = patternStringItem.getStringValue();
         String flags = null;
-        if (this.children.size() == 4) {
-            Item flagsItem = this.children.get(3)
+        if (this.getChildren().size() == 4) {
+            Item flagsItem = this.getChild(3)
                 .materializeFirstItemOrNull(context);
             if (flagsItem != null) {
                 flags = flagsItem.getStringValue();
@@ -73,7 +73,7 @@ public class ReplaceFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
             );
         }
 
-        Item replacementStringItem = this.children.get(2)
+        Item replacementStringItem = this.getChild(2)
             .materializeFirstItemOrNull(context);
         String replacement = replacementStringItem.getStringValue();
         if (compiledRegex.isQuote()) {

--- a/src/main/java/org/rumbledb/runtime/functions/strings/ResolveURIFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/ResolveURIFunctionIterator.java
@@ -27,13 +27,13 @@ public class ResolveURIFunctionIterator extends AtMostOneItemLocalRuntimeIterato
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item relative = this.children.get(0).materializeFirstItemOrNull(context);
+        Item relative = this.getChild(0).materializeFirstItemOrNull(context);
         if (relative == null) {
             return null;
         }
         Item base;
-        if (this.children.size() == 2) {
-            base = this.children.get(1).materializeFirstItemOrNull(context);
+        if (this.getChildren().size() == 2) {
+            base = this.getChild(1).materializeFirstItemOrNull(context);
         } else {
             base = ItemFactory.getInstance().createAnyURIItem(this.staticContext.getStaticURI().toString());
         }

--- a/src/main/java/org/rumbledb/runtime/functions/strings/SerializeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/SerializeFunctionIterator.java
@@ -51,7 +51,7 @@ public class SerializeFunctionIterator extends LocalFunctionCallIterator {
     @Override
     public Item next() {
         if (this.hasNext) {
-            List<Item> items = this.children.get(0).materialize(this.currentDynamicContextForLocalExecution);
+            List<Item> items = this.getChild(0).materialize(this.currentDynamicContextForLocalExecution);
             SerializationParameters params = resolveSerializationParameters();
             SerializationParameters itemParams = SerializationParameters.copy(params);
             if ("xml".equalsIgnoreCase(params.getMethod())) {
@@ -104,11 +104,11 @@ public class SerializeFunctionIterator extends LocalFunctionCallIterator {
         SerializationParameters params = SerializationParameterUtils.defaultsForSerializeFunction(
             this.staticContext.getQueryLanguage()
         );
-        if (this.children.size() < 2) {
+        if (this.getNumberOfChildren() < 2) {
             return params;
         }
 
-        List<Item> optionsItems = this.children.get(1).materialize(this.currentDynamicContextForLocalExecution);
+        List<Item> optionsItems = this.getChild(1).materialize(this.currentDynamicContextForLocalExecution);
         SerializationParameterUtils.applyParameterItems(params, optionsItems, getMetadata());
         return params;
     }

--- a/src/main/java/org/rumbledb/runtime/functions/strings/SerializeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/SerializeFunctionIterator.java
@@ -104,7 +104,7 @@ public class SerializeFunctionIterator extends LocalFunctionCallIterator {
         SerializationParameters params = SerializationParameterUtils.defaultsForSerializeFunction(
             this.staticContext.getQueryLanguage()
         );
-        if (this.getNumberOfChildren() < 2) {
+        if (this.getChildren().size() < 2) {
             return params;
         }
 

--- a/src/main/java/org/rumbledb/runtime/functions/strings/StartsWithFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/StartsWithFunctionIterator.java
@@ -45,19 +45,19 @@ public class StartsWithFunctionIterator extends AtMostOneItemLocalRuntimeIterato
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 3) {
-            String collation = this.children.get(2).materializeFirstItemOrNull(context).getStringValue();
+        if (this.getChildren().size() == 3) {
+            String collation = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new UnsupportedCollationException("Wrong collation parameter", getMetadata());
             }
         }
 
-        Item substringItem = this.children.get(1)
+        Item substringItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
         if (substringItem == null || substringItem.getStringValue().isEmpty()) {
             return ItemFactory.getInstance().createBooleanItem(true);
         }
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (stringItem == null || stringItem.getStringValue().isEmpty()) {
             return ItemFactory.getInstance().createBooleanItem(false);

--- a/src/main/java/org/rumbledb/runtime/functions/strings/StringFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/StringFunctionIterator.java
@@ -54,13 +54,13 @@ public class StringFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 0) {
+        if (this.getChildren().size() == 0) {
             List<Item> items = context.getVariableValues().getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata());
             Item contextItem = items.get(0);
             return stringResultFromItem(contextItem);
         }
 
-        Item item = this.children.get(0)
+        Item item = this.getChild(0)
             .materializeFirstItemOrNull(context);
 
         if (item == null) {

--- a/src/main/java/org/rumbledb/runtime/functions/strings/StringJoinFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/StringJoinFunctionIterator.java
@@ -46,16 +46,16 @@ public class StringJoinFunctionIterator extends AtMostOneItemLocalRuntimeIterato
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
         Item joinString = ItemFactory.getInstance().createStringItem("");
-        if (this.children.size() > 1) {
-            joinString = this.children.get(1).materializeFirstItemOrNull(context);
+        if (this.getNumberOfChildren() > 1) {
+            joinString = this.getChild(1).materializeFirstItemOrNull(context);
         }
-        List<Item> strings = this.children.get(0).materialize(context);
+        List<Item> strings = this.getChild(0).materialize(context);
 
         StringBuilder stringBuilder = new StringBuilder();
         boolean first = true;
         for (Item item : strings) {
             if (!(item.isString())) {
-                throw new UnexpectedTypeException("String item expected", this.children.get(0).getMetadata());
+                throw new UnexpectedTypeException("String item expected", this.getChild(0).getMetadata());
             }
             if (!first) {
                 stringBuilder.append(joinString.getStringValue());

--- a/src/main/java/org/rumbledb/runtime/functions/strings/StringJoinFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/StringJoinFunctionIterator.java
@@ -46,7 +46,7 @@ public class StringJoinFunctionIterator extends AtMostOneItemLocalRuntimeIterato
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
         Item joinString = ItemFactory.getInstance().createStringItem("");
-        if (this.getNumberOfChildren() > 1) {
+        if (this.getChildren().size() > 1) {
             joinString = this.getChild(1).materializeFirstItemOrNull(context);
         }
         List<Item> strings = this.getChild(0).materialize(context);

--- a/src/main/java/org/rumbledb/runtime/functions/strings/StringLengthFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/StringLengthFunctionIterator.java
@@ -48,11 +48,11 @@ public class StringLengthFunctionIterator extends AtMostOneItemLocalRuntimeItera
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        if (this.children.size() == 0) {
+        if (this.getChildren().size() == 0) {
             List<Item> items = context.getVariableValues().getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata());
             return ItemFactory.getInstance().createIntItem(items.get(0).getStringValue().length());
         }
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
 
         if (stringItem == null) {
@@ -64,10 +64,10 @@ public class StringLengthFunctionIterator extends AtMostOneItemLocalRuntimeItera
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        if (this.children.size() == 0) {
+        if (this.getChildren().size() == 0) {
             return NativeClauseContext.NoNativeQuery;
         }
-        NativeClauseContext childContext = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext childContext = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (childContext == NativeClauseContext.NoNativeQuery) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/strings/StringToCodepointsFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/StringToCodepointsFunctionIterator.java
@@ -67,7 +67,7 @@ public class StringToCodepointsFunctionIterator extends LocalFunctionCallIterato
     public void setNextResult() {
         if (this.input == null) {
             // Getting first parameter
-            Item stringItem = this.children.get(0)
+            Item stringItem = this.getChild(0)
                 .materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
 
             if (stringItem == null) {

--- a/src/main/java/org/rumbledb/runtime/functions/strings/SubstringAfterFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/SubstringAfterFunctionIterator.java
@@ -25,12 +25,12 @@ public class SubstringAfterFunctionIterator extends AtMostOneItemLocalRuntimeIte
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
-        Item substringItem = this.children.get(1)
+        Item substringItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
-        if (this.children.size() == 3) {
-            String collation = this.children.get(2).materializeFirstItemOrNull(context).getStringValue();
+        if (this.getChildren().size() == 3) {
+            String collation = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new UnsupportedCollationException("Wrong collation parameter", getMetadata());
             }

--- a/src/main/java/org/rumbledb/runtime/functions/strings/SubstringBeforeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/SubstringBeforeFunctionIterator.java
@@ -25,12 +25,12 @@ public class SubstringBeforeFunctionIterator extends AtMostOneItemLocalRuntimeIt
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
-        Item substringItem = this.children.get(1)
+        Item substringItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
-        if (this.children.size() == 3) {
-            String collation = this.children.get(2).materializeFirstItemOrNull(context).getStringValue();
+        if (this.getChildren().size() == 3) {
+            String collation = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
             if (!collation.equals("http://www.w3.org/2005/xpath-functions/collation/codepoint")) {
                 throw new UnsupportedCollationException("Wrong collation parameter", getMetadata());
             }

--- a/src/main/java/org/rumbledb/runtime/functions/strings/SubstringFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/SubstringFunctionIterator.java
@@ -46,12 +46,12 @@ public class SubstringFunctionIterator extends AtMostOneItemLocalRuntimeIterator
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
         String result;
-        Item stringItem = this.children.get(0)
+        Item stringItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
         if (stringItem == null) {
             return ItemFactory.getInstance().createStringItem("");
         }
-        Item indexItem = this.children.get(1)
+        Item indexItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
         if (indexItem == null) {
             throw new UnexpectedTypeException(
@@ -63,8 +63,8 @@ public class SubstringFunctionIterator extends AtMostOneItemLocalRuntimeIterator
         if (index >= stringItem.getStringValue().length()) {
             return ItemFactory.getInstance().createStringItem("");
         }
-        if (this.children.size() > 2) {
-            Item endIndexItem = this.children.get(2)
+        if (this.getChildren().size() > 2) {
+            Item endIndexItem = this.getChild(2)
                 .materializeFirstItemOrNull(context);
             if (endIndexItem == null) {
                 throw new UnexpectedTypeException(

--- a/src/main/java/org/rumbledb/runtime/functions/strings/TokenizeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/TokenizeFunctionIterator.java
@@ -69,7 +69,7 @@ public class TokenizeFunctionIterator extends LocalFunctionCallIterator {
     public void setNextResult() {
         if (this.results == null) {
             // Getting first parameter
-            RuntimeIterator stringIterator = this.children.get(0);
+            RuntimeIterator stringIterator = this.getChild(0);
             String input = null;
             String separator = null;
             Item stringItem = stringIterator.materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);

--- a/src/main/java/org/rumbledb/runtime/functions/strings/TokenizeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/TokenizeFunctionIterator.java
@@ -80,11 +80,11 @@ public class TokenizeFunctionIterator extends LocalFunctionCallIterator {
             input = stringItem.getStringValue();
 
             // Getting second parameter
-            if (this.children.size() == 1) {
+            if (this.getChildren().size() == 1) {
                 this.results = RegexPatternUtils.tokenizeOnXmlWhitespace(input);
                 this.currentPosition = 0;
             } else {
-                RuntimeIterator separatorIterator = this.children.get(1);
+                RuntimeIterator separatorIterator = this.getChild(1);
                 separatorIterator.open(this.currentDynamicContextForLocalExecution);
                 if (!separatorIterator.hasNext()) {
                     throw new UnexpectedTypeException("Second parameter of tokenize must be a string.", getMetadata());
@@ -103,8 +103,8 @@ public class TokenizeFunctionIterator extends LocalFunctionCallIterator {
                     throw new UnexpectedTypeException("Second parameter of tokenize must be a string.", getMetadata());
                 }
                 String flags = null;
-                if (this.children.size() == 3) {
-                    Item flagsItem = this.children.get(2)
+                if (this.getChildren().size() == 3) {
+                    Item flagsItem = this.getChild(2)
                         .materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
                     if (flagsItem != null) {
                         flags = flagsItem.getStringValue();

--- a/src/main/java/org/rumbledb/runtime/functions/strings/TranslateFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/TranslateFunctionIterator.java
@@ -46,11 +46,11 @@ public class TranslateFunctionIterator extends AtMostOneItemLocalRuntimeIterator
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item inputItem = this.children.get(0)
+        Item inputItem = this.getChild(0)
             .materializeFirstItemOrNull(context);
-        Item mapStringItem = this.children.get(1)
+        Item mapStringItem = this.getChild(1)
             .materializeFirstItemOrNull(context);
-        Item transStringItem = this.children.get(2)
+        Item transStringItem = this.getChild(2)
             .materializeFirstItemOrNull(context);
 
         if (inputItem == null) {

--- a/src/main/java/org/rumbledb/runtime/functions/strings/UpperCaseFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/strings/UpperCaseFunctionIterator.java
@@ -44,7 +44,7 @@ public class UpperCaseFunctionIterator extends AtMostOneItemLocalRuntimeIterator
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext dynamicContext) {
-        Item stringItem = this.children.get(0).materializeFirstItemOrNull(dynamicContext);
+        Item stringItem = this.getChild(0).materializeFirstItemOrNull(dynamicContext);
 
         if (stringItem == null) {
             return ItemFactory.getInstance().createStringItem("");

--- a/src/main/java/org/rumbledb/runtime/functions/typing/DynamicItemTypeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/typing/DynamicItemTypeIterator.java
@@ -29,7 +29,7 @@ public class DynamicItemTypeIterator extends AtMostOneItemLocalRuntimeIterator {
     }
 
     private void materializeArgument(DynamicContext context) {
-        this.materializedArgument = this.children.get(0).materialize(context);
+        this.materializedArgument = this.getChild(0).materialize(context);
     }
 
     private void setArgumentType() {

--- a/src/main/java/org/rumbledb/runtime/functions/typing/FunctionArityFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/typing/FunctionArityFunctionIterator.java
@@ -26,7 +26,7 @@ public class FunctionArityFunctionIterator extends AtMostOneItemLocalRuntimeIter
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item function = this.children.get(0).materializeFirstItemOrNull(context);
+        Item function = this.getChild(0).materializeFirstItemOrNull(context);
         if (function == null || !function.isFunction()) {
             throw new UnexpectedTypeException(
                     "The argument of fn:function-arity must be a single function item [err:XPTY0004].",

--- a/src/main/java/org/rumbledb/runtime/functions/typing/FunctionNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/typing/FunctionNameFunctionIterator.java
@@ -28,7 +28,7 @@ public class FunctionNameFunctionIterator extends AtMostOneItemLocalRuntimeItera
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        RuntimeIterator functionIterator = this.children.get(0);
+        RuntimeIterator functionIterator = this.getChild(0);
         /*
          * TODO remove...
          * Currently used for debugging, this guard fails when given an if statement

--- a/src/main/java/org/rumbledb/runtime/functions/typing/LocalNameFromQNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/typing/LocalNameFromQNameFunctionIterator.java
@@ -25,7 +25,7 @@ public class LocalNameFromQNameFunctionIterator extends AtMostOneItemLocalRuntim
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        QNameItem qnameItem = (QNameItem) this.children.get(0).materializeFirstItemOrNull(context);
+        QNameItem qnameItem = (QNameItem) this.getChild(0).materializeFirstItemOrNull(context);
         if (qnameItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/typing/NamespaceURIFromQNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/typing/NamespaceURIFromQNameFunctionIterator.java
@@ -25,7 +25,7 @@ public class NamespaceURIFromQNameFunctionIterator extends AtMostOneItemLocalRun
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        QNameItem qnameItem = (QNameItem) this.children.get(0).materializeFirstItemOrNull(context);
+        QNameItem qnameItem = (QNameItem) this.getChild(0).materializeFirstItemOrNull(context);
         if (qnameItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/typing/PrefixFromQNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/typing/PrefixFromQNameFunctionIterator.java
@@ -24,7 +24,7 @@ public class PrefixFromQNameFunctionIterator extends AtMostOneItemLocalRuntimeIt
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        QNameItem qnameItem = (QNameItem) this.children.get(0).materializeFirstItemOrNull(context);
+        QNameItem qnameItem = (QNameItem) this.getChild(0).materializeFirstItemOrNull(context);
         if (qnameItem == null) {
             return null;
         }

--- a/src/main/java/org/rumbledb/runtime/functions/xml/BaseUriFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/BaseUriFunctionIterator.java
@@ -122,14 +122,14 @@ public class BaseUriFunctionIterator extends LocalFunctionCallIterator {
      * If a parameter is provided, uses the first parameter.
      */
     private Item getContextNode() {
-        if (this.children.isEmpty()) {
+        if (this.getChildren().isEmpty()) {
             // No argument provided, use context item
             return this.currentDynamicContextForLocalExecution.getVariableValues()
                 .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())
                 .get(0);
         }
         // Argument provided, use first parameter
-        return this.children.get(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
+        return this.getChild(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
     }
 }
 

--- a/src/main/java/org/rumbledb/runtime/functions/xml/DocumentUriFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/DocumentUriFunctionIterator.java
@@ -120,14 +120,14 @@ public class DocumentUriFunctionIterator extends LocalFunctionCallIterator {
      * If a parameter is provided, uses the first parameter.
      */
     private Item getContextNode() {
-        if (this.children.isEmpty()) {
+        if (this.getChildren().isEmpty()) {
             // No argument provided, use context item
             return this.currentDynamicContextForLocalExecution.getVariableValues()
                 .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())
                 .get(0);
         }
         // Argument provided, use first parameter
-        return this.children.get(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
+        return this.getChild(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
     }
 }
 

--- a/src/main/java/org/rumbledb/runtime/functions/xml/GetRootFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/GetRootFunctionIterator.java
@@ -59,11 +59,11 @@ public class GetRootFunctionIterator extends LocalFunctionCallIterator {
     }
 
     private Item getContextNode() {
-        if (this.children.isEmpty()) {
+        if (this.getChildren().isEmpty()) {
             return this.currentDynamicContextForLocalExecution.getVariableValues()
                 .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())
                 .get(0);
         }
-        return this.children.get(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
+        return this.getChild(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
     }
 }

--- a/src/main/java/org/rumbledb/runtime/functions/xml/HasChildrenFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/HasChildrenFunctionIterator.java
@@ -36,8 +36,8 @@ public class HasChildrenFunctionIterator extends AtMostOneItemLocalRuntimeIterat
     }
 
     private Item getContextNode(DynamicContext context) {
-        if (!this.children.isEmpty()) {
-            return this.children.get(0).materializeFirstItemOrNull(context);
+        if (!this.getChildren().isEmpty()) {
+            return this.getChild(0).materializeFirstItemOrNull(context);
         }
         return context.getVariableValues()
             .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())

--- a/src/main/java/org/rumbledb/runtime/functions/xml/InScopePrefixesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/InScopePrefixesFunctionIterator.java
@@ -72,7 +72,7 @@ public class InScopePrefixesFunctionIterator extends LocalFunctionCallIterator {
 
         // fn:in-scope-prefixes($element as element()) as xs:string*
         // The function requires exactly one argument of type element().
-        Item element = this.children.get(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
+        Item element = this.getChild(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
 
         this.prefixItems = computeInScopePrefixes(element);
         this.hasNext = !this.prefixItems.isEmpty();

--- a/src/main/java/org/rumbledb/runtime/functions/xml/InnermostFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/InnermostFunctionIterator.java
@@ -35,7 +35,7 @@ public class InnermostFunctionIterator extends HybridRuntimeIterator {
     }
 
     private void computeResults() {
-        List<Item> nodes = this.children.get(0).materialize(this.currentDynamicContextForLocalExecution);
+        List<Item> nodes = this.getChild(0).materialize(this.currentDynamicContextForLocalExecution);
         for (Item node : nodes) {
             if (!node.isNode()) {
                 throw new UnexpectedTypeException("fn:innermost requires a sequence of nodes", getMetadata());

--- a/src/main/java/org/rumbledb/runtime/functions/xml/LangFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/LangFunctionIterator.java
@@ -25,7 +25,7 @@ public class LangFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item testlangItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item testlangItem = this.getChild(0).materializeFirstItemOrNull(context);
         String testlang = testlangItem == null ? "" : testlangItem.getStringValue();
 
         Item node = getContextNode(context);
@@ -57,8 +57,8 @@ public class LangFunctionIterator extends AtMostOneItemLocalRuntimeIterator {
     }
 
     private Item getContextNode(DynamicContext context) {
-        if (this.children.size() == 2) {
-            return this.children.get(1).materializeFirstItemOrNull(context);
+        if (this.getChildren().size() == 2) {
+            return this.getChild(1).materializeFirstItemOrNull(context);
         }
         return context.getVariableValues()
             .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())

--- a/src/main/java/org/rumbledb/runtime/functions/xml/LocalNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/LocalNameFunctionIterator.java
@@ -40,8 +40,8 @@ public class LocalNameFunctionIterator extends AtMostOneItemLocalRuntimeIterator
     }
 
     private Item getContextNode(DynamicContext context) {
-        if (!this.children.isEmpty()) {
-            return this.children.get(0).materializeFirstItemOrNull(context);
+        if (!this.getChildren().isEmpty()) {
+            return this.getChild(0).materializeFirstItemOrNull(context);
         }
         return context.getVariableValues()
             .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())

--- a/src/main/java/org/rumbledb/runtime/functions/xml/NamespaceUriForPrefixFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/NamespaceUriForPrefixFunctionIterator.java
@@ -24,9 +24,9 @@ public class NamespaceUriForPrefixFunctionIterator extends AtMostOneItemLocalRun
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        Item prefixItem = this.children.get(0).materializeFirstItemOrNull(context);
+        Item prefixItem = this.getChild(0).materializeFirstItemOrNull(context);
         String prefix = prefixItem == null ? "" : prefixItem.getStringValue();
-        Item element = this.children.get(1).materializeFirstItemOrNull(context);
+        Item element = this.getChild(1).materializeFirstItemOrNull(context);
         for (Item namespaceNode : element.namespaceNodes()) {
             Name name = namespaceNode.nodeName();
             String namespacePrefix = name == null ? "" : name.getLocalName();

--- a/src/main/java/org/rumbledb/runtime/functions/xml/NamespaceUriFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/NamespaceUriFunctionIterator.java
@@ -39,7 +39,7 @@ public class NamespaceUriFunctionIterator extends AtMostOneItemLocalRuntimeItera
     }
 
     private Item getContextNode(DynamicContext context) {
-        if (this.getNumberOfChildren() > 0) {
+        if (this.getChildren().size() > 0) {
             return this.getChild(0).materializeFirstItemOrNull(context);
         }
         return context.getVariableValues()

--- a/src/main/java/org/rumbledb/runtime/functions/xml/NamespaceUriFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/NamespaceUriFunctionIterator.java
@@ -39,8 +39,8 @@ public class NamespaceUriFunctionIterator extends AtMostOneItemLocalRuntimeItera
     }
 
     private Item getContextNode(DynamicContext context) {
-        if (!this.children.isEmpty()) {
-            return this.children.get(0).materializeFirstItemOrNull(context);
+        if (this.getNumberOfChildren() > 0) {
+            return this.getChild(0).materializeFirstItemOrNull(context);
         }
         return context.getVariableValues()
             .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())

--- a/src/main/java/org/rumbledb/runtime/functions/xml/NilledFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/NilledFunctionIterator.java
@@ -122,14 +122,14 @@ public class NilledFunctionIterator extends LocalFunctionCallIterator {
      * If a parameter is provided, uses the first parameter.
      */
     private Item getContextNode() {
-        if (this.children.isEmpty()) {
+        if (this.getChildren().isEmpty()) {
             // No argument provided, use context item
             return this.currentDynamicContextForLocalExecution.getVariableValues()
                 .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())
                 .get(0);
         }
         // Argument provided, use first parameter
-        return this.children.get(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
+        return this.getChild(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
     }
 }
 

--- a/src/main/java/org/rumbledb/runtime/functions/xml/NodeNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/NodeNameFunctionIterator.java
@@ -112,13 +112,13 @@ public class NodeNameFunctionIterator extends LocalFunctionCallIterator {
      * If a parameter is provided, uses the first parameter.
      */
     private Item getContextNode() {
-        if (this.children.isEmpty()) {
+        if (this.getChildren().isEmpty()) {
             // No argument provided, use context item
             return this.currentDynamicContextForLocalExecution.getVariableValues()
                 .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())
                 .get(0);
         }
         // Argument provided, use first parameter
-        return this.children.get(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
+        return this.getChild(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
     }
 }

--- a/src/main/java/org/rumbledb/runtime/functions/xml/NodeQNameFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/NodeQNameFunctionIterator.java
@@ -136,14 +136,14 @@ public class NodeQNameFunctionIterator extends LocalFunctionCallIterator {
      * Spec: "If the argument is omitted, it defaults to the context item."
      */
     private Item getContextNode() {
-        if (this.children.isEmpty()) {
+        if (this.getChildren().isEmpty()) {
             // No argument provided, use context item
             return this.currentDynamicContextForLocalExecution.getVariableValues()
                 .getLocalVariableValue(Name.CONTEXT_ITEM, getMetadata())
                 .get(0);
         }
         // Argument provided, use first parameter (may materialize to the empty sequence).
-        return this.children.get(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
+        return this.getChild(0).materializeFirstItemOrNull(this.currentDynamicContextForLocalExecution);
     }
 }
 

--- a/src/main/java/org/rumbledb/runtime/functions/xml/OutermostFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/OutermostFunctionIterator.java
@@ -35,7 +35,7 @@ public class OutermostFunctionIterator extends HybridRuntimeIterator {
     }
 
     private void computeResults() {
-        List<Item> nodes = this.children.get(0).materialize(this.currentDynamicContextForLocalExecution);
+        List<Item> nodes = this.getChild(0).materialize(this.currentDynamicContextForLocalExecution);
         for (Item node : nodes) {
             if (!node.isNode()) {
                 throw new UnexpectedTypeException("fn:outermost requires a sequence of nodes", getMetadata());

--- a/src/main/java/org/rumbledb/runtime/functions/xml/XMLToJsonFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/xml/XMLToJsonFunctionIterator.java
@@ -53,7 +53,7 @@ public class XMLToJsonFunctionIterator extends AtMostOneItemLocalRuntimeIterator
 
     private Item materializeInput(DynamicContext context) {
         try {
-            return this.children.get(0).materializeAtMostOneItemOrNull(context);
+            return this.getChild(0).materializeAtMostOneItemOrNull(context);
         } catch (MoreThanOneItemException e) {
             throw new UnexpectedTypeException(
                     "fn:xml-to-json expects at most one input item [err:XPTY0004].",
@@ -63,13 +63,13 @@ public class XMLToJsonFunctionIterator extends AtMostOneItemLocalRuntimeIterator
     }
 
     private boolean resolveIndentOption(DynamicContext context) {
-        if (this.children.size() < 2) {
+        if (this.getChildren().size() < 2) {
             return false;
         }
 
         Item options;
         try {
-            options = this.children.get(1).materializeAtMostOneItemOrNull(context);
+            options = this.getChild(1).materializeAtMostOneItemOrNull(context);
         } catch (MoreThanOneItemException e) {
             throw new UnexpectedTypeException(
                     "The options argument of fn:xml-to-json must be a single map item [err:XPTY0004].",

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupIterator.java
@@ -98,7 +98,7 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
     }
 
     private void initLookupPosition(DynamicContext context) {
-        RuntimeIterator lookupIterator = this.children.get(1);
+        RuntimeIterator lookupIterator = this.getChild(1);
 
         try {
             Item lookupExpression = lookupIterator.materializeExactlyOneItem(context);
@@ -167,7 +167,7 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
-        JavaRDD<Item> childRDD = this.children.get(0).getRDD(dynamicContext);
+        JavaRDD<Item> childRDD = this.getChild(0).getRDD(dynamicContext);
         initLookupPosition(dynamicContext);
         FlatMapFunction<Item, Item> transformation = new ArrayLookupClosure(this.lookup);
 
@@ -189,7 +189,7 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
             }
             // check if the key has variable dependencies inside the FLWOR expression
             // in that case we switch over to UDF
-            Map<Name, DynamicContext.VariableDependency> keyDependencies = this.children.get(1)
+            Map<Name, DynamicContext.VariableDependency> keyDependencies = this.getChild(1)
                 .getVariableDependencies();
             // we use nativeClauseContext that contains the top level schema
             DataType schema = nativeClauseContext.getSchema();
@@ -255,7 +255,7 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
+        JSoundDataFrame childDataFrame = this.getChild(0).getDataFrame(context);
         initLookupPosition(context);
         String array = FlworDataFrameUtils.createTempView(childDataFrame.getDataFrame());
         boolean isObject = childDataFrame.getItemType().isObjectItemType();

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayUnboxingIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayUnboxingIterator.java
@@ -121,7 +121,7 @@ public class ArrayUnboxingIterator extends HybridRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
-        JavaRDD<Item> childRDD = this.children.get(0).getRDD(dynamicContext);
+        JavaRDD<Item> childRDD = this.getChild(0).getRDD(dynamicContext);
         FlatMapFunction<Item, Item> transformation = new ArrayUnboxingClosure();
         JavaRDD<Item> resultRDD = childRDD.flatMap(transformation);
         return resultRDD;
@@ -188,7 +188,7 @@ public class ArrayUnboxingIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
+        JSoundDataFrame childDataFrame = this.getChild(0).getDataFrame(context);
         String array = FlworDataFrameUtils.createTempView(childDataFrame.getDataFrame());
         boolean isObject = childDataFrame.getItemType().isObjectItemType();
         boolean hasNonObjectJSONiqItem = isObject

--- a/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupIterator.java
@@ -82,8 +82,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
     }
 
     private void initLookupKey(DynamicContext context) {
-
-        RuntimeIterator lookupIterator = this.children.get(1);
+        RuntimeIterator lookupIterator = this.getChild(1);
 
         this.contextLookup = lookupIterator instanceof ContextExpressionIterator;
 
@@ -199,7 +198,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
-        JavaRDD<Item> childRDD = this.children.get(0).getRDD(dynamicContext);
+        JavaRDD<Item> childRDD = this.getChild(0).getRDD(dynamicContext);
         initLookupKey(dynamicContext);
         String key;
         if (this.contextLookup) {
@@ -228,7 +227,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
         // check if the key has variable dependencies inside the FLWOR expression
         // in that case we switch over to UDF
-        Map<Name, DynamicContext.VariableDependency> keyDependencies = this.children.get(1)
+        Map<Name, DynamicContext.VariableDependency> keyDependencies = this.getChild(1)
             .getVariableDependencies();
         // we use nativeClauseContext that contains the top level schema
         DataType outerContextSchema = nativeClauseContext.getSchema();
@@ -293,7 +292,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
         String key = this.lookupKey.getStringValue().replace("`", FlworDataFrameUtils.backtickEscape);
         String sequenceKey = key + SparkSessionManager.sequenceColumnName;
         if (!(leftSchema instanceof StructType structSchema)) {
-            if (this.children.get(1) instanceof StringRuntimeIterator) {
+            if (this.getChild(1) instanceof StringRuntimeIterator) {
                 if (getConfiguration().doStaticAnalysis()) {
                     throw new UnexpectedStaticTypeException(
                             "You are trying to look up the value associated with the field "
@@ -361,7 +360,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
             );
             newContext.setSchema(field.dataType());
         } else {
-            if (this.children.get(1) instanceof StringRuntimeIterator) {
+            if (this.getChild(1) instanceof StringRuntimeIterator) {
                 LogManager.getLogger("ObjectLookupIterator")
                     .warn(
                         "Object lookup on a DataFrame that does not have this column. Empty sequence returned."
@@ -384,7 +383,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
+        JSoundDataFrame childDataFrame = this.getChild(0).getDataFrame(context);
         initLookupKey(context);
         String key;
         if (this.contextLookup) {

--- a/src/main/java/org/rumbledb/runtime/navigation/PredicateIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/PredicateIterator.java
@@ -124,7 +124,7 @@ public class PredicateIterator extends HybridRuntimeIterator {
 
     @Override
     protected void openLocal() {
-        if (this.children.size() < 2) {
+        if (this.getChildren().size() < 2) {
             throw new OurBadException("Invalid Predicate! Must initialize filter before calling next");
         }
         this.filterDynamicContext = new DynamicContext(this.currentDynamicContextForLocalExecution);
@@ -220,8 +220,8 @@ public class PredicateIterator extends HybridRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
-        RuntimeIterator iterator = this.children.get(0);
-        RuntimeIterator filter = this.children.get(1);
+        RuntimeIterator iterator = this.getChild(0);
+        RuntimeIterator filter = this.getChild(1);
         JavaRDD<Item> childRDD = iterator.getRDD(dynamicContext);
         if (this.isBooleanOnlyFilter) {
             Function<Item, Boolean> transformation = new PredicateClosure(filter, dynamicContext);
@@ -250,8 +250,8 @@ public class PredicateIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        JSoundDataFrame childDataFrame = this.children.get(0).getDataFrame(context);
-        RuntimeIterator filter = this.children.get(1);
+        JSoundDataFrame childDataFrame = this.getChild(0).getDataFrame(context);
+        RuntimeIterator filter = this.getChild(1);
         NativeClauseContext nativeClauseContext = new NativeClauseContext(
                 FLWOR_CLAUSES.FILTER,
                 childDataFrame.getDataFrame().schema(),

--- a/src/main/java/org/rumbledb/runtime/navigation/SequenceLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/SequenceLookupIterator.java
@@ -159,13 +159,14 @@ public class SequenceLookupIterator extends AtMostOneItemLocalRuntimeIterator {
             nativeClauseContext.getClauseType() == FLWOR_CLAUSES.WHERE
                 && this.iterator instanceof CommaExpressionIterator childIterator
         ) {
+            List<RuntimeIterator> children = childIterator.getOperands();
             if (
-                childIterator.getChildren().size() == 2
-                    && childIterator.getChildren().get(0) instanceof ComparisonIterator
-                    && childIterator.getChildren().get(1) instanceof BooleanRuntimeIterator
+                children.size() == 2
+                    && children.get(0) instanceof ComparisonIterator
+                    && children.get(1) instanceof BooleanRuntimeIterator
                     && this.position == 1
             ) {
-                NativeClauseContext childContext = childIterator.getChildren()
+                NativeClauseContext childContext = children
                     .get(0)
                     .generateNativeQuery(nativeClauseContext);
                 if (childContext == NativeClauseContext.NoNativeQuery) {

--- a/src/main/java/org/rumbledb/runtime/primary/ArrayRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/ArrayRuntimeIterator.java
@@ -51,12 +51,9 @@ public class ArrayRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
             RuntimeStaticContext staticContext,
             boolean mutable
     ) {
-        super(null, staticContext);
+        super(arrayItems == null ? List.of() : List.of(arrayItems), staticContext);
         this.isFixedSlotsArrayConstructor = false;
         this.mutable = mutable;
-        if (arrayItems != null) {
-            this.children.add(arrayItems);
-        }
     }
 
     /**
@@ -68,12 +65,9 @@ public class ArrayRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
             RuntimeStaticContext staticContext,
             boolean mutable
     ) {
-        super(null, staticContext);
+        super(memberIterators == null ? List.of() : memberIterators, staticContext);
         this.isFixedSlotsArrayConstructor = isFixedSlotsArrayConstructor;
         this.mutable = mutable;
-        if (memberIterators != null) {
-            this.children.addAll(memberIterators);
-        }
     }
 
     @Override
@@ -83,7 +77,7 @@ public class ArrayRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
         if (isEffectiveFixedSlotsArrayConstructor()) {
             boolean allSingleton = true;
             List<List<Item>> memberSequences = new ArrayList<>();
-            for (RuntimeIterator child : this.children) {
+            for (RuntimeIterator child : this.getChildren()) {
                 List<Item> member = child.materialize(dynamicContext);
                 if (allSingleton && member.size() != 1) {
                     allSingleton = false;
@@ -103,7 +97,7 @@ public class ArrayRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
             }
         }
         List<Item> result = new ArrayList<>();
-        for (RuntimeIterator child : this.children) {
+        for (RuntimeIterator child : this.getChildren()) {
             result.addAll(child.materialize(dynamicContext));
         }
         return ItemFactory.getInstance().createArrayItem(result, this.mutable);
@@ -114,13 +108,13 @@ public class ArrayRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
         if (isEffectiveFixedSlotsArrayConstructor()) {
             return NativeClauseContext.NoNativeQuery;
         }
-        if (this.children.size() == 1) {
-            NativeClauseContext childQuery = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        if (this.getNumberOfChildren() == 1) {
+            NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
             if (childQuery == NativeClauseContext.NoNativeQuery) {
                 return NativeClauseContext.NoNativeQuery;
             }
             String resultingQuery;
-            if (this.children.get(0) instanceof CommaExpressionIterator) {
+            if (this.getChild(0) instanceof CommaExpressionIterator) {
                 resultingQuery = childQuery.getResultingQuery();
             } else {
                 resultingQuery = "array( "

--- a/src/main/java/org/rumbledb/runtime/primary/ArrayRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/ArrayRuntimeIterator.java
@@ -108,7 +108,7 @@ public class ArrayRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
         if (isEffectiveFixedSlotsArrayConstructor()) {
             return NativeClauseContext.NoNativeQuery;
         }
-        if (this.getNumberOfChildren() == 1) {
+        if (this.getChildren().size() == 1) {
             NativeClauseContext childQuery = this.getChild(0).generateNativeQuery(nativeClauseContext);
             if (childQuery == NativeClauseContext.NoNativeQuery) {
                 return NativeClauseContext.NoNativeQuery;

--- a/src/main/java/org/rumbledb/runtime/primary/MapConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/MapConstructorRuntimeIterator.java
@@ -48,8 +48,7 @@ public class MapConstructorRuntimeIterator extends AtMostOneItemLocalRuntimeIter
             RuntimeStaticContext staticContext,
             boolean mutable
     ) {
-        super(keys, staticContext);
-        this.children.addAll(values);
+        super(Stream.concat(keys.stream(), values.stream()).toList(), staticContext);
         this.keys = keys;
         this.values = values;
         this.mutable = mutable;

--- a/src/main/java/org/rumbledb/runtime/primary/MapConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/MapConstructorRuntimeIterator.java
@@ -21,6 +21,7 @@ import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.rumbledb.api.Item;
 import org.rumbledb.context.DynamicContext;

--- a/src/main/java/org/rumbledb/runtime/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/ObjectConstructorRuntimeIterator.java
@@ -59,8 +59,7 @@ public class ObjectConstructorRuntimeIterator extends AtMostOneItemLocalRuntimeI
             RuntimeStaticContext staticContext,
             boolean mutable
     ) {
-        super(keys, staticContext);
-        this.children.addAll(values);
+        super(Stream.concat(keys.stream(), values.stream()).toList(), staticContext);
         this.keys = keys;
         this.values = values;
         this.mutable = mutable;
@@ -71,8 +70,7 @@ public class ObjectConstructorRuntimeIterator extends AtMostOneItemLocalRuntimeI
             RuntimeStaticContext staticContext,
             boolean mutable
     ) {
-        super(null, staticContext);
-        this.children.addAll(childExpressions);
+        super(childExpressions, staticContext);
         this.isMergedObject = true;
         this.mutable = mutable;
     }
@@ -82,7 +80,7 @@ public class ObjectConstructorRuntimeIterator extends AtMostOneItemLocalRuntimeI
         List<Item> values = new ArrayList<>();
         List<String> keys = new ArrayList<>();
         if (this.isMergedObject) {
-            for (RuntimeIterator iterator : this.children) {
+            for (RuntimeIterator iterator : this.getChildren()) {
                 iterator.open(dynamicContext);
                 while (iterator.hasNext()) {
                     ObjectItem item = (ObjectItem) iterator.next();
@@ -153,8 +151,8 @@ public class ObjectConstructorRuntimeIterator extends AtMostOneItemLocalRuntimeI
     }
 
     private NativeClauseContext generateMergedObject(NativeClauseContext nativeClauseContext) {
-        List<RuntimeIterator> objectsToMerge = this.children;
-        if (this.children.get(0) instanceof CommaExpressionIterator commaExpressionIterator) {
+        List<RuntimeIterator> objectsToMerge = this.getChildren();
+        if (this.getChild(0) instanceof CommaExpressionIterator commaExpressionIterator) {
             objectsToMerge = commaExpressionIterator.getChildren();
         }
         if (

--- a/src/main/java/org/rumbledb/runtime/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/ObjectConstructorRuntimeIterator.java
@@ -24,6 +24,7 @@ import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.rumbledb.api.Item;
 import org.rumbledb.context.DynamicContext;

--- a/src/main/java/org/rumbledb/runtime/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/ObjectConstructorRuntimeIterator.java
@@ -154,7 +154,7 @@ public class ObjectConstructorRuntimeIterator extends AtMostOneItemLocalRuntimeI
     private NativeClauseContext generateMergedObject(NativeClauseContext nativeClauseContext) {
         List<RuntimeIterator> objectsToMerge = this.getChildren();
         if (this.getChild(0) instanceof CommaExpressionIterator commaExpressionIterator) {
-            objectsToMerge = commaExpressionIterator.getChildren();
+            objectsToMerge = commaExpressionIterator.getOperands();
         }
         if (
             !objectsToMerge.stream()

--- a/src/main/java/org/rumbledb/runtime/scripting/block/StatementsOnlyIterator.java
+++ b/src/main/java/org/rumbledb/runtime/scripting/block/StatementsOnlyIterator.java
@@ -34,12 +34,12 @@ public class StatementsOnlyIterator extends AtMostOneItemLocalRuntimeIterator {
 
     private void startLocal(DynamicContext dynamicContext) {
         // Case exists for when an empty bracket is provided for some statement
-        if (this.children.isEmpty()) {
+        if (this.getChildren().isEmpty()) {
             this.hasNext = false;
             return;
         }
         this.childIndex = 0;
-        this.currentChild = this.children.get(this.childIndex);
+        this.currentChild = this.getChild(this.childIndex);
         this.currentDynamicContextForLocalExecution = dynamicContext;
         this.currentChild.open(this.currentDynamicContextForLocalExecution);
 
@@ -50,10 +50,10 @@ public class StatementsOnlyIterator extends AtMostOneItemLocalRuntimeIterator {
         while (this.currentChild != null) {
             if (!this.currentChild.hasNext()) {
                 this.currentChild.close();
-                if (++this.childIndex == this.children.size()) {
+                if (++this.childIndex == this.getChildren().size()) {
                     this.currentChild = null;
                 } else {
-                    this.currentChild = this.children.get(this.childIndex);
+                    this.currentChild = this.getChild(this.childIndex);
                     this.currentChild.open(this.currentDynamicContextForLocalExecution);
                 }
             } else {

--- a/src/main/java/org/rumbledb/runtime/scripting/block/StatementsWithExprIterator.java
+++ b/src/main/java/org/rumbledb/runtime/scripting/block/StatementsWithExprIterator.java
@@ -14,6 +14,7 @@ import sparksoniq.spark.SparkSessionManager;
 
 import java.io.Serial;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class StatementsWithExprIterator extends HybridRuntimeIterator {
     @Serial
@@ -27,18 +28,11 @@ public class StatementsWithExprIterator extends HybridRuntimeIterator {
             RuntimeIterator exprIterator,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
+        super(Stream.concat(statements.stream(), Stream.of(exprIterator)).toList(), staticContext);
         // Expect an expression to be present
         assert exprIterator != null;
 
-        this.children.addAll(statements);
-        this.children.add(exprIterator);
-
-        for (RuntimeIterator child : this.children) {
-            if (child.isSequential()) {
-                this.isSequential = child.isSequential();
-            }
-        }
+        this.isSequential = this.getChildren().stream().anyMatch(RuntimeIterator::isSequential);
     }
 
     @Override
@@ -50,15 +44,15 @@ public class StatementsWithExprIterator extends HybridRuntimeIterator {
 
     @Override
     protected JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
-        if (!this.children.isEmpty()) {
+        if (!this.getChildren().isEmpty()) {
             this.childIndex = 0;
-            this.currentChild = this.children.get(this.childIndex);
+            this.currentChild = this.getChild(this.childIndex);
 
             JavaRDD<Item> childRDD = this.currentChild.getRDD(dynamicContext);
             this.childIndex++;
 
-            while (this.childIndex < this.children.size()) {
-                this.currentChild = this.children.get(this.childIndex);
+            while (this.childIndex < this.getChildren().size()) {
+                this.currentChild = this.getChild(this.childIndex);
                 JavaRDD<Item> nextChildRDD = this.currentChild.getRDD(dynamicContext);
                 childRDD = childRDD.union(nextChildRDD);
                 this.childIndex++;
@@ -73,7 +67,7 @@ public class StatementsWithExprIterator extends HybridRuntimeIterator {
 
     private void startLocal() {
         this.childIndex = 0;
-        this.currentChild = this.children.get(this.childIndex);
+        this.currentChild = this.getChild(this.childIndex);
         this.currentChild.open(this.currentDynamicContextForLocalExecution);
 
         setNextResult();
@@ -89,15 +83,15 @@ public class StatementsWithExprIterator extends HybridRuntimeIterator {
         while (this.result == null) {
             if (!this.currentChild.hasNext()) {
                 this.currentChild.close();
-                if (++this.childIndex == this.children.size()) {
+                if (++this.childIndex == this.getChildren().size()) {
                     this.currentChild = null;
                     break;
                 } else {
-                    this.currentChild = this.children.get(this.childIndex);
+                    this.currentChild = this.getChild(this.childIndex);
                     this.currentChild.open(this.currentDynamicContextForLocalExecution);
                 }
             } else {
-                if (this.childIndex == this.children.size() - 1) {
+                if (this.childIndex == this.getChildren().size() - 1) {
                     // Result is only the expression's result
                     this.result = this.currentChild.next();
                 } else {
@@ -145,23 +139,23 @@ public class StatementsWithExprIterator extends HybridRuntimeIterator {
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext dynamicContext) {
         int childIndex = 0;
-        while (childIndex < this.children.size() - 1) {
-            this.children.get(childIndex).getDataFrame(dynamicContext);
+        while (childIndex < this.getChildren().size() - 1) {
+            this.getChild(childIndex).getDataFrame(dynamicContext);
             ++childIndex;
         }
-        RuntimeIterator exprIterator = this.children.get(childIndex);
+        RuntimeIterator exprIterator = this.getChild(childIndex);
         return exprIterator.getDataFrame(dynamicContext);
     }
 
     @Override
     public boolean isUpdating() {
-        this.isUpdating = this.children.get(this.children.size() - 1).isUpdating();
+        this.isUpdating = this.getChild(this.getChildren().size() - 1).isUpdating();
         return this.isUpdating;
     }
 
     @Override
     public PendingUpdateList getPendingUpdateList(DynamicContext context) {
-        RuntimeIterator exprIterator = this.children.get(this.children.size() - 1);
+        RuntimeIterator exprIterator = this.getChild(this.getChildren().size() - 1);
         if (exprIterator.isUpdating()) {
             return exprIterator.getPendingUpdateList(context);
         }

--- a/src/main/java/org/rumbledb/runtime/scripting/control/ConditionalStatementIterator.java
+++ b/src/main/java/org/rumbledb/runtime/scripting/control/ConditionalStatementIterator.java
@@ -19,12 +19,12 @@ public class ConditionalStatementIterator extends AtMostOneItemLocalRuntimeItera
     }
 
     private RuntimeIterator selectApplicableIterator(DynamicContext dynamicContext) {
-        RuntimeIterator condition = this.children.get(0);
+        RuntimeIterator condition = this.getChild(0);
         boolean effectiveBooleanValue = condition.getEffectiveBooleanValue(dynamicContext);
         if (effectiveBooleanValue) {
-            return this.children.get(1);
+            return this.getChild(1);
         } else {
-            return this.children.get(2);
+            return this.getChild(2);
         }
     }
 

--- a/src/main/java/org/rumbledb/runtime/scripting/control/SwitchStatementIterator.java
+++ b/src/main/java/org/rumbledb/runtime/scripting/control/SwitchStatementIterator.java
@@ -11,6 +11,8 @@ import org.rumbledb.runtime.misc.ComparisonIterator;
 
 import java.io.Serial;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 public class SwitchStatementIterator extends AtMostOneItemLocalRuntimeIterator {
     @Serial
@@ -25,11 +27,13 @@ public class SwitchStatementIterator extends AtMostOneItemLocalRuntimeIterator {
             RuntimeIterator defaultReturn,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        this.children.add(testField);
-        this.children.addAll(cases.keySet());
-        this.children.addAll(cases.values());
-        this.children.add(defaultReturn);
+        super(
+            Stream.of(Stream.of(testField), cases.keySet().stream(), cases.values().stream(), Stream.of(defaultReturn))
+                .flatMap(Function.identity())
+                .toList(),
+            staticContext
+        );
+
         this.testField = testField;
         this.cases = cases;
         this.defaultReturn = defaultReturn;

--- a/src/main/java/org/rumbledb/runtime/scripting/control/TryCatchStatementIterator.java
+++ b/src/main/java/org/rumbledb/runtime/scripting/control/TryCatchStatementIterator.java
@@ -14,6 +14,7 @@ import org.rumbledb.runtime.RuntimeIterator;
 
 import java.io.Serial;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class TryCatchStatementIterator extends AtMostOneItemLocalRuntimeIterator {
     @Serial
@@ -26,9 +27,10 @@ public class TryCatchStatementIterator extends AtMostOneItemLocalRuntimeIterator
             Map<CatchPattern, RuntimeIterator> catchStatements,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        this.children.add(tryStatement);
-        this.children.addAll(catchStatements.values());
+        super(
+            Stream.concat(Stream.of(tryStatement), catchStatements.values().stream()).toList(),
+            staticContext
+        );
         this.tryStatementIterator = tryStatement;
         this.catchStatements = catchStatements;
     }

--- a/src/main/java/org/rumbledb/runtime/scripting/control/TypeSwitchStatementIterator.java
+++ b/src/main/java/org/rumbledb/runtime/scripting/control/TypeSwitchStatementIterator.java
@@ -12,6 +12,8 @@ import org.rumbledb.types.SequenceType;
 import java.io.Serial;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 public class TypeSwitchStatementIterator extends AtMostOneItemLocalRuntimeIterator {
     @Serial
@@ -28,13 +30,14 @@ public class TypeSwitchStatementIterator extends AtMostOneItemLocalRuntimeIterat
             TypeswitchRuntimeIteratorCase defaultCase,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        this.children.add(testField);
-        for (TypeswitchRuntimeIteratorCase typeSwitchCase : cases) {
-            this.children.add(typeSwitchCase.getReturnIterator());
-        }
-        this.children.add(defaultCase.getReturnIterator());
-
+        super(
+            Stream.of(
+                Stream.of(testField),
+                cases.stream().map(TypeswitchRuntimeIteratorCase::getReturnIterator),
+                Stream.of(defaultCase.getReturnIterator())
+            ).flatMap(Function.identity()).toList(),
+            staticContext
+        );
         this.testField = testField;
         this.cases = cases;
         this.defaultCase = defaultCase;

--- a/src/main/java/org/rumbledb/runtime/scripting/declaration/CommaVariableDeclStatementIterator.java
+++ b/src/main/java/org/rumbledb/runtime/scripting/declaration/CommaVariableDeclStatementIterator.java
@@ -26,8 +26,8 @@ public class CommaVariableDeclStatementIterator extends AtMostOneItemLocalRuntim
     public Item materializeFirstItemOrNull(DynamicContext context) {
         this.childIndex = 0;
 
-        if (!this.children.isEmpty()) {
-            this.currentChild = this.children.get(this.childIndex);
+        if (!this.getChildren().isEmpty()) {
+            this.currentChild = this.getChild(this.childIndex);
             this.currentChild.open(this.currentDynamicContextForLocalExecution);
             materializeChildren();
         } else {
@@ -42,10 +42,10 @@ public class CommaVariableDeclStatementIterator extends AtMostOneItemLocalRuntim
                 this.currentChild.next();
             } else {
                 this.currentChild.close();
-                if (++this.childIndex == this.children.size()) {
+                if (++this.childIndex == this.getChildren().size()) {
                     this.currentChild = null;
                 } else {
-                    this.currentChild = this.children.get(this.childIndex);
+                    this.currentChild = this.getChild(this.childIndex);
                     this.currentChild.open(this.currentDynamicContextForLocalExecution);
                 }
             }

--- a/src/main/java/org/rumbledb/runtime/scripting/declaration/VariableDeclStatementIterator.java
+++ b/src/main/java/org/rumbledb/runtime/scripting/declaration/VariableDeclStatementIterator.java
@@ -32,8 +32,8 @@ public class VariableDeclStatementIterator extends AtMostOneItemLocalRuntimeIter
         if (variableValues.containsLocally(variableValues, this.variableName)) {
             throw new VariableAlreadyExistsException(this.variableName, this.getMetadata());
         }
-        if (this.children != null && !this.children.isEmpty()) {
-            RuntimeIterator exprIterator = this.children.get(0);
+        if (!this.getChildren().isEmpty()) {
+            RuntimeIterator exprIterator = this.getChild(0);
             exprIterator.bindToVariableInDynamicContext(dynamicContext, this.variableName, dynamicContext);
         } else {
             // Casting needed to distinguish between local and RDD variables.

--- a/src/main/java/org/rumbledb/runtime/typing/AtMostOneItemTypePromotionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/AtMostOneItemTypePromotionIterator.java
@@ -141,7 +141,7 @@ public class AtMostOneItemTypePromotionIterator extends AtMostOneItemLocalRuntim
 
     @Override
     public NativeClauseContext generateNativeQuery(NativeClauseContext nativeClauseContext) {
-        NativeClauseContext value = this.children.get(0).generateNativeQuery(nativeClauseContext);
+        NativeClauseContext value = this.getChild(0).generateNativeQuery(nativeClauseContext);
         if (value.equals(NativeClauseContext.NoNativeQuery)) {
             return NativeClauseContext.NoNativeQuery;
         }

--- a/src/main/java/org/rumbledb/runtime/typing/ValidateTypeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/ValidateTypeIterator.java
@@ -464,7 +464,7 @@ public class ValidateTypeIterator extends HybridRuntimeIterator {
 
     @Override
     protected void openLocal() {
-        this.children.get(0).open(this.currentDynamicContextForLocalExecution);
+        this.getChild(0).open(this.currentDynamicContextForLocalExecution);
     }
 
     @Override

--- a/src/main/java/org/rumbledb/runtime/typing/ValidateTypeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/ValidateTypeIterator.java
@@ -64,7 +64,7 @@ public class ValidateTypeIterator extends HybridRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        RuntimeIterator inputDataIterator = this.children.get(0);
+        RuntimeIterator inputDataIterator = this.getChild(0);
         if (!this.itemType.isResolved()) {
             this.itemType.resolve(context, getMetadata());
         }
@@ -458,7 +458,7 @@ public class ValidateTypeIterator extends HybridRuntimeIterator {
 
     @Override
     protected JavaRDD<Item> getRDDAux(DynamicContext context) {
-        JavaRDD<Item> childrenItems = this.children.get(0).getRDD(context);
+        JavaRDD<Item> childrenItems = this.getChild(0).getRDD(context);
         return childrenItems.map(x -> validate(x, this.itemType, getMetadata(), this.isValidate, this.staticContext));
     }
 
@@ -469,17 +469,17 @@ public class ValidateTypeIterator extends HybridRuntimeIterator {
 
     @Override
     protected void closeLocal() {
-        this.children.get(0).close();
+        this.getChild(0).close();
     }
 
     @Override
     protected boolean hasNextLocal() {
-        return this.children.get(0).hasNext();
+        return this.getChild(0).hasNext();
     }
 
     @Override
     protected Item nextLocal() {
-        return validate(this.children.get(0).next(), this.itemType, getMetadata(), this.isValidate, this.staticContext);
+        return validate(this.getChild(0).next(), this.itemType, getMetadata(), this.isValidate, this.staticContext);
     }
 
     private static Item validate(
@@ -817,7 +817,7 @@ public class ValidateTypeIterator extends HybridRuntimeIterator {
         if (this.isValidate) {
             return NativeClauseContext.NoNativeQuery;
         }
-        return this.children.get(0).generateNativeQuery(nativeClauseContext);
+        return this.getChild(0).generateNativeQuery(nativeClauseContext);
     }
 
 

--- a/src/main/java/org/rumbledb/runtime/update/expression/TransformExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/TransformExpressionIterator.java
@@ -4,6 +4,7 @@ import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.rumbledb.api.Item;
@@ -33,10 +34,13 @@ public class TransformExpressionIterator extends HybridRuntimeIterator {
             int mutabilityLevel,
             boolean resultMutable
     ) {
-        super(null, staticContext);
-        this.children.addAll(copyDeclMap.values());
-        this.children.add(modifyIterator);
-        this.children.add(returnIterator);
+        super(
+            Stream.concat(
+                copyDeclMap.values().stream(),
+                Stream.of(modifyIterator, returnIterator)
+            ).toList(),
+            staticContext
+        );
 
         this.copyDeclMap = copyDeclMap;
         this.modifyIterator = modifyIterator;

--- a/src/main/java/org/rumbledb/runtime/xml/PostfixLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/PostfixLookupIterator.java
@@ -185,7 +185,7 @@ public class PostfixLookupIterator extends HybridRuntimeIterator {
 
     @Override
     public JavaRDD<Item> getRDDAux(DynamicContext dynamicContext) {
-        JavaRDD<Item> childRDD = this.children.get(0).getRDD(dynamicContext);
+        JavaRDD<Item> childRDD = this.getChild(0).getRDD(dynamicContext);
         initLookupKey(dynamicContext);
         List<Item> keys = this.lookupKeys;
         FlatMapFunction<Item, Item> transformation = new PostfixLookupClosure(

--- a/src/main/java/org/rumbledb/runtime/xml/StepExprIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/StepExprIterator.java
@@ -39,8 +39,7 @@ public class StepExprIterator extends LocalRuntimeIterator {
             NodeTest nodeTest,
             RuntimeStaticContext staticContext
     ) {
-        super(null, staticContext);
-        this.children.add(axisIterator);
+        super(List.of(axisIterator), staticContext);
         this.axisIterator = axisIterator;
         this.nodeTest = nodeTest;
     }

--- a/src/main/java/sparksoniq/spark/ml/AnnotateFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/AnnotateFunctionIterator.java
@@ -29,8 +29,8 @@ public class AnnotateFunctionIterator extends DataFrameRuntimeIterator {
 
     @Override
     public JSoundDataFrame getDataFrame(DynamicContext context) {
-        RuntimeIterator inputDataIterator = this.children.get(0);
-        RuntimeIterator schemaIterator = this.children.get(1);
+        RuntimeIterator inputDataIterator = this.getChild(0);
+        RuntimeIterator schemaIterator = this.getChild(1);
         Item schemaItem = schemaIterator.materializeFirstItemOrNull(context);
         ItemType schemaType = ItemTypeFactory.createItemTypeFromJSoundCompactItem(null, schemaItem, null);
         schemaType.resolve(context, getMetadata());

--- a/src/main/java/sparksoniq/spark/ml/BinaryClassificationMetricsFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/BinaryClassificationMetricsFunctionIterator.java
@@ -39,7 +39,7 @@ public class BinaryClassificationMetricsFunctionIterator extends AtMostOneItemLo
         String scoreCol = this.getChild(1).materializeFirstItemOrNull(context).getStringValue();
         String labelCol = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
         int numBins = -1;
-        if (this.getNumberOfChildren() > 3) {
+        if (this.getChildren().size() > 3) {
             numBins = this.getChild(3).materializeFirstItemOrNull(context).getIntValue();
         }
         JavaPairRDD<Object, Object> predictionAndLabels = scoresAndLabels.mapToPair(

--- a/src/main/java/sparksoniq/spark/ml/BinaryClassificationMetricsFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/BinaryClassificationMetricsFunctionIterator.java
@@ -35,12 +35,12 @@ public class BinaryClassificationMetricsFunctionIterator extends AtMostOneItemLo
 
     @Override
     public Item materializeFirstItemOrNull(DynamicContext context) {
-        JavaRDD<Item> scoresAndLabels = this.children.get(0).getRDD(context);
-        String scoreCol = this.children.get(1).materializeFirstItemOrNull(context).getStringValue();
-        String labelCol = this.children.get(2).materializeFirstItemOrNull(context).getStringValue();
+        JavaRDD<Item> scoresAndLabels = this.getChild(0).getRDD(context);
+        String scoreCol = this.getChild(1).materializeFirstItemOrNull(context).getStringValue();
+        String labelCol = this.getChild(2).materializeFirstItemOrNull(context).getStringValue();
         int numBins = -1;
-        if (this.children.size() > 3) {
-            numBins = this.children.get(3).materializeFirstItemOrNull(context).getIntValue();
+        if (this.getNumberOfChildren() > 3) {
+            numBins = this.getChild(3).materializeFirstItemOrNull(context).getIntValue();
         }
         JavaPairRDD<Object, Object> predictionAndLabels = scoresAndLabels.mapToPair(
             p -> new Tuple2<>(

--- a/src/main/java/sparksoniq/spark/ml/GetEstimatorFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/GetEstimatorFunctionIterator.java
@@ -66,10 +66,10 @@ public class GetEstimatorFunctionIterator extends AtMostOneItemLocalRuntimeItera
     public Item materializeFirstItemOrNull(
             DynamicContext dynamicContext
     ) {
-        String estimatorShortName = this.children.get(0).materializeFirstItemOrNull(dynamicContext).getStringValue();
+        String estimatorShortName = this.getChild(0).materializeFirstItemOrNull(dynamicContext).getStringValue();
         Item paramMapItem = null;
-        if (this.children.size() >= 2) {
-            paramMapItem = this.children.get(1).materializeFirstItemOrNull(dynamicContext);
+        if (this.getChildren().size() >= 2) {
+            paramMapItem = this.getChild(1).materializeFirstItemOrNull(dynamicContext);
         }
 
         String estimatorFullClassName = RumbleMLCatalog.getEstimatorFullClassName(

--- a/src/main/java/sparksoniq/spark/ml/GetTransformerFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/GetTransformerFunctionIterator.java
@@ -70,7 +70,7 @@ public class GetTransformerFunctionIterator extends AtMostOneItemLocalRuntimeIte
     ) {
         String transformerShortName = this.getChild(0).materializeFirstItemOrNull(dynamicContext).getStringValue();
         Item paramMapItem = null;
-        if (this.getNumberOfChildren() >= 2) {
+        if (this.getChildren().size() >= 2) {
             paramMapItem = this.getChild(1).materializeFirstItemOrNull(dynamicContext);
         }
 

--- a/src/main/java/sparksoniq/spark/ml/GetTransformerFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/GetTransformerFunctionIterator.java
@@ -68,10 +68,10 @@ public class GetTransformerFunctionIterator extends AtMostOneItemLocalRuntimeIte
     public Item materializeFirstItemOrNull(
             DynamicContext dynamicContext
     ) {
-        String transformerShortName = this.children.get(0).materializeFirstItemOrNull(dynamicContext).getStringValue();
+        String transformerShortName = this.getChild(0).materializeFirstItemOrNull(dynamicContext).getStringValue();
         Item paramMapItem = null;
-        if (this.children.size() >= 2) {
-            paramMapItem = this.children.get(1).materializeFirstItemOrNull(dynamicContext);
+        if (this.getNumberOfChildren() >= 2) {
+            paramMapItem = this.getChild(1).materializeFirstItemOrNull(dynamicContext);
         }
 
         String transformerFullClassName = RumbleMLCatalog.getTransformerFullClassName(


### PR DESCRIPTION
Previously, this field was protected, so all subclasses can read and write it freely. However, this allowed patterns like this in subclass constructors:

```java
super(null, staticContext);    /// The first argument is List<RuntimeIterators> children
this.children.add(tryExpression);
for (RuntimeIterator value : catchExpressions.values())
    this.children.add(value);
```

To fix the pattern, we no longer allow subclasses to read `children` field directly, and force them to use the superclass' constructor so we get a better encapsulation.

`getChild(int)` and `getChildren()` are added to RuntimeIterator, both marked as `protected final`