### PR TITLE
Add `final` modifier on instance fields

### DIFF
--- a/src/main/java/org/rumbledb/api/Rumble.java
+++ b/src/main/java/org/rumbledb/api/Rumble.java
@@ -28,7 +28,7 @@ public class Rumble {
 
     @Getter
     private RumbleRuntimeConfiguration configuration;
-    private CompilationConfiguration compilationConfiguration;
+    private final CompilationConfiguration compilationConfiguration;
 
     /**
      * Creates a new Rumble instance. This initializes a brand new Spark session.

--- a/src/main/java/org/rumbledb/api/SequenceOfItems.java
+++ b/src/main/java/org/rumbledb/api/SequenceOfItems.java
@@ -47,9 +47,9 @@ import sparksoniq.spark.SparkSessionManager;
  */
 public class SequenceOfItems {
 
-    private RuntimeIterator iterator;
-    private DynamicContext dynamicContext;
-    private RumbleRuntimeConfiguration configuration;
+    private final RuntimeIterator iterator;
+    private final DynamicContext dynamicContext;
+    private final RumbleRuntimeConfiguration configuration;
     private boolean isOpen;
     private List<Item> cachedItems;
 

--- a/src/main/java/org/rumbledb/cli/JsoniqQueryExecutor.java
+++ b/src/main/java/org/rumbledb/cli/JsoniqQueryExecutor.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 
 
 public class JsoniqQueryExecutor {
-    private RumbleRuntimeConfiguration configuration;
+    private final RumbleRuntimeConfiguration configuration;
 
     public JsoniqQueryExecutor(RumbleRuntimeConfiguration configuration) {
         this.configuration = configuration;

--- a/src/main/java/org/rumbledb/compiler/DynamicContextVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/DynamicContextVisitor.java
@@ -68,8 +68,8 @@ import java.util.Map;
  */
 public class DynamicContextVisitor extends AbstractNodeVisitor<DynamicContext> {
 
-    private RumbleRuntimeConfiguration configuration;
-    private Map<String, DynamicContext> importedModuleContexts;
+    private final RumbleRuntimeConfiguration configuration;
+    private final Map<String, DynamicContext> importedModuleContexts;
 
     DynamicContextVisitor(RumbleRuntimeConfiguration configuration) {
         this.configuration = configuration;

--- a/src/main/java/org/rumbledb/compiler/ExecutionModeVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/ExecutionModeVisitor.java
@@ -97,7 +97,7 @@ import java.util.Map.Entry;
 public class ExecutionModeVisitor extends AbstractNodeVisitor<StaticContext> {
 
     private VisitorConfig visitorConfig;
-    private RumbleRuntimeConfiguration configuration;
+    private final RumbleRuntimeConfiguration configuration;
     private List<Statement> exitStatementChildren;
 
     ExecutionModeVisitor(RumbleRuntimeConfiguration configuration) {

--- a/src/main/java/org/rumbledb/compiler/InferTypeVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/InferTypeVisitor.java
@@ -168,7 +168,7 @@ import org.apache.spark.sql.SparkSession;
  */
 public class InferTypeVisitor extends AbstractNodeVisitor<StaticContext> {
 
-    private RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
+    private final RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
 
     /**
      * Builds a new visitor.

--- a/src/main/java/org/rumbledb/compiler/ModulePruningVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/ModulePruningVisitor.java
@@ -37,8 +37,8 @@ import org.rumbledb.expressions.module.Prolog;
 public class ModulePruningVisitor extends AbstractNodeVisitor<Void> {
 
     @SuppressWarnings("unused")
-    private RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
-    private List<String> visitedModules;
+    private final RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
+    private final List<String> visitedModules;
 
     /**
      * Builds a new visitor.

--- a/src/main/java/org/rumbledb/compiler/ProjectionPushdownDetectionVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/ProjectionPushdownDetectionVisitor.java
@@ -276,7 +276,7 @@ public class ProjectionPushdownDetectionVisitor
 
     public static class ReferenceMap {
 
-        private Map<Name, ReferenceMap> map;
+        private final Map<Name, ReferenceMap> map;
 
         public ReferenceMap() {
             this.map = new HashMap<>();

--- a/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/RuntimeIteratorVisitor.java
@@ -267,8 +267,8 @@ import org.rumbledb.types.SequenceType;
 
 public class RuntimeIteratorVisitor extends AbstractNodeVisitor<RuntimeIterator> {
 
-    private VisitorConfig visitorConfig;
-    private RumbleRuntimeConfiguration config;
+    private final VisitorConfig visitorConfig;
+    private final RumbleRuntimeConfiguration config;
 
     public RuntimeIteratorVisitor(RumbleRuntimeConfiguration config) {
         this.visitorConfig = VisitorConfig.runtimeIteratorVisitorConfig;

--- a/src/main/java/org/rumbledb/compiler/SequentialClassificationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/SequentialClassificationVisitor.java
@@ -52,7 +52,7 @@ import static org.rumbledb.expressions.module.Prolog.getFunctionDeclarationFromP
 public class SequentialClassificationVisitor extends AbstractNodeVisitor<DescendentSequentialProperties> {
     private final Prolog prolog;
     private int blockLevel;
-    private Map<Name, Integer> variableBlockLevel;
+    private final Map<Name, Integer> variableBlockLevel;
 
     public SequentialClassificationVisitor(Prolog prolog) {
         this.prolog = prolog;

--- a/src/main/java/org/rumbledb/compiler/StaticContextVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/StaticContextVisitor.java
@@ -96,7 +96,7 @@ public class StaticContextVisitor extends AbstractNodeVisitor<StaticContext> {
 
     private static final String SERIALIZATION_NAMESPACE = "http://www.w3.org/2010/xslt-xquery-serialization";
 
-    private Map<String, StaticContext> importedModuleContexts;
+    private final Map<String, StaticContext> importedModuleContexts;
 
     StaticContextVisitor() {
         this.importedModuleContexts = new HashMap<>();

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -210,13 +210,13 @@ import java.util.stream.Collectors;
  */
 public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
-    private StaticContext moduleContext;
-    private RumbleRuntimeConfiguration configuration;
-    private CompilationConfiguration compilationConfiguration;
-    private boolean isMainModule;
+    private final StaticContext moduleContext;
+    private final RumbleRuntimeConfiguration configuration;
+    private final CompilationConfiguration compilationConfiguration;
+    private final boolean isMainModule;
     private String libraryModuleNamespace;
-    private String code;
-    private ArrayDeque<Map<String, String>> dirElemNamespaceFrames;
+    private final String code;
+    private final ArrayDeque<Map<String, String>> dirElemNamespaceFrames;
     private final CommonTokenStream jsoniqTokenStream;
 
     public TranslationVisitor(

--- a/src/main/java/org/rumbledb/compiler/VariableDependenciesVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/VariableDependenciesVisitor.java
@@ -105,16 +105,16 @@ import java.util.TreeSet;
 public class VariableDependenciesVisitor extends AbstractNodeVisitor<Void> {
 
     @SuppressWarnings("unused")
-    private RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
+    private final RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
 
     /**
      * Input variable dependencies are lists of variables and functions that an expression depends on.
      */
-    Map<Node, Set<Name>> inputVariableDependencies;
+    final Map<Node, Set<Name>> inputVariableDependencies;
     /**
      * Output variable dependencies are lists of variables in the tuples that a clause produces.
      */
-    Map<Node, Set<Name>> outputVariableDependenciesForClauses;
+    final Map<Node, Set<Name>> outputVariableDependenciesForClauses;
 
     /**
      * Builds a new visitor.

--- a/src/main/java/org/rumbledb/compiler/VisitorConfig.java
+++ b/src/main/java/org/rumbledb/compiler/VisitorConfig.java
@@ -3,13 +3,13 @@ package org.rumbledb.compiler;
 public class VisitorConfig {
 
     // flag to suppress errors when a function declaration collides with an existing function
-    private boolean suppressErrorsForFunctionSignatureCollision;
+    private final boolean suppressErrorsForFunctionSignatureCollision;
     // flag to suppress errors when an unrecognized function is called
-    private boolean suppressErrorsForCallingMissingFunctions;
+    private final boolean suppressErrorsForCallingMissingFunctions;
     // flag to suppress errors when an unset execution mode value is fetched from a node
-    private boolean suppressErrorsForAccessingUnsetExecutionModes;
+    private final boolean suppressErrorsForAccessingUnsetExecutionModes;
     // flag to set unset expressions (actually, variable references) to local
-    private boolean setUnsetExecutionModeOfVariableReferenceExpressionsToLocal;
+    private final boolean setUnsetExecutionModeOfVariableReferenceExpressionsToLocal;
 
     public static class Builder {
         private boolean suppressErrorsForFunctionSignatureCollision = false;

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -190,13 +190,13 @@ import java.util.stream.Collectors;
  */
 public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
 
-    private StaticContext moduleContext;
-    private RumbleRuntimeConfiguration configuration;
-    private CompilationConfiguration compilationConfiguration;
-    private boolean isMainModule;
+    private final StaticContext moduleContext;
+    private final RumbleRuntimeConfiguration configuration;
+    private final CompilationConfiguration compilationConfiguration;
+    private final boolean isMainModule;
     private String libraryModuleNamespace;
-    private String code;
-    private ArrayDeque<Map<String, String>> dirElemNamespaceFrames;
+    private final String code;
+    private final ArrayDeque<Map<String, String>> dirElemNamespaceFrames;
     private final CommonTokenStream xQueryTokenStream;
 
     public XQueryTranslationVisitor(

--- a/src/main/java/org/rumbledb/config/RumbleRuntimeConfiguration.java
+++ b/src/main/java/org/rumbledb/config/RumbleRuntimeConfiguration.java
@@ -48,7 +48,7 @@ public class RumbleRuntimeConfiguration implements Serializable {
 
     private static final String SHORTCUT_PREFIX = "-";
     private static final String ARGUMENT_PREFIX = "--";
-    private HashMap<String, String> arguments;
+    private final HashMap<String, String> arguments;
 
     List<String> allowedPrefixes;
     private int resultsSizeCap;

--- a/src/main/java/org/rumbledb/context/GlobalVariables.java
+++ b/src/main/java/org/rumbledb/context/GlobalVariables.java
@@ -10,7 +10,7 @@ import java.util.Set;
 public class GlobalVariables implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
-    private Set<Name> globalVariables;
+    private final Set<Name> globalVariables;
 
     public GlobalVariables() {
         this.globalVariables = new HashSet<>();

--- a/src/main/java/org/rumbledb/context/InScopeSchemaTypes.java
+++ b/src/main/java/org/rumbledb/context/InScopeSchemaTypes.java
@@ -17,7 +17,7 @@ public class InScopeSchemaTypes implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private HashMap<Name, ItemType> inScopeSchemaTypes;
+    private final HashMap<Name, ItemType> inScopeSchemaTypes;
 
     public InScopeSchemaTypes() {
         this.inScopeSchemaTypes = new HashMap<>();

--- a/src/main/java/org/rumbledb/context/InScopeVariable.java
+++ b/src/main/java/org/rumbledb/context/InScopeVariable.java
@@ -6,9 +6,9 @@ import org.rumbledb.types.SequenceType;
 
 public class InScopeVariable {
 
-    private Name name;
-    private SequenceType sequenceType;
-    private ExceptionMetadata metadata;
+    private final Name name;
+    private final SequenceType sequenceType;
+    private final ExceptionMetadata metadata;
     private ExecutionMode storageMode;
     private final boolean isAssignable;
 

--- a/src/main/java/org/rumbledb/context/Name.java
+++ b/src/main/java/org/rumbledb/context/Name.java
@@ -48,7 +48,7 @@ public class Name implements Comparable<Name>, Serializable {
     @EqualsAndHashCode.Include
     private String namespace;
 
-    private String prefix;
+    private final String prefix;
 
     @EqualsAndHashCode.Include
     private String localName;

--- a/src/main/java/org/rumbledb/context/NamedFunctions.java
+++ b/src/main/java/org/rumbledb/context/NamedFunctions.java
@@ -56,7 +56,7 @@ public class NamedFunctions implements Serializable {
     // two maps for User defined function are needed as execution mode is known at
     // static analysis phase
     // but functions items are fully known at runtimeIterator generation
-    private HashMap<FunctionIdentifier, FunctionItem> userDefinedFunctions;
+    private final HashMap<FunctionIdentifier, FunctionItem> userDefinedFunctions;
 
     public NamedFunctions() {
         this.userDefinedFunctions = new HashMap<>();

--- a/src/main/java/org/rumbledb/context/UserDefinedFunctionExecutionModes.java
+++ b/src/main/java/org/rumbledb/context/UserDefinedFunctionExecutionModes.java
@@ -36,9 +36,9 @@ public class UserDefinedFunctionExecutionModes {
 
     // two maps for User defined function are needed as execution mode is known at static analysis phase
     // but functions items are fully known at runtimeIterator generation
-    private HashMap<FunctionIdentifier, ExecutionMode> userDefinedFunctionsExecutionMode;
-    private HashMap<FunctionIdentifier, List<ExecutionMode>> userDefinedFunctionsParametersStorageMode;
-    private List<FunctionIdentifier> userDefinedFunctionIdentifiersWithUnsetExecutionModes;
+    private final HashMap<FunctionIdentifier, ExecutionMode> userDefinedFunctionsExecutionMode;
+    private final HashMap<FunctionIdentifier, List<ExecutionMode>> userDefinedFunctionsParametersStorageMode;
+    private final List<FunctionIdentifier> userDefinedFunctionIdentifiersWithUnsetExecutionModes;
     private String queryLanguage;
 
     public UserDefinedFunctionExecutionModes() {

--- a/src/main/java/org/rumbledb/exceptions/InvalidRumbleMLParamException.java
+++ b/src/main/java/org/rumbledb/exceptions/InvalidRumbleMLParamException.java
@@ -29,7 +29,7 @@ public class InvalidRumbleMLParamException extends RumbleException {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    String message;
+    final String message;
 
     public InvalidRumbleMLParamException(String message, ExceptionMetadata metadata) {
         super(

--- a/src/main/java/org/rumbledb/expressions/arithmetic/AdditiveExpression.java
+++ b/src/main/java/org/rumbledb/expressions/arithmetic/AdditiveExpression.java
@@ -30,9 +30,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public class AdditiveExpression extends Expression {
-    private Expression leftExpression;
-    private Expression rightExpression;
-    private boolean isMinus;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
+    private final boolean isMinus;
 
     public AdditiveExpression(
             Expression leftExpression,

--- a/src/main/java/org/rumbledb/expressions/arithmetic/MultiplicativeExpression.java
+++ b/src/main/java/org/rumbledb/expressions/arithmetic/MultiplicativeExpression.java
@@ -38,7 +38,7 @@ public class MultiplicativeExpression extends Expression {
         MOD("mod"),
         IDIV("idiv");
 
-        private String name;
+        private final String name;
 
         MultiplicativeOperator(String name) {
             this.name = name;
@@ -66,9 +66,9 @@ public class MultiplicativeExpression extends Expression {
         }
     };
 
-    private Expression leftExpression;
-    private Expression rightExpression;
-    private MultiplicativeOperator multiplicativeOperator;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
+    private final MultiplicativeOperator multiplicativeOperator;
 
     public MultiplicativeExpression(
             Expression leftExpression,

--- a/src/main/java/org/rumbledb/expressions/comparison/ComparisonExpression.java
+++ b/src/main/java/org/rumbledb/expressions/comparison/ComparisonExpression.java
@@ -45,8 +45,8 @@ public class ComparisonExpression extends Expression {
         GC_GT(">"),
         GC_GE(">=");
 
-        private String name;
-        private boolean isValueComparison;
+        private final String name;
+        private final boolean isValueComparison;
 
         ComparisonOperator(String name) {
             switch (name) {
@@ -158,9 +158,9 @@ public class ComparisonExpression extends Expression {
         }
     };
 
-    private Expression leftExpression;
-    private Expression rightExpression;
-    private ComparisonOperator comparisonOperator;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
+    private final ComparisonOperator comparisonOperator;
 
     public ComparisonExpression(
             Expression leftExpression,

--- a/src/main/java/org/rumbledb/expressions/comparison/NodeComparisonExpression.java
+++ b/src/main/java/org/rumbledb/expressions/comparison/NodeComparisonExpression.java
@@ -43,7 +43,7 @@ public class NodeComparisonExpression extends Expression {
         NC_FOLLOWS(">>"),
         NC_IS("is");
 
-        private String symbol;
+        private final String symbol;
 
         NodeComparisonOperator(String symbol) {
             this.symbol = symbol;
@@ -68,9 +68,9 @@ public class NodeComparisonExpression extends Expression {
         }
     }
 
-    private Expression leftExpression;
-    private Expression rightExpression;
-    private NodeComparisonOperator operator;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
+    private final NodeComparisonOperator operator;
 
     public NodeComparisonExpression(
             Expression leftExpression,

--- a/src/main/java/org/rumbledb/expressions/control/TypeswitchCase.java
+++ b/src/main/java/org/rumbledb/expressions/control/TypeswitchCase.java
@@ -15,8 +15,8 @@ import java.util.List;
  */
 public class TypeswitchCase {
 
-    private Name variableName;
-    private List<SequenceType> union;
+    private final Name variableName;
+    private final List<SequenceType> union;
     private final Expression returnExpression;
 
     public TypeswitchCase(

--- a/src/main/java/org/rumbledb/expressions/flowr/Clause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/Clause.java
@@ -43,7 +43,7 @@ public abstract class Clause extends Node {
     /* Clauses are organized in doubly-linked lists */
     protected Clause previousClause;
     protected Clause nextClause;
-    protected FLWOR_CLAUSES clauseType;
+    protected final FLWOR_CLAUSES clauseType;
     protected StaticContext staticContext;
 
     public Clause(FLWOR_CLAUSES clauseType, ExceptionMetadata metadata) {

--- a/src/main/java/org/rumbledb/expressions/flowr/CountClause.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/CountClause.java
@@ -30,7 +30,7 @@ import org.rumbledb.expressions.Node;
 
 
 public class CountClause extends Clause {
-    private Name variableName;
+    private final Name variableName;
 
     public CountClause(Name variableName, ExceptionMetadata metadata) {
         super(FLWOR_CLAUSES.COUNT, metadata);

--- a/src/main/java/org/rumbledb/expressions/flowr/SimpleMapExpression.java
+++ b/src/main/java/org/rumbledb/expressions/flowr/SimpleMapExpression.java
@@ -30,8 +30,8 @@ import java.util.Arrays;
 import java.util.List;
 
 public class SimpleMapExpression extends Expression {
-    private Expression leftExpression;
-    private Expression rightExpression;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
 
     public SimpleMapExpression(
             Expression leftExpression,

--- a/src/main/java/org/rumbledb/expressions/logic/AndExpression.java
+++ b/src/main/java/org/rumbledb/expressions/logic/AndExpression.java
@@ -29,8 +29,8 @@ import java.util.Arrays;
 import java.util.List;
 
 public class AndExpression extends Expression {
-    private Expression leftExpression;
-    private Expression rightExpression;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
 
     public AndExpression(
             Expression leftExpression,

--- a/src/main/java/org/rumbledb/expressions/logic/OrExpression.java
+++ b/src/main/java/org/rumbledb/expressions/logic/OrExpression.java
@@ -29,8 +29,8 @@ import java.util.Arrays;
 import java.util.List;
 
 public class OrExpression extends Expression {
-    private Expression leftExpression;
-    private Expression rightExpression;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
 
     public OrExpression(
             Expression leftExpression,

--- a/src/main/java/org/rumbledb/expressions/miscellaneous/NodeSetExpression.java
+++ b/src/main/java/org/rumbledb/expressions/miscellaneous/NodeSetExpression.java
@@ -58,9 +58,9 @@ public class NodeSetExpression extends Expression {
         }
     }
 
-    private Expression leftExpression;
-    private Expression rightExpression;
-    private NodeSetOperator operator;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
+    private final NodeSetOperator operator;
 
     public NodeSetExpression(
             Expression leftExpression,

--- a/src/main/java/org/rumbledb/expressions/miscellaneous/RangeExpression.java
+++ b/src/main/java/org/rumbledb/expressions/miscellaneous/RangeExpression.java
@@ -31,8 +31,8 @@ import org.rumbledb.expressions.Node;
 
 public class RangeExpression extends Expression {
 
-    private Expression leftExpression;
-    private Expression rightExpression;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
 
     public RangeExpression(Expression leftExpression, Expression rightExpression, ExceptionMetadata metadata) {
         super(metadata);

--- a/src/main/java/org/rumbledb/expressions/miscellaneous/StringConcatExpression.java
+++ b/src/main/java/org/rumbledb/expressions/miscellaneous/StringConcatExpression.java
@@ -30,8 +30,8 @@ import java.util.Arrays;
 import java.util.List;
 
 public class StringConcatExpression extends Expression {
-    private Expression leftExpression;
-    private Expression rightExpression;
+    private final Expression leftExpression;
+    private final Expression rightExpression;
 
     public StringConcatExpression(
             Expression leftExpression,

--- a/src/main/java/org/rumbledb/expressions/module/LibraryModule.java
+++ b/src/main/java/org/rumbledb/expressions/module/LibraryModule.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class LibraryModule extends Module {
 
     protected StaticContext staticContext;
-    private String namespace;
+    private final String namespace;
     private final Prolog prolog;
 
     public LibraryModule(Prolog prolog, String namespace, ExceptionMetadata metadata) {

--- a/src/main/java/org/rumbledb/expressions/module/Prolog.java
+++ b/src/main/java/org/rumbledb/expressions/module/Prolog.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 public class Prolog extends Node {
 
     private List<Node> declarations;
-    private List<LibraryModule> importedModules;
+    private final List<LibraryModule> importedModules;
 
     public Prolog(
             List<VariableDeclaration> variableDeclarations,

--- a/src/main/java/org/rumbledb/expressions/module/VariableDeclaration.java
+++ b/src/main/java/org/rumbledb/expressions/module/VariableDeclaration.java
@@ -43,8 +43,8 @@ public class VariableDeclaration extends Node {
     private final boolean DEFAULT_ASSIGNABLE = false;
     private final Name variableName;
     private final boolean external;
-    protected SequenceType sequenceType;
-    protected Expression expression;
+    protected final SequenceType sequenceType;
+    protected final Expression expression;
     private final List<Annotation> annotations;
     private final boolean isAssignable;
 

--- a/src/main/java/org/rumbledb/expressions/primary/ArrayConstructorExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/ArrayConstructorExpression.java
@@ -31,9 +31,9 @@ import java.util.List;
 
 public class ArrayConstructorExpression extends Expression {
 
-    private Expression expression;
-    private List<Expression> memberExpressions;
-    private boolean isFixedSlotsArrayConstructor;
+    private final Expression expression;
+    private final List<Expression> memberExpressions;
+    private final boolean isFixedSlotsArrayConstructor;
 
     /**
      * Curly array constructor: {@code array { expr }}.

--- a/src/main/java/org/rumbledb/expressions/primary/BooleanLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/BooleanLiteralExpression.java
@@ -31,7 +31,7 @@ import org.rumbledb.expressions.Node;
 
 public class BooleanLiteralExpression extends Expression {
 
-    private boolean value;
+    private final boolean value;
 
     public BooleanLiteralExpression(boolean value, ExceptionMetadata metadata) {
         super(metadata);

--- a/src/main/java/org/rumbledb/expressions/primary/DecimalLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/DecimalLiteralExpression.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 public class DecimalLiteralExpression extends Expression {
 
-    private BigDecimal value;
+    private final BigDecimal value;
 
     public DecimalLiteralExpression(BigDecimal value, ExceptionMetadata metadata) {
         super(metadata);

--- a/src/main/java/org/rumbledb/expressions/primary/DoubleLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/DoubleLiteralExpression.java
@@ -31,7 +31,7 @@ import org.rumbledb.expressions.Node;
 
 public class DoubleLiteralExpression extends Expression {
 
-    private double value;
+    private final double value;
 
     public DoubleLiteralExpression(double value, ExceptionMetadata metadata) {
         super(metadata);

--- a/src/main/java/org/rumbledb/expressions/primary/IntegerLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/IntegerLiteralExpression.java
@@ -31,7 +31,7 @@ import org.rumbledb.expressions.Node;
 
 public class IntegerLiteralExpression extends Expression {
 
-    private String lexicalValue;
+    private final String lexicalValue;
 
     public IntegerLiteralExpression(String lexicalValue, ExceptionMetadata metadata) {
         super(metadata);

--- a/src/main/java/org/rumbledb/expressions/primary/MapConstructorExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/MapConstructorExpression.java
@@ -30,8 +30,8 @@ import java.util.List;
  */
 public class MapConstructorExpression extends Expression {
 
-    private List<Expression> keys;
-    private List<Expression> values;
+    private final List<Expression> keys;
+    private final List<Expression> values;
 
     public MapConstructorExpression(
             List<Expression> keys,

--- a/src/main/java/org/rumbledb/expressions/primary/StringLiteralExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/StringLiteralExpression.java
@@ -32,7 +32,7 @@ import org.rumbledb.expressions.Node;
 
 public class StringLiteralExpression extends Expression {
 
-    private String value;
+    private final String value;
 
     public StringLiteralExpression(String value, ExceptionMetadata metadata) {
         super(metadata);

--- a/src/main/java/org/rumbledb/expressions/primary/VariableReferenceExpression.java
+++ b/src/main/java/org/rumbledb/expressions/primary/VariableReferenceExpression.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class VariableReferenceExpression extends Expression {
-    private Name name;
+    private final Name name;
     private SequenceType type;
 
 

--- a/src/main/java/org/rumbledb/expressions/typing/CastableExpression.java
+++ b/src/main/java/org/rumbledb/expressions/typing/CastableExpression.java
@@ -13,8 +13,8 @@ import org.rumbledb.types.SequenceType.Arity;
 
 public class CastableExpression extends Expression {
 
-    protected Expression mainExpression;
-    private SequenceType sequenceType;
+    protected final Expression mainExpression;
+    private final SequenceType sequenceType;
 
     public CastableExpression(Expression mainExpression, SequenceType type, ExceptionMetadata metadata) {
         super(metadata);

--- a/src/main/java/org/rumbledb/expressions/update/InsertExpression.java
+++ b/src/main/java/org/rumbledb/expressions/update/InsertExpression.java
@@ -11,9 +11,9 @@ import java.util.List;
 
 public class InsertExpression extends Expression {
 
-    private Expression mainExpression;
-    private Expression toInsertExpression;
-    private Expression positionExpression;
+    private final Expression mainExpression;
+    private final Expression toInsertExpression;
+    private final Expression positionExpression;
 
     public InsertExpression(
             Expression mainExpression,

--- a/src/main/java/org/rumbledb/expressions/xml/AttributeNodeContentExpression.java
+++ b/src/main/java/org/rumbledb/expressions/xml/AttributeNodeContentExpression.java
@@ -38,7 +38,7 @@ import org.rumbledb.exceptions.ExceptionMetadata;
  */
 public class AttributeNodeContentExpression extends Expression {
 
-    private String content;
+    private final String content;
 
     public AttributeNodeContentExpression(String content, ExceptionMetadata metadata) {
         super(metadata);

--- a/src/main/java/org/rumbledb/expressions/xml/AttributeNodeExpression.java
+++ b/src/main/java/org/rumbledb/expressions/xml/AttributeNodeExpression.java
@@ -38,14 +38,14 @@ public class AttributeNodeExpression extends Expression {
     /**
      * Resolved expanded name of the attribute (compile-time).
      */
-    private Name attributeName;
+    private final Name attributeName;
     /**
      * The value of the attribute node.
      * 
      * The value is a list of expressions. This is because an attribute node can be
      * constructed from multiple expressions and literals, which are materialized at runtime.
      */
-    private List<Expression> value;
+    private final List<Expression> value;
 
     public AttributeNodeExpression(Name attributeName, List<Expression> value, ExceptionMetadata metadata) {
         super(metadata);

--- a/src/main/java/org/rumbledb/expressions/xml/TextNodeExpression.java
+++ b/src/main/java/org/rumbledb/expressions/xml/TextNodeExpression.java
@@ -37,8 +37,8 @@ import org.rumbledb.exceptions.ExceptionMetadata;
 public class TextNodeExpression extends Expression {
 
     /** The content of the text node */
-    private String content;
-    private boolean boundaryWhitespace;
+    private final String content;
+    private final boolean boundaryWhitespace;
 
     /**
      * Constructor for a text node.

--- a/src/main/java/org/rumbledb/expressions/xml/UnaryLookupExpression.java
+++ b/src/main/java/org/rumbledb/expressions/xml/UnaryLookupExpression.java
@@ -32,7 +32,7 @@ import java.util.List;
 // clone of ObjectLookupExpression but for xquery lookup
 public class UnaryLookupExpression extends Expression {
 
-    private Expression lookupExpression;
+    private final Expression lookupExpression;
     // lookupexpression is null if we have a wildcard!!
 
     public UnaryLookupExpression(Expression lookupExpression, ExceptionMetadata metadata) {

--- a/src/main/java/org/rumbledb/expressions/xml/axis/ForwardStepExpr.java
+++ b/src/main/java/org/rumbledb/expressions/xml/axis/ForwardStepExpr.java
@@ -12,8 +12,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class ForwardStepExpr extends StepExpr {
-    private ForwardAxis forwardAxis;
-    private NodeTest nodeTest;
+    private final ForwardAxis forwardAxis;
+    private final NodeTest nodeTest;
 
     public ForwardStepExpr(ForwardAxis forwardAxis, NodeTest nodeTest, ExceptionMetadata exceptionMetadata) {
         super(exceptionMetadata);

--- a/src/main/java/org/rumbledb/expressions/xml/axis/ReverseStepExpr.java
+++ b/src/main/java/org/rumbledb/expressions/xml/axis/ReverseStepExpr.java
@@ -12,8 +12,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class ReverseStepExpr extends StepExpr {
-    private ReverseAxis reverseAxis;
-    private NodeTest nodeTest;
+    private final ReverseAxis reverseAxis;
+    private final NodeTest nodeTest;
 
     public ReverseStepExpr(ReverseAxis reverseAxis, NodeTest nodeTest, ExceptionMetadata exceptionMetadata) {
         super(exceptionMetadata);

--- a/src/main/java/org/rumbledb/expressions/xml/node_test/AttributeTest.java
+++ b/src/main/java/org/rumbledb/expressions/xml/node_test/AttributeTest.java
@@ -7,9 +7,9 @@ import java.io.Serial;
 public class AttributeTest implements NodeTest {
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name attributeName;
-    private boolean hasWildcard;
-    private Name typeName;
+    private final Name attributeName;
+    private final boolean hasWildcard;
+    private final Name typeName;
 
     public AttributeTest(Name attributeName, Name typeName) {
         this.attributeName = attributeName;

--- a/src/main/java/org/rumbledb/expressions/xml/node_test/DocumentTest.java
+++ b/src/main/java/org/rumbledb/expressions/xml/node_test/DocumentTest.java
@@ -7,7 +7,7 @@ public class DocumentTest implements NodeTest {
     @Serial
     private static final long serialVersionUID = 1L;
     // TODO: schemaElement test unsupported yet.
-    private NodeTest nodeTest;
+    private final NodeTest nodeTest;
 
     public DocumentTest(NodeTest nodeTest) {
         this.nodeTest = nodeTest;

--- a/src/main/java/org/rumbledb/expressions/xml/node_test/ElementTest.java
+++ b/src/main/java/org/rumbledb/expressions/xml/node_test/ElementTest.java
@@ -7,9 +7,9 @@ import java.io.Serial;
 public class ElementTest implements NodeTest {
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name elementName;
-    private boolean hasWildcard;
-    private Name typeName;
+    private final Name elementName;
+    private final boolean hasWildcard;
+    private final Name typeName;
     // TODO: add support for optional type
 
 

--- a/src/main/java/org/rumbledb/expressions/xml/node_test/NameTest.java
+++ b/src/main/java/org/rumbledb/expressions/xml/node_test/NameTest.java
@@ -8,8 +8,8 @@ import java.io.Serial;
 public class NameTest implements NodeTest {
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name qname;
-    private String wildcardWithNCName;
+    private final Name qname;
+    private final String wildcardWithNCName;
 
     public NameTest(Name qname) {
         this.qname = qname;

--- a/src/main/java/org/rumbledb/expressions/xml/node_test/PITest.java
+++ b/src/main/java/org/rumbledb/expressions/xml/node_test/PITest.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 public class PITest implements NodeTest {
     @Serial
     private static final long serialVersionUID = 1L;
-    private String targetName;
+    private final String targetName;
 
     /**
      * Creates a PITest that matches any processing-instruction node.

--- a/src/main/java/org/rumbledb/items/ArrayItem.java
+++ b/src/main/java/org/rumbledb/items/ArrayItem.java
@@ -41,7 +41,7 @@ public class ArrayItem implements Item {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private List<Item> arrayItems;
+    private final List<Item> arrayItems;
     private int mutabilityLevel;
     private long topLevelID;
     private String pathIn;

--- a/src/main/java/org/rumbledb/items/DurationItem.java
+++ b/src/main/java/org/rumbledb/items/DurationItem.java
@@ -155,7 +155,7 @@ public class DurationItem implements Item {
         return BuiltinTypesCatalogue.durationItem;
     }
 
-    public static Comparator<Period> periodComparator = (p1, p2) -> {
+    public static final Comparator<Period> periodComparator = (p1, p2) -> {
         LocalDate base = LocalDate.of(2000, 1, 1);
         return base.plus(p1).compareTo(base.plus(p2));
     };

--- a/src/main/java/org/rumbledb/items/ItemComparator.java
+++ b/src/main/java/org/rumbledb/items/ItemComparator.java
@@ -36,7 +36,7 @@ public class ItemComparator implements Comparator<Item>, Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private RumbleException exception;
+    private final RumbleException exception;
     // For min(), NaN is returned if it appears in the input sequence. It must thus compare to less
     // than any other number for this purpose.
     private boolean compareMin = false;

--- a/src/main/java/org/rumbledb/items/LazyObjectItem.java
+++ b/src/main/java/org/rumbledb/items/LazyObjectItem.java
@@ -41,14 +41,14 @@ public class LazyObjectItem implements Item {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private List<String> keys;
-    private Map<String, Item> values;
-    transient private Map<String, LazyValue> lazyValues;
+    private final List<String> keys;
+    private final Map<String, Item> values;
+    final transient private Map<String, LazyValue> lazyValues;
 
     public class LazyValue {
-        private RuntimeIterator iterator;
-        private DynamicContext context;
-        private boolean isArray;
+        private final RuntimeIterator iterator;
+        private final DynamicContext context;
+        private final boolean isArray;
 
         public LazyValue(RuntimeIterator iterator, DynamicContext context, boolean isArray) {
             this.iterator = iterator;

--- a/src/main/java/org/rumbledb/items/MapEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapEntryItem.java
@@ -45,8 +45,8 @@ public class MapEntryItem implements Item {
     /**
      * This is an optimization version of maps when there is exactly one key-value pair.
      */
-    private Item key;
-    private List<Item> value;
+    private final Item key;
+    private final List<Item> value;
 
     public MapEntryItem() {
         this.key = null;

--- a/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
@@ -41,10 +41,10 @@ public class MapWithAdditionalEntryItem implements Item {
     /**
      * This is an optimization version of maps when there is exactly one key-value pair.
      */
-    private Item original;
-    private Item additionalKey;
-    private List<Item> additionalValue;
-    private ItemSameKeyComparator itemSameKeyComparator = new ItemSameKeyComparator();
+    private final Item original;
+    private final Item additionalKey;
+    private final List<Item> additionalValue;
+    private final ItemSameKeyComparator itemSameKeyComparator = new ItemSameKeyComparator();
 
     public MapWithAdditionalEntryItem() {
         this.original = null;

--- a/src/main/java/org/rumbledb/items/MapWithRemovedEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithRemovedEntryItem.java
@@ -44,8 +44,8 @@ public class MapWithRemovedEntryItem implements Item {
     /**
      * This is an optimization version of maps when there is exactly one key-value pair.
      */
-    private Item original;
-    private Set<Item> removedKeys;
+    private final Item original;
+    private final Set<Item> removedKeys;
 
     public MapWithRemovedEntryItem() {
         this.original = null;

--- a/src/main/java/org/rumbledb/items/SequenceArrayItem.java
+++ b/src/main/java/org/rumbledb/items/SequenceArrayItem.java
@@ -17,7 +17,7 @@ public class SequenceArrayItem implements Item {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private List<List<Item>> memberSequences;
+    private final List<List<Item>> memberSequences;
     private int mutabilityLevel;
     private long topLevelID;
     private String pathIn;

--- a/src/main/java/org/rumbledb/items/structured/JSoundDataFrame.java
+++ b/src/main/java/org/rumbledb/items/structured/JSoundDataFrame.java
@@ -29,7 +29,7 @@ public class JSoundDataFrame implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private Dataset<Row> dataFrame;
+    private final Dataset<Row> dataFrame;
     private ItemType itemType;
 
     public JSoundDataFrame(Dataset<Row> dataFrame, ItemType itemType) {

--- a/src/main/java/org/rumbledb/optimizations/Profiler.java
+++ b/src/main/java/org/rumbledb/optimizations/Profiler.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 public class Profiler {
 
     public static int counter = 0;
-    public static Map<String, Integer> stacks = new HashMap<>();
+    public static final Map<String, Integer> stacks = new HashMap<>();
 
     public static void increase() {
         ++counter;

--- a/src/main/java/org/rumbledb/runtime/ConstantRDDRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/ConstantRDDRuntimeIterator.java
@@ -31,7 +31,7 @@ public class ConstantRDDRuntimeIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private JavaRDD<Item> items;
+    private final JavaRDD<Item> items;
 
     public ConstantRDDRuntimeIterator(
             JavaRDD<Item> items,

--- a/src/main/java/org/rumbledb/runtime/RuntimeTupleIterator.java
+++ b/src/main/java/org/rumbledb/runtime/RuntimeTupleIterator.java
@@ -49,7 +49,7 @@ public abstract class RuntimeTupleIterator implements RuntimeIteratorInterface<F
     private static final long serialVersionUID = 1L;
     protected static final String FLOW_EXCEPTION_MESSAGE = "Invalid next() call; ";
     private final RuntimeStaticContext staticContext;
-    protected RuntimeTupleIterator child;
+    protected final RuntimeTupleIterator child;
     protected int evaluationDepthLimit;
 
     protected transient DynamicContext currentDynamicContext;

--- a/src/main/java/org/rumbledb/runtime/arithmetics/MultiplicativeOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/arithmetics/MultiplicativeOperationIterator.java
@@ -52,7 +52,7 @@ public class MultiplicativeOperationIterator extends AtMostOneItemLocalRuntimeIt
     private static final long serialVersionUID = 1L;
     Item left;
     Item right;
-    MultiplicativeExpression.MultiplicativeOperator multiplicativeOperator;
+    final MultiplicativeExpression.MultiplicativeOperator multiplicativeOperator;
     private final RuntimeIterator leftIterator;
     private final RuntimeIterator rightIterator;
 

--- a/src/main/java/org/rumbledb/runtime/arithmetics/UnaryOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/arithmetics/UnaryOperationIterator.java
@@ -39,7 +39,7 @@ import java.util.Collections;
 
 public class UnaryOperationIterator extends AtMostOneItemLocalRuntimeIterator {
 
-    private boolean negated;
+    private final boolean negated;
     private final RuntimeIterator child;
     private Item item;
     @Serial

--- a/src/main/java/org/rumbledb/runtime/control/TypeswitchRuntimeIteratorCase.java
+++ b/src/main/java/org/rumbledb/runtime/control/TypeswitchRuntimeIteratorCase.java
@@ -11,9 +11,9 @@ import java.util.List;
 public class TypeswitchRuntimeIteratorCase implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name variableName;
-    private List<SequenceType> sequenceTypeUnion;
-    private RuntimeIterator returnIterator;
+    private final Name variableName;
+    private final List<SequenceType> sequenceTypeUnion;
+    private final RuntimeIterator returnIterator;
 
     public TypeswitchRuntimeIteratorCase(
             Name variableName,

--- a/src/main/java/org/rumbledb/runtime/flwor/FlworDataFrameUtils.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/FlworDataFrameUtils.java
@@ -99,11 +99,11 @@ import sparksoniq.spark.SparkSessionManager;
 public class FlworDataFrameUtils {
 
     // we use UUID to escape backtick within DataFrame columns
-    public static String backtickEscape = "d32a3242-b15d-46b8-b689-d2288f7f492f";
+    public static final String backtickEscape = "d32a3242-b15d-46b8-b689-d2288f7f492f";
 
-    private static ThreadLocal<byte[]> lastBytesCache = ThreadLocal.withInitial(() -> null);
+    private static final ThreadLocal<byte[]> lastBytesCache = ThreadLocal.withInitial(() -> null);
 
-    private static ThreadLocal<List<Item>> lastObjectItemCache = ThreadLocal.withInitial(() -> null);
+    private static final ThreadLocal<List<Item>> lastObjectItemCache = ThreadLocal.withInitial(() -> null);
 
     public static void registerKryoClassesKryo(Kryo kryo) {
         kryo.register(Item.class);

--- a/src/main/java/org/rumbledb/runtime/flwor/NativeClauseContext.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/NativeClauseContext.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * This class describes the context of a native clause and is used when processing FLWOR expressions without UDF
  */
 public class NativeClauseContext {
-    public static NativeClauseContext NoNativeQuery = new NativeClauseContext();
+    public static final NativeClauseContext NoNativeQuery = new NativeClauseContext();
 
     private NativeClauseContext parent;
     private FLWOR_CLAUSES clauseType;

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/CountClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/CountClauseIterator.java
@@ -55,7 +55,7 @@ public class CountClauseIterator extends RuntimeTupleIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name variableName;
+    private final Name variableName;
     private FlworTuple nextLocalTupleResult;
     private int currentCountIndex;
 

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/ForClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/ForClauseIterator.java
@@ -81,11 +81,11 @@ public class ForClauseIterator extends RuntimeTupleIterator {
     private static final long serialVersionUID = 1L;
 
     // Properties
-    private Name variableName; // for efficient use in local iteration
-    private Name positionalVariableName; // for efficient use in local iteration
-    private RuntimeIterator assignmentIterator;
-    private boolean allowingEmpty;
-    private DataFrameContext dataFrameContext;
+    private final Name variableName; // for efficient use in local iteration
+    private final Name positionalVariableName; // for efficient use in local iteration
+    private final RuntimeIterator assignmentIterator;
+    private final boolean allowingEmpty;
+    private final DataFrameContext dataFrameContext;
 
     // Computation state
     private transient DynamicContext tupleContext; // re-use same DynamicContext object for efficiency

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/GroupByClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/GroupByClauseIterator.java
@@ -80,7 +80,7 @@ public class GroupByClauseIterator extends RuntimeTupleIterator {
     private final List<GroupByClauseSparkIteratorExpression> groupingExpressions;
     private List<FlworTuple> localTupleResults;
     private int resultIndex;
-    private Map<Name, DynamicContext.VariableDependency> dependencies;
+    private final Map<Name, DynamicContext.VariableDependency> dependencies;
 
     public GroupByClauseIterator(
             RuntimeTupleIterator child,

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/JoinClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/JoinClauseIterator.java
@@ -66,9 +66,9 @@ public class JoinClauseIterator extends RuntimeTupleIterator {
 
     // Properties
     @SuppressWarnings("unused")
-    private boolean isLeftOuterJoin;
+    private final boolean isLeftOuterJoin;
     @SuppressWarnings("unused")
-    private DataFrameContext dataFrameContext;
+    private final DataFrameContext dataFrameContext;
 
     // Computation state
     @SuppressWarnings("unused")

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/LetClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/LetClauseIterator.java
@@ -75,9 +75,9 @@ public class LetClauseIterator extends RuntimeTupleIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name variableName; // for efficient use in local iteration
-    private SequenceType sequenceType;
-    private RuntimeIterator assignmentIterator;
+    private final Name variableName; // for efficient use in local iteration
+    private final SequenceType sequenceType;
+    private final RuntimeIterator assignmentIterator;
     private DynamicContext tupleContext; // re-use same DynamicContext object for efficiency
     private FlworTuple nextLocalTupleResult;
 

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/OrderByClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/OrderByClauseIterator.java
@@ -67,9 +67,9 @@ public class OrderByClauseIterator extends RuntimeTupleIterator {
     @Serial
     private static final long serialVersionUID = 1L;
     private final List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator;
-    private Map<Name, DynamicContext.VariableDependency> dependencies;
+    private final Map<Name, DynamicContext.VariableDependency> dependencies;
 
-    private List<FlworTuple> localTupleResults;
+    private final List<FlworTuple> localTupleResults;
     private int resultIndex;
 
     public OrderByClauseIterator(

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/ReturnClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/ReturnClauseIterator.java
@@ -69,9 +69,9 @@ public class ReturnClauseIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeTupleIterator child;
+    private final RuntimeTupleIterator child;
     private DynamicContext tupleContext; // re-use same DynamicContext object for efficiency
-    private RuntimeIterator expression;
+    private final RuntimeIterator expression;
     private Item nextResult;
 
     public ReturnClauseIterator(

--- a/src/main/java/org/rumbledb/runtime/flwor/clauses/WhereClauseIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/clauses/WhereClauseIterator.java
@@ -56,7 +56,7 @@ public class WhereClauseIterator extends RuntimeTupleIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator expression;
+    private final RuntimeIterator expression;
     private DynamicContext tupleContext; // re-use same DynamicContext object for efficiency
     private FlworTuple nextLocalTupleResult;
 

--- a/src/main/java/org/rumbledb/runtime/flwor/closures/ItemsToBinaryColumn.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/closures/ItemsToBinaryColumn.java
@@ -36,7 +36,7 @@ public class ItemsToBinaryColumn implements Function<Item, Row> {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private DataFrameContext dataFrameContext;
+    private final DataFrameContext dataFrameContext;
 
     public ItemsToBinaryColumn() {
         this.dataFrameContext = new DataFrameContext();

--- a/src/main/java/org/rumbledb/runtime/flwor/closures/ReturnFlatMapClosure.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/closures/ReturnFlatMapClosure.java
@@ -38,8 +38,8 @@ public class ReturnFlatMapClosure implements FlatMapFunction<Row, Item> {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private DataFrameContext dataFrameContext;
-    private RuntimeIterator expression;
+    private final DataFrameContext dataFrameContext;
+    private final RuntimeIterator expression;
 
     List<Item> results;
 

--- a/src/main/java/org/rumbledb/runtime/flwor/expression/SimpleMapExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/expression/SimpleMapExpressionIterator.java
@@ -58,8 +58,8 @@ public class SimpleMapExpressionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator leftIterator;
-    private RuntimeIterator rightIterator;
+    private final RuntimeIterator leftIterator;
+    private final RuntimeIterator rightIterator;
     private Item nextResult;
     private DynamicContext mapDynamicContext;
     private Queue<Item> mapValues;

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/ExpressionEvaluationUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/ExpressionEvaluationUDF.java
@@ -39,8 +39,8 @@ public class ExpressionEvaluationUDF implements UDF1<Row, List<byte[]>> {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private DataFrameContext dataFrameContext;
-    private RuntimeIterator expression;
+    private final DataFrameContext dataFrameContext;
+    private final RuntimeIterator expression;
 
     private transient List<byte[]> results;
 

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/ForClauseUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/ForClauseUDF.java
@@ -38,8 +38,8 @@ public class ForClauseUDF implements UDF1<Row, List<byte[]>> {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private DataFrameContext dataFrameContext;
-    private RuntimeIterator expression;
+    private final DataFrameContext dataFrameContext;
+    private final RuntimeIterator expression;
 
     private List<Item> nextResult;
     private List<byte[]> results;

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/GenericForClauseUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/GenericForClauseUDF.java
@@ -17,8 +17,8 @@ public class GenericForClauseUDF<T> implements UDF1<Row, List<T>> {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private DataFrameContext dataFrameContext;
-    private RuntimeIterator expression;
+    private final DataFrameContext dataFrameContext;
+    private final RuntimeIterator expression;
     private String classSimpleName;
 
     private List<T> results;

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/GenericLetClauseUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/GenericLetClauseUDF.java
@@ -18,8 +18,8 @@ public class GenericLetClauseUDF<T> implements UDF1<Row, T> {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private DataFrameContext dataFrameContext;
-    private RuntimeIterator expression;
+    private final DataFrameContext dataFrameContext;
+    private final RuntimeIterator expression;
     private String classSimpleName;
 
     private List<Item> nextResult;

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/GroupClauseArrayMergeAggregateResultsUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/GroupClauseArrayMergeAggregateResultsUDF.java
@@ -38,8 +38,8 @@ public class GroupClauseArrayMergeAggregateResultsUDF implements UDF1<ArraySeq<O
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private List<Item> nextResult;
-    private List<List<Item>> deserializedParams;
+    private final List<Item> nextResult;
+    private final List<List<Item>> deserializedParams;
 
     public GroupClauseArrayMergeAggregateResultsUDF() {
         this.nextResult = new ArrayList<>();

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/GroupClauseSerializeAggregateResultsUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/GroupClauseSerializeAggregateResultsUDF.java
@@ -34,9 +34,9 @@ public class GroupClauseSerializeAggregateResultsUDF implements UDF1<ArraySeq<by
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private List<Item> nextResult;
-    private List<List<Item>> deserializedParams;
-    private DataFrameContext dataFrameContext;
+    private final List<Item> nextResult;
+    private final List<List<Item>> deserializedParams;
+    private final DataFrameContext dataFrameContext;
 
     public GroupClauseSerializeAggregateResultsUDF() {
         this.nextResult = new ArrayList<>();

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/HashUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/HashUDF.java
@@ -38,8 +38,8 @@ public class HashUDF implements UDF1<Row, Long> {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private DataFrameContext dataFrameContext;
-    private RuntimeIterator expression;
+    private final DataFrameContext dataFrameContext;
+    private final RuntimeIterator expression;
 
     public HashUDF(
             RuntimeIterator expression,

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/IntegerSerializeUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/IntegerSerializeUDF.java
@@ -34,9 +34,9 @@ public class IntegerSerializeUDF implements UDF1<Integer, byte[]> {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private List<Item> nextResult;
+    private final List<Item> nextResult;
 
-    private DataFrameContext dataFrameContext;
+    private final DataFrameContext dataFrameContext;
 
     public IntegerSerializeUDF() {
         this.dataFrameContext = new DataFrameContext();

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/LongSerializeUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/LongSerializeUDF.java
@@ -34,9 +34,9 @@ public class LongSerializeUDF implements UDF1<Long, byte[]> {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private List<Item> nextResult;
+    private final List<Item> nextResult;
 
-    private DataFrameContext dataFrameContext;
+    private final DataFrameContext dataFrameContext;
 
     public LongSerializeUDF() {
         this.dataFrameContext = new DataFrameContext();

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/OrderClauseDetermineTypeUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/OrderClauseDetermineTypeUDF.java
@@ -39,11 +39,11 @@ import java.util.List;
 public class OrderClauseDetermineTypeUDF implements UDF1<Row, List<String>> {
     @Serial
     private static final long serialVersionUID = 1L;
-    private DataFrameContext dataFrameContext;
-    private List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator;
+    private final DataFrameContext dataFrameContext;
+    private final List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator;
 
     private Item nextItem;
-    private List<String> result;
+    private final List<String> result;
 
     public OrderClauseDetermineTypeUDF(
             List<OrderByClauseAnnotatedChildIterator> expressionsWithIterator,

--- a/src/main/java/org/rumbledb/runtime/flwor/udfs/WhereClauseUDF.java
+++ b/src/main/java/org/rumbledb/runtime/flwor/udfs/WhereClauseUDF.java
@@ -34,8 +34,8 @@ public class WhereClauseUDF implements UDF1<Row, Boolean> {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private DataFrameContext dataFrameContext;
-    private RuntimeIterator expression;
+    private final DataFrameContext dataFrameContext;
+    private final RuntimeIterator expression;
 
     public WhereClauseUDF(
             RuntimeIterator expression,

--- a/src/main/java/org/rumbledb/runtime/functions/DynamicFunctionCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/DynamicFunctionCallIterator.java
@@ -53,13 +53,13 @@ public class DynamicFunctionCallIterator extends HybridRuntimeIterator {
     @Serial
     private static final long serialVersionUID = 1L;
     // parametrized fields
-    private RuntimeIterator functionItemIterator;
-    private List<RuntimeIterator> functionArguments;
+    private final RuntimeIterator functionItemIterator;
+    private final List<RuntimeIterator> functionArguments;
 
     // calculated fields
     private Item functionItem;
     private RuntimeIterator functionCallIterator;
-    private boolean isPartialApplication;
+    private final boolean isPartialApplication;
     private Item nextResult;
 
     // Exit statement fields

--- a/src/main/java/org/rumbledb/runtime/functions/FunctionItemCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/FunctionItemCallIterator.java
@@ -54,8 +54,8 @@ public class FunctionItemCallIterator extends HybridRuntimeIterator {
     private static final long serialVersionUID = 1L;
 
     // parametrized fields
-    private Item functionItem;
-    private List<RuntimeIterator> functionArguments;
+    private final Item functionItem;
+    private final List<RuntimeIterator> functionArguments;
 
     // calculated fields
     private boolean isPartialApplication;

--- a/src/main/java/org/rumbledb/runtime/functions/FunctionRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/FunctionRuntimeIterator.java
@@ -36,10 +36,10 @@ public class FunctionRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name functionName;
-    private Map<Name, SequenceType> paramNameToSequenceTypes;
-    SequenceType returnType;
-    RuntimeIterator bodyIterator;
+    private final Name functionName;
+    private final Map<Name, SequenceType> paramNameToSequenceTypes;
+    final SequenceType returnType;
+    final RuntimeIterator bodyIterator;
 
     public FunctionRuntimeIterator(
             Name functionName,

--- a/src/main/java/org/rumbledb/runtime/functions/StaticUserDefinedFunctionCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/StaticUserDefinedFunctionCallIterator.java
@@ -47,8 +47,8 @@ public class StaticUserDefinedFunctionCallIterator extends HybridRuntimeIterator
     @Serial
     private static final long serialVersionUID = 1L;
     // parametrized fields
-    private FunctionIdentifier functionIdentifier;
-    private List<RuntimeIterator> functionArguments;
+    private final FunctionIdentifier functionIdentifier;
+    private final List<RuntimeIterator> functionArguments;
 
     // calculated fields
     private RuntimeIterator userDefinedFunctionCallIterator;
@@ -56,7 +56,7 @@ public class StaticUserDefinedFunctionCallIterator extends HybridRuntimeIterator
     private List<Item> exitStatementLocalResult;
     private boolean encounteredExitStatement;
     private int nextExitStatementResult;
-    private boolean tailCallOptimizationCandidate;
+    private final boolean tailCallOptimizationCandidate;
 
     public StaticUserDefinedFunctionCallIterator(
             FunctionIdentifier functionIdentifier,

--- a/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayDescendantFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayDescendantFunctionIterator.java
@@ -40,7 +40,7 @@ public class ArrayDescendantFunctionIterator extends HybridRuntimeIterator {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Queue<Item> nextResults; // queue that holds the results created by the current item in inspection
 
 

--- a/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayFlattenFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayFlattenFunctionIterator.java
@@ -40,7 +40,7 @@ public class ArrayFlattenFunctionIterator extends HybridRuntimeIterator {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Queue<Item> nextResults; // queue that holds the results created by the current item in inspection
 
     public ArrayFlattenFunctionIterator(

--- a/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayFunctionCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayFunctionCallIterator.java
@@ -21,7 +21,7 @@ public class ArrayFunctionCallIterator extends HybridRuntimeIterator {
 
     private final Item arrayItem;
     private final RuntimeIterator indexIterator;
-    private Queue<Item> pendingResults;
+    private final Queue<Item> pendingResults;
 
     public ArrayFunctionCallIterator(
             Item arrayItem,

--- a/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayMembersFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/arrays/ArrayMembersFunctionIterator.java
@@ -40,8 +40,8 @@ public class ArrayMembersFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
-    private Queue<Item> nextResults; // queue that holds the results created by the current item in inspection
+    private final RuntimeIterator iterator;
+    private final Queue<Item> nextResults; // queue that holds the results created by the current item in inspection
 
     public ArrayMembersFunctionIterator(
             List<RuntimeIterator> arguments,

--- a/src/main/java/org/rumbledb/runtime/functions/input/JsonLinesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/JsonLinesFunctionIterator.java
@@ -46,7 +46,7 @@ public class JsonLinesFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    RuntimeIterator iterator;
+    final RuntimeIterator iterator;
     BufferedReader reader;
     Item path;
     Item nextItem;

--- a/src/main/java/org/rumbledb/runtime/functions/input/ParallelizeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/ParallelizeFunctionIterator.java
@@ -40,7 +40,7 @@ public class ParallelizeFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator sequenceIterator;
+    private final RuntimeIterator sequenceIterator;
     private RuntimeIterator partitionsIterator;
 
     public ParallelizeFunctionIterator(List<RuntimeIterator> parameters, RuntimeStaticContext staticContext) {

--- a/src/main/java/org/rumbledb/runtime/functions/input/RepartitionFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/RepartitionFunctionIterator.java
@@ -37,7 +37,7 @@ public class RepartitionFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private int numberPartitions;
 
     public RepartitionFunctionIterator(

--- a/src/main/java/org/rumbledb/runtime/functions/input/XmlFilesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/input/XmlFilesFunctionIterator.java
@@ -42,10 +42,10 @@ public class XmlFilesFunctionIterator extends RDDRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    RuntimeIterator iterator;
-    BufferedReader reader;
-    Item path;
-    Item nextItem;
+    final RuntimeIterator iterator;
+    final BufferedReader reader;
+    final Item path;
+    final Item nextItem;
 
     public XmlFilesFunctionIterator(
             List<RuntimeIterator> arguments,

--- a/src/main/java/org/rumbledb/runtime/functions/maps/MapFunctionCallIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/maps/MapFunctionCallIterator.java
@@ -45,7 +45,7 @@ public class MapFunctionCallIterator extends HybridRuntimeIterator {
 
     private final Item mapItem;
     private final RuntimeIterator keyIterator;
-    private Queue<Item> pendingResults;
+    private final Queue<Item> pendingResults;
 
     public MapFunctionCallIterator(
             Item mapItem,

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectDescendantFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectDescendantFunctionIterator.java
@@ -40,7 +40,7 @@ public class ObjectDescendantFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Queue<Item> nextResults; // queue that holds the results created by the current item in inspection
 
     public ObjectDescendantFunctionIterator(

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectIntersectFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectIntersectFunctionIterator.java
@@ -43,7 +43,7 @@ public class ObjectIntersectFunctionIterator extends AtMostOneItemLocalRuntimeIt
      */
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
 
     public ObjectIntersectFunctionIterator(
             List<RuntimeIterator> children,

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectIntersectMapClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectIntersectMapClosure.java
@@ -35,7 +35,7 @@ public class ObjectIntersectMapClosure implements Function<Item, Item> {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private boolean mutable;
+    private final boolean mutable;
 
     public ObjectIntersectMapClosure(boolean mutable) {
         this.mutable = mutable;

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectKeysFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectKeysFunctionIterator.java
@@ -43,7 +43,7 @@ public class ObjectKeysFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Queue<Item> nextResults; // queue that holds the results created by the current item in inspection
     private List<Item> alreadyFoundKeys;
 

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectProjectClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectProjectClosure.java
@@ -15,8 +15,8 @@ public class ObjectProjectClosure implements FlatMapFunction<Item, Item> {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private List<Item> projectionKeys;
-    private ExceptionMetadata itemMetadata;
+    private final List<Item> projectionKeys;
+    private final ExceptionMetadata itemMetadata;
 
     public ObjectProjectClosure(List<Item> projectionKeys, ExceptionMetadata itemMetadata) {
         this.projectionKeys = projectionKeys;

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectProjectFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectProjectFunctionIterator.java
@@ -44,7 +44,7 @@ public class ObjectProjectFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Item nextResult;
     private List<Item> projectionKeys;
 

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectRemoveKeysClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectRemoveKeysClosure.java
@@ -14,8 +14,8 @@ public class ObjectRemoveKeysClosure implements FlatMapFunction<Item, Item> {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private List<String> removalKeys;
-    private ExceptionMetadata itemMetadata;
+    private final List<String> removalKeys;
+    private final ExceptionMetadata itemMetadata;
 
     public ObjectRemoveKeysClosure(List<String> removalKeys, ExceptionMetadata itemMetadata) {
         this.removalKeys = removalKeys;

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectRemoveKeysFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectRemoveKeysFunctionIterator.java
@@ -42,7 +42,7 @@ public class ObjectRemoveKeysFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Item nextResult;
     private List<String> removalKeys;
 

--- a/src/main/java/org/rumbledb/runtime/functions/object/ObjectValuesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/object/ObjectValuesFunctionIterator.java
@@ -38,7 +38,7 @@ public class ObjectValuesFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Queue<Item> nextResults; // queue that holds the results created by the current item in inspection
 
     public ObjectValuesFunctionIterator(

--- a/src/main/java/org/rumbledb/runtime/functions/random/GeneratedRandomsIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/random/GeneratedRandomsIterator.java
@@ -5,7 +5,7 @@ import org.rumbledb.api.Item;
 import java.util.Random;
 
 public abstract class GeneratedRandomsIterator {
-    protected Random random;
+    protected final Random random;
 
     protected GeneratedRandomsIterator() {
         this.random = new Random();

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/SumClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/aggregate/SumClosure.java
@@ -12,7 +12,7 @@ public class SumClosure implements Function2<Item, Item, Item> {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private ExceptionMetadata metadata;
+    private final ExceptionMetadata metadata;
 
     public SumClosure(ExceptionMetadata metadata) {
         this.metadata = metadata;

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/cardinality/OneOrMoreIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/cardinality/OneOrMoreIterator.java
@@ -37,7 +37,7 @@ public class OneOrMoreIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Item nextResult;
 
     public OneOrMoreIterator(

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/InsertBeforeFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/InsertBeforeFunctionIterator.java
@@ -39,9 +39,9 @@ public class InsertBeforeFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator sequenceIterator;
-    private RuntimeIterator positionIterator;
-    private RuntimeIterator insertIterator;
+    private final RuntimeIterator sequenceIterator;
+    private final RuntimeIterator positionIterator;
+    private final RuntimeIterator insertIterator;
     private Item nextResult;
     private int insertPosition; // position to start inserting
     private int currentPosition; // current position

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/InstanceOfClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/InstanceOfClosure.java
@@ -8,7 +8,7 @@ import org.rumbledb.types.ItemType;
 import java.io.Serial;
 
 public class InstanceOfClosure implements Function<Item, Boolean> {
-    private ItemType itemType;
+    private final ItemType itemType;
     @Serial
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/RemoveFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/RemoveFunctionIterator.java
@@ -37,8 +37,8 @@ public class RemoveFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator sequenceIterator;
-    private RuntimeIterator positionIterator;
+    private final RuntimeIterator sequenceIterator;
+    private final RuntimeIterator positionIterator;
     private Item nextResult;
     private int removePosition; // position to remove the item
     private int currentPosition; // current position

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/ReverseFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/ReverseFunctionIterator.java
@@ -44,7 +44,7 @@ public class ReverseFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator sequenceIterator;
+    private final RuntimeIterator sequenceIterator;
     private List<Item> results;
     private int currentIndex = 0;
 

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -45,8 +45,8 @@ public class SubsequenceFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator sequenceIterator;
-    private RuntimeIterator positionIterator;
+    private final RuntimeIterator sequenceIterator;
+    private final RuntimeIterator positionIterator;
     private RuntimeIterator lengthIterator;
     private Item nextResult;
     private int startPosition;

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/TailFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/TailFunctionIterator.java
@@ -37,7 +37,7 @@ public class TailFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Item nextResult;
 
     public TailFunctionIterator(

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/TreatAsClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/TreatAsClosure.java
@@ -14,9 +14,9 @@ import org.rumbledb.types.SequenceType;
 import java.io.Serial;
 
 public class TreatAsClosure implements Function<Item, Boolean> {
-    private SequenceType sequenceType;
-    private ExceptionMetadata metadata;
-    private ErrorCode errorCode;
+    private final SequenceType sequenceType;
+    private final ExceptionMetadata metadata;
+    private final ErrorCode errorCode;
     @Serial
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/TypePromotionClosure.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/TypePromotionClosure.java
@@ -12,9 +12,9 @@ import org.rumbledb.types.SequenceType;
 import java.io.Serial;
 
 public class TypePromotionClosure implements Function<Item, Item> {
-    private String exceptionMessage;
-    private SequenceType sequenceType;
-    private ExceptionMetadata metadata;
+    private final String exceptionMessage;
+    private final SequenceType sequenceType;
+    private final ExceptionMetadata metadata;
     @Serial
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/general/UnorderedFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/general/UnorderedFunctionIterator.java
@@ -37,7 +37,7 @@ public class UnorderedFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Item nextResult;
 
     public UnorderedFunctionIterator(

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/value/DistinctValuesFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/value/DistinctValuesFunctionIterator.java
@@ -40,7 +40,7 @@ public class DistinctValuesFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator sequenceIterator;
+    private final RuntimeIterator sequenceIterator;
     private Item nextResult;
     private List<Item> prevResults;
 

--- a/src/main/java/org/rumbledb/runtime/functions/sequences/value/IndexOfFunctionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/functions/sequences/value/IndexOfFunctionIterator.java
@@ -40,8 +40,8 @@ public class IndexOfFunctionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator sequenceIterator;
-    private RuntimeIterator searchIterator;
+    private final RuntimeIterator sequenceIterator;
+    private final RuntimeIterator searchIterator;
     private Item search;
     private Item nextResult;
     private int currentIndex;

--- a/src/main/java/org/rumbledb/runtime/functions/util/formatting/NumericPictureParser.java
+++ b/src/main/java/org/rumbledb/runtime/functions/util/formatting/NumericPictureParser.java
@@ -14,8 +14,8 @@ public final class NumericPictureParser {
         private NumericPictureKind() {
         }
 
-        public static String DATE = "DATE";
-        public static String INTEGER = "INTEGER";
+        public static final String DATE = "DATE";
+        public static final String INTEGER = "INTEGER";
     }
 
     private NumericPictureParser() {

--- a/src/main/java/org/rumbledb/runtime/logics/AndOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/logics/AndOperationIterator.java
@@ -37,8 +37,8 @@ public class AndOperationIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator leftIterator;
-    private RuntimeIterator rightIterator;
+    private final RuntimeIterator leftIterator;
+    private final RuntimeIterator rightIterator;
 
     public AndOperationIterator(
             RuntimeIterator leftIterator,

--- a/src/main/java/org/rumbledb/runtime/logics/OrOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/logics/OrOperationIterator.java
@@ -38,8 +38,8 @@ public class OrOperationIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator leftIterator;
-    private RuntimeIterator rightIterator;
+    private final RuntimeIterator leftIterator;
+    private final RuntimeIterator rightIterator;
 
     public OrOperationIterator(
             RuntimeIterator leftIterator,

--- a/src/main/java/org/rumbledb/runtime/misc/NodeComparisonRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/misc/NodeComparisonRuntimeIterator.java
@@ -46,9 +46,9 @@ public class NodeComparisonRuntimeIterator extends AtMostOneItemLocalRuntimeIter
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private NodeComparisonExpression.NodeComparisonOperator operator;
-    private RuntimeIterator leftIterator;
-    private RuntimeIterator rightIterator;
+    private final NodeComparisonExpression.NodeComparisonOperator operator;
+    private final RuntimeIterator leftIterator;
+    private final RuntimeIterator rightIterator;
 
     public NodeComparisonRuntimeIterator(
             RuntimeIterator leftIterator,

--- a/src/main/java/org/rumbledb/runtime/misc/NodeSetOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/misc/NodeSetOperationIterator.java
@@ -41,9 +41,9 @@ public class NodeSetOperationIterator extends HybridRuntimeIterator {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private RuntimeIterator leftIterator;
-    private RuntimeIterator rightIterator;
-    private NodeSetExpression.NodeSetOperator operator;
+    private final RuntimeIterator leftIterator;
+    private final RuntimeIterator rightIterator;
+    private final NodeSetExpression.NodeSetOperator operator;
     private List<Item> localResults;
     private int nextResultIndex;
 

--- a/src/main/java/org/rumbledb/runtime/misc/RangeOperationIterator.java
+++ b/src/main/java/org/rumbledb/runtime/misc/RangeOperationIterator.java
@@ -49,8 +49,8 @@ public class RangeOperationIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator leftIterator;
-    private RuntimeIterator rightIterator;
+    private final RuntimeIterator leftIterator;
+    private final RuntimeIterator rightIterator;
     private long left;
     private long right;
     private long index;

--- a/src/main/java/org/rumbledb/runtime/misc/StringConcatIterator.java
+++ b/src/main/java/org/rumbledb/runtime/misc/StringConcatIterator.java
@@ -36,8 +36,8 @@ public class StringConcatIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator leftIterator;
-    private RuntimeIterator rightIterator;
+    private final RuntimeIterator leftIterator;
+    private final RuntimeIterator rightIterator;
 
     public StringConcatIterator(
             RuntimeIterator leftIterator,

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayLookupIterator.java
@@ -54,7 +54,7 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private int lookup;
     private Item nextResult;
     private java.util.Queue<Item> lookupResultQueue;

--- a/src/main/java/org/rumbledb/runtime/navigation/ArrayUnboxingIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ArrayUnboxingIterator.java
@@ -54,7 +54,7 @@ public class ArrayUnboxingIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Queue<Item> nextResults; // queue that holds the results created by the current item in inspection
 
     public ArrayUnboxingIterator(

--- a/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/ObjectLookupIterator.java
@@ -67,7 +67,7 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private Item lookupKey;
     private boolean contextLookup;
     private Item nextResult;

--- a/src/main/java/org/rumbledb/runtime/navigation/PredicateIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/PredicateIterator.java
@@ -63,13 +63,13 @@ public class PredicateIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
-    private RuntimeIterator filter;
+    private final RuntimeIterator iterator;
+    private final RuntimeIterator filter;
     private Item nextResult;
     private long position;
     private boolean mustMaintainPosition;
     private DynamicContext filterDynamicContext;
-    private boolean isBooleanOnlyFilter;
+    private final boolean isBooleanOnlyFilter;
 
 
     public PredicateIterator(

--- a/src/main/java/org/rumbledb/runtime/navigation/PredicateUDF.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/PredicateUDF.java
@@ -42,7 +42,7 @@ public class PredicateUDF implements UDF1<Row, Boolean> {
     private final DynamicContext dynamicContext;
     private final ExceptionMetadata metadata;
     private final ItemType itemType;
-    List<Item> currentItems = new ArrayList<>();
+    final List<Item> currentItems = new ArrayList<>();
 
     public PredicateUDF(
             RuntimeIterator expression,

--- a/src/main/java/org/rumbledb/runtime/navigation/PredicateWithZipUDF.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/PredicateWithZipUDF.java
@@ -47,7 +47,7 @@ public class PredicateWithZipUDF implements UDF1<Row, Boolean> {
     private final ExceptionMetadata metadata;
     private final ItemType itemType;
     private final long contextSize;
-    List<Item> currentItems = new ArrayList<>();
+    final List<Item> currentItems = new ArrayList<>();
 
     public PredicateWithZipUDF(
             RuntimeIterator expression,

--- a/src/main/java/org/rumbledb/runtime/navigation/SequenceLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/navigation/SequenceLookupIterator.java
@@ -49,8 +49,8 @@ public class SequenceLookupIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
-    private int position;
+    private final RuntimeIterator iterator;
+    private final int position;
     private final int optimizationThreshold = 10_000_000; // do optimization only if position is above this threshold
 
     public SequenceLookupIterator(

--- a/src/main/java/org/rumbledb/runtime/primary/ArrayRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/ArrayRuntimeIterator.java
@@ -40,8 +40,8 @@ public class ArrayRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private boolean isFixedSlotsArrayConstructor;
-    private boolean mutable;
+    private final boolean isFixedSlotsArrayConstructor;
+    private final boolean mutable;
 
     /**
      * Curly array constructor: single child whose items become singleton members.

--- a/src/main/java/org/rumbledb/runtime/primary/BooleanRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/BooleanRuntimeIterator.java
@@ -35,7 +35,7 @@ public class BooleanRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Item item;
+    private final Item item;
 
     public BooleanRuntimeIterator(boolean value, RuntimeStaticContext staticContext) {
         super(null, staticContext);

--- a/src/main/java/org/rumbledb/runtime/primary/DecimalRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/DecimalRuntimeIterator.java
@@ -36,7 +36,7 @@ public class DecimalRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Item item;
+    private final Item item;
 
     public DecimalRuntimeIterator(BigDecimal value, RuntimeStaticContext staticContext) {
         super(null, staticContext);

--- a/src/main/java/org/rumbledb/runtime/primary/DoubleRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/DoubleRuntimeIterator.java
@@ -35,7 +35,7 @@ public class DoubleRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Item item;
+    private final Item item;
 
     public DoubleRuntimeIterator(Double value, RuntimeStaticContext staticContext) {
         super(null, staticContext);

--- a/src/main/java/org/rumbledb/runtime/primary/IntegerRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/IntegerRuntimeIterator.java
@@ -35,7 +35,7 @@ public class IntegerRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Item item;
+    private final Item item;
 
     public IntegerRuntimeIterator(
             String lexicalValue,

--- a/src/main/java/org/rumbledb/runtime/primary/MapConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/MapConstructorRuntimeIterator.java
@@ -41,7 +41,7 @@ public class MapConstructorRuntimeIterator extends AtMostOneItemLocalRuntimeIter
     private static final long serialVersionUID = 1L;
     private final List<RuntimeIterator> keys;
     private final List<RuntimeIterator> values;
-    private boolean mutable;
+    private final boolean mutable;
 
     public MapConstructorRuntimeIterator(
             List<RuntimeIterator> keys,

--- a/src/main/java/org/rumbledb/runtime/primary/NullRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/NullRuntimeIterator.java
@@ -33,7 +33,7 @@ public class NullRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Item item;
+    private final Item item;
 
     public NullRuntimeIterator(RuntimeStaticContext staticContext) {
         super(null, staticContext);

--- a/src/main/java/org/rumbledb/runtime/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/ObjectConstructorRuntimeIterator.java
@@ -52,7 +52,7 @@ public class ObjectConstructorRuntimeIterator extends AtMostOneItemLocalRuntimeI
     private List<RuntimeIterator> keys;
     private List<RuntimeIterator> values;
     private boolean isMergedObject = false;
-    private boolean mutable;
+    private final boolean mutable;
 
     public ObjectConstructorRuntimeIterator(
             List<RuntimeIterator> keys,

--- a/src/main/java/org/rumbledb/runtime/primary/StringRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/StringRuntimeIterator.java
@@ -34,7 +34,7 @@ public class StringRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Item item;
+    private final Item item;
 
     public StringRuntimeIterator(String value, RuntimeStaticContext staticContext) {
         super(null, staticContext);

--- a/src/main/java/org/rumbledb/runtime/primary/VariableReferenceIterator.java
+++ b/src/main/java/org/rumbledb/runtime/primary/VariableReferenceIterator.java
@@ -47,7 +47,7 @@ public class VariableReferenceIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name variableName;
+    private final Name variableName;
     private List<Item> items = null;
     private int currentIndex = 0;
 

--- a/src/main/java/org/rumbledb/runtime/typing/AtMostOneItemTypePromotionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/AtMostOneItemTypePromotionIterator.java
@@ -26,10 +26,10 @@ public class AtMostOneItemTypePromotionIterator extends AtMostOneItemLocalRuntim
     @Serial
     private static final long serialVersionUID = 1L;
     private final String exceptionMessage;
-    private RuntimeIterator iterator;
-    private SequenceType sequenceType;
+    private final RuntimeIterator iterator;
+    private final SequenceType sequenceType;
 
-    private ItemType itemType;
+    private final ItemType itemType;
 
     public AtMostOneItemTypePromotionIterator(
             RuntimeIterator iterator,

--- a/src/main/java/org/rumbledb/runtime/typing/TreatIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/TreatIterator.java
@@ -43,9 +43,9 @@ public class TreatIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private final SequenceType sequenceType;
-    private ErrorCode errorCode;
+    private final ErrorCode errorCode;
 
     private ItemType itemType;
 

--- a/src/main/java/org/rumbledb/runtime/typing/TypePromotionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/TypePromotionIterator.java
@@ -31,10 +31,10 @@ public class TypePromotionIterator extends HybridRuntimeIterator {
     @Serial
     private static final long serialVersionUID = 1L;
     private final String exceptionMessage;
-    private RuntimeIterator iterator;
-    private SequenceType sequenceType;
+    private final RuntimeIterator iterator;
+    private final SequenceType sequenceType;
 
-    private ItemType itemType;
+    private final ItemType itemType;
 
     private Item nextResult;
     private int childIndex;

--- a/src/main/java/org/rumbledb/runtime/typing/ValidateTypeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/typing/ValidateTypeIterator.java
@@ -47,9 +47,9 @@ public class ValidateTypeIterator extends HybridRuntimeIterator {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private ItemType itemType;
+    private final ItemType itemType;
 
-    private boolean isValidate;
+    private final boolean isValidate;
 
     public ValidateTypeIterator(
             RuntimeIterator instance,

--- a/src/main/java/org/rumbledb/runtime/update/PendingUpdateList.java
+++ b/src/main/java/org/rumbledb/runtime/update/PendingUpdateList.java
@@ -13,22 +13,22 @@ import java.util.*;
 
 public class PendingUpdateList {
 
-    private Map<Item, Item> insertObjMap;
-    private Map<Item, Map<Item, List<Item>>> insertArrayMap;
-    private Map<Item, Map<Item, Item>> delReplaceObjMap;
-    private Map<Item, Map<Item, Item>> delReplaceArrayMap;
-    private Map<Item, Map<Item, Item>> renameObjMap;
-    private Comparator<Item> targetComparator;
-    private Comparator<Item> arraySelectorComparator;
+    private final Map<Item, Item> insertObjMap;
+    private final Map<Item, Map<Item, List<Item>>> insertArrayMap;
+    private final Map<Item, Map<Item, Item>> delReplaceObjMap;
+    private final Map<Item, Map<Item, Item>> delReplaceArrayMap;
+    private final Map<Item, Map<Item, Item>> renameObjMap;
+    private final Comparator<Item> targetComparator;
+    private final Comparator<Item> arraySelectorComparator;
 
-    private Map<String, UpdatePrimitive> createCollectionMap;
-    private Map<String, UpdatePrimitive> truncateCollectionMap;
-    private Map<String, Map<Double, UpdatePrimitive>> deleteTupleMap;
-    private Map<String, Map<Double, UpdatePrimitive>> editTupleMap;
-    private List<UpdatePrimitive> insertFirstList;
-    private List<UpdatePrimitive> insertLastList;
-    private List<UpdatePrimitive> insertBeforeList;
-    private List<UpdatePrimitive> insertAfterList;
+    private final Map<String, UpdatePrimitive> createCollectionMap;
+    private final Map<String, UpdatePrimitive> truncateCollectionMap;
+    private final Map<String, Map<Double, UpdatePrimitive>> deleteTupleMap;
+    private final Map<String, Map<Double, UpdatePrimitive>> editTupleMap;
+    private final List<UpdatePrimitive> insertFirstList;
+    private final List<UpdatePrimitive> insertLastList;
+    private final List<UpdatePrimitive> insertBeforeList;
+    private final List<UpdatePrimitive> insertAfterList;
 
 
     public PendingUpdateList() {

--- a/src/main/java/org/rumbledb/runtime/update/expression/AppendExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/AppendExpressionIterator.java
@@ -26,8 +26,8 @@ public class AppendExpressionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator arrayIterator;
-    private RuntimeIterator toAppendIterator;
+    private final RuntimeIterator arrayIterator;
+    private final RuntimeIterator toAppendIterator;
 
     public AppendExpressionIterator(
             RuntimeIterator arrayIterator,

--- a/src/main/java/org/rumbledb/runtime/update/expression/CreateCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/CreateCollectionIterator.java
@@ -30,7 +30,7 @@ public class CreateCollectionIterator extends HybridRuntimeIterator {
     private static final long serialVersionUID = 1L;
     private final RuntimeIterator targetIterator;
     private final RuntimeIterator contentIterator;
-    private Mode mode;
+    private final Mode mode;
 
     public CreateCollectionIterator(
             RuntimeIterator targetIterator,

--- a/src/main/java/org/rumbledb/runtime/update/expression/DeleteExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/DeleteExpressionIterator.java
@@ -24,8 +24,8 @@ public class DeleteExpressionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator mainIterator;
-    private RuntimeIterator lookupIterator;
+    private final RuntimeIterator mainIterator;
+    private final RuntimeIterator lookupIterator;
 
     public DeleteExpressionIterator(
             RuntimeIterator mainIterator,

--- a/src/main/java/org/rumbledb/runtime/update/expression/InsertExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/InsertExpressionIterator.java
@@ -27,9 +27,9 @@ public class InsertExpressionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator mainIterator;
-    private RuntimeIterator toInsertIterator;
-    private RuntimeIterator positionIterator;
+    private final RuntimeIterator mainIterator;
+    private final RuntimeIterator toInsertIterator;
+    private final RuntimeIterator positionIterator;
 
     public InsertExpressionIterator(
             RuntimeIterator mainIterator,

--- a/src/main/java/org/rumbledb/runtime/update/expression/InsertSearchIntoCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/InsertSearchIntoCollectionIterator.java
@@ -25,7 +25,7 @@ public class InsertSearchIntoCollectionIterator extends HybridRuntimeIterator {
     private static final long serialVersionUID = 1L;
     private final RuntimeIterator targetIterator;
     private final RuntimeIterator contentIterator;
-    private boolean isBefore;
+    private final boolean isBefore;
 
     public InsertSearchIntoCollectionIterator(
             RuntimeIterator targetIterator,

--- a/src/main/java/org/rumbledb/runtime/update/expression/RenameExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/RenameExpressionIterator.java
@@ -24,9 +24,9 @@ public class RenameExpressionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator mainIterator;
-    private RuntimeIterator locatorIterator;
-    private RuntimeIterator nameIterator;
+    private final RuntimeIterator mainIterator;
+    private final RuntimeIterator locatorIterator;
+    private final RuntimeIterator nameIterator;
 
     public RenameExpressionIterator(
             RuntimeIterator mainIterator,

--- a/src/main/java/org/rumbledb/runtime/update/expression/ReplaceExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/ReplaceExpressionIterator.java
@@ -28,9 +28,9 @@ public class ReplaceExpressionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator mainIterator;
-    private RuntimeIterator locatorIterator;
-    private RuntimeIterator replacerIterator;
+    private final RuntimeIterator mainIterator;
+    private final RuntimeIterator locatorIterator;
+    private final RuntimeIterator replacerIterator;
 
     public ReplaceExpressionIterator(
             RuntimeIterator mainIterator,

--- a/src/main/java/org/rumbledb/runtime/update/expression/TransformExpressionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/TransformExpressionIterator.java
@@ -19,12 +19,12 @@ public class TransformExpressionIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Map<Name, RuntimeIterator> copyDeclMap;
-    private RuntimeIterator modifyIterator;
-    private RuntimeIterator returnIterator;
-    private boolean mutable;
+    private final Map<Name, RuntimeIterator> copyDeclMap;
+    private final RuntimeIterator modifyIterator;
+    private final RuntimeIterator returnIterator;
+    private final boolean mutable;
 
-    private int mutabilityLevel;
+    private final int mutabilityLevel;
 
     public TransformExpressionIterator(
             Map<Name, RuntimeIterator> copyDeclMap,

--- a/src/main/java/org/rumbledb/runtime/update/expression/TruncateCollectionIterator.java
+++ b/src/main/java/org/rumbledb/runtime/update/expression/TruncateCollectionIterator.java
@@ -26,7 +26,7 @@ public class TruncateCollectionIterator extends HybridRuntimeIterator {
     @Serial
     private static final long serialVersionUID = 1L;
     private final RuntimeIterator targetIterator;
-    private Mode mode;
+    private final Mode mode;
 
     public TruncateCollectionIterator(
             RuntimeIterator targetIterator,

--- a/src/main/java/org/rumbledb/runtime/update/primitives/Collection.java
+++ b/src/main/java/org/rumbledb/runtime/update/primitives/Collection.java
@@ -11,7 +11,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 public class Collection implements Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
-    private Mode mode;
+    private final Mode mode;
     private String logicalName;
     private String physicalName;
 

--- a/src/main/java/org/rumbledb/runtime/update/primitives/DeleteTupleFromCollectionPrimitive.java
+++ b/src/main/java/org/rumbledb/runtime/update/primitives/DeleteTupleFromCollectionPrimitive.java
@@ -6,8 +6,8 @@ import org.apache.spark.sql.SparkSession;
 
 
 public class DeleteTupleFromCollectionPrimitive implements UpdatePrimitive {
-    private Collection collection;
-    private double rowOrder;
+    private final Collection collection;
+    private final double rowOrder;
     @SuppressWarnings("unused")
     private ExceptionMetadata metadata;
 

--- a/src/main/java/org/rumbledb/runtime/update/primitives/EditTuplePrimitive.java
+++ b/src/main/java/org/rumbledb/runtime/update/primitives/EditTuplePrimitive.java
@@ -11,7 +11,7 @@ import static org.apache.spark.sql.functions.lit;
 
 
 public class EditTuplePrimitive implements UpdatePrimitive {
-    private Item target;
+    private final Item target;
     private Dataset<Row> contents;
     // private Row targetRow;
     private final Collection collection;

--- a/src/main/java/org/rumbledb/runtime/update/primitives/TruncateCollectionPrimitive.java
+++ b/src/main/java/org/rumbledb/runtime/update/primitives/TruncateCollectionPrimitive.java
@@ -13,8 +13,8 @@ import org.apache.spark.sql.SparkSession;
 
 public class TruncateCollectionPrimitive implements UpdatePrimitive {
     private final Collection collection;
-    private ExceptionMetadata metadata;
-    private RumbleRuntimeConfiguration configuration;
+    private final ExceptionMetadata metadata;
+    private final RumbleRuntimeConfiguration configuration;
 
     public TruncateCollectionPrimitive(
             Collection collection,

--- a/src/main/java/org/rumbledb/runtime/xml/AttributeNodeContentRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/AttributeNodeContentRuntimeIterator.java
@@ -37,7 +37,7 @@ public class AttributeNodeContentRuntimeIterator extends AtMostOneItemLocalRunti
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Item item;
+    private final Item item;
 
     public AttributeNodeContentRuntimeIterator(String content, RuntimeStaticContext staticContext) {
         super(null, staticContext);

--- a/src/main/java/org/rumbledb/runtime/xml/AttributeNodeRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/AttributeNodeRuntimeIterator.java
@@ -42,8 +42,8 @@ public class AttributeNodeRuntimeIterator extends AtMostOneItemLocalRuntimeItera
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name attributeName;
-    private List<DataFunctionIterator> atomizedValues;
+    private final Name attributeName;
+    private final List<DataFunctionIterator> atomizedValues;
 
     public AttributeNodeRuntimeIterator(
             Name attributeName,

--- a/src/main/java/org/rumbledb/runtime/xml/ComputedAttributeConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/ComputedAttributeConstructorRuntimeIterator.java
@@ -47,9 +47,9 @@ public class ComputedAttributeConstructorRuntimeIterator extends AtMostOneItemLo
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name staticAttributeName;
-    private DataFunctionIterator nameIterator;
-    private DataFunctionIterator contentExpression;
+    private final Name staticAttributeName;
+    private final DataFunctionIterator nameIterator;
+    private final DataFunctionIterator contentExpression;
 
     /**
      * Constructor for static attribute name: attribute attributeName { value }

--- a/src/main/java/org/rumbledb/runtime/xml/ComputedElementConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/ComputedElementConstructorRuntimeIterator.java
@@ -52,9 +52,9 @@ public class ComputedElementConstructorRuntimeIterator extends AtMostOneItemLoca
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name staticElementName;
-    private DataFunctionIterator nameIterator;
-    private RuntimeIterator contentIterator;
+    private final Name staticElementName;
+    private final DataFunctionIterator nameIterator;
+    private final RuntimeIterator contentIterator;
 
     /**
      * Constructor for static element name: element elementName { content }

--- a/src/main/java/org/rumbledb/runtime/xml/ComputedNamespaceConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/ComputedNamespaceConstructorRuntimeIterator.java
@@ -48,9 +48,9 @@ public class ComputedNamespaceConstructorRuntimeIterator extends AtMostOneItemLo
     @Serial
     private static final long serialVersionUID = 1L;
     private static final Pattern NCNAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9._-]*");
-    private String staticPrefix;
-    private DataFunctionIterator prefixIterator;
-    private DataFunctionIterator uriIterator;
+    private final String staticPrefix;
+    private final DataFunctionIterator prefixIterator;
+    private final DataFunctionIterator uriIterator;
 
     /**
      * Constructor for static prefix: namespace prefix { uri }

--- a/src/main/java/org/rumbledb/runtime/xml/DirElemConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/DirElemConstructorRuntimeIterator.java
@@ -48,10 +48,10 @@ public class DirElemConstructorRuntimeIterator extends AtMostOneItemLocalRuntime
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private Name elementName;
-    private List<RuntimeIterator> content;
-    private List<AttributeNodeRuntimeIterator> attributes;
-    private List<NamespaceDeclaration> namespaceDeclarations;
+    private final Name elementName;
+    private final List<RuntimeIterator> content;
+    private final List<AttributeNodeRuntimeIterator> attributes;
+    private final List<NamespaceDeclaration> namespaceDeclarations;
 
     public DirElemConstructorRuntimeIterator(
             Name elementName,

--- a/src/main/java/org/rumbledb/runtime/xml/DocumentNodeConstructorRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/DocumentNodeConstructorRuntimeIterator.java
@@ -47,7 +47,7 @@ public class DocumentNodeConstructorRuntimeIterator extends AtMostOneItemLocalRu
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator contentIterator;
+    private final RuntimeIterator contentIterator;
 
     /**
      * Constructor for document node constructor runtime iterator

--- a/src/main/java/org/rumbledb/runtime/xml/PostfixLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/PostfixLookupIterator.java
@@ -46,11 +46,11 @@ public class PostfixLookupIterator extends HybridRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private RuntimeIterator iterator;
+    private final RuntimeIterator iterator;
     private final RuntimeIterator lookupIterator;
     private List<Item> lookupKeys;
-    private Queue<Item> nextResult;
-    private boolean wildcard;
+    private final Queue<Item> nextResult;
+    private final boolean wildcard;
 
     public PostfixLookupIterator(
             RuntimeIterator object,

--- a/src/main/java/org/rumbledb/runtime/xml/SlashExprIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/SlashExprIterator.java
@@ -45,8 +45,8 @@ public class SlashExprIterator extends HybridRuntimeIterator {
         Item::getXmlDocumentPosition,
         Comparator.nullsLast(Comparator.naturalOrder())
     );
-    private RuntimeIterator leftIterator;
-    private RuntimeIterator rightIterator;
+    private final RuntimeIterator leftIterator;
+    private final RuntimeIterator rightIterator;
     private List<Item> results = null;
     private int nextResultCounter = 0;
     private Item nextResult;

--- a/src/main/java/org/rumbledb/runtime/xml/TextNodeRuntimeIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/TextNodeRuntimeIterator.java
@@ -38,7 +38,7 @@ public class TextNodeRuntimeIterator extends AtMostOneItemLocalRuntimeIterator {
     @Serial
     private static final long serialVersionUID = 1L;
     /** The string content of the text node */
-    private String content;
+    private final String content;
 
     /**
      * Constructor for text node runtime iterator.

--- a/src/main/java/org/rumbledb/runtime/xml/UnaryLookupIterator.java
+++ b/src/main/java/org/rumbledb/runtime/xml/UnaryLookupIterator.java
@@ -46,8 +46,8 @@ public class UnaryLookupIterator extends LocalRuntimeIterator {
     private final RuntimeIterator lookupIterator;
     private List<Item> lookupKeys;
     private List<Item> contextItem;
-    private Queue<Item> nextResult;
-    private boolean wildcard;
+    private final Queue<Item> nextResult;
+    private final boolean wildcard;
 
     public UnaryLookupIterator(
             RuntimeIterator lookupIterator,

--- a/src/main/java/org/rumbledb/server/RumbleHttpHandler.java
+++ b/src/main/java/org/rumbledb/server/RumbleHttpHandler.java
@@ -28,14 +28,14 @@ import com.sun.net.httpserver.HttpHandler;
 
 public class RumbleHttpHandler implements HttpHandler {
 
-    private RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
+    private final RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
 
     private enum StatusCode {
         SUCCESS(200),
         METHOD_NOT_SUPPORTED(405),
         SERVER_ERROR(500);
 
-        private int code;
+        private final int code;
 
         StatusCode(int code) {
             this.code = code;

--- a/src/main/java/org/rumbledb/server/RumbleServer.java
+++ b/src/main/java/org/rumbledb/server/RumbleServer.java
@@ -12,7 +12,7 @@ import com.sun.net.httpserver.HttpServer;
 
 public class RumbleServer {
 
-    private RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
+    private final RumbleRuntimeConfiguration rumbleRuntimeConfiguration;
 
     public RumbleServer(RumbleRuntimeConfiguration rumbleRuntimeConfiguration) {
         this.rumbleRuntimeConfiguration = rumbleRuntimeConfiguration;

--- a/src/main/java/org/rumbledb/types/ConstrainingFacetTypes.java
+++ b/src/main/java/org/rumbledb/types/ConstrainingFacetTypes.java
@@ -29,7 +29,7 @@ public enum ConstrainingFacetTypes {
     METADATA("metadata"),
     CONSTRAINTS("constraints");
 
-    private String facetName;
+    private final String facetName;
 
     ConstrainingFacetTypes(String facetName) {
         this.facetName = facetName;

--- a/src/main/java/org/rumbledb/types/FunctionItemType.java
+++ b/src/main/java/org/rumbledb/types/FunctionItemType.java
@@ -15,7 +15,7 @@ public class FunctionItemType implements ItemType {
     private final boolean isGeneric;
     private final FunctionSignature signature;
 
-    static FunctionItemType anyFunctionItem = new FunctionItemType(true);
+    static final FunctionItemType anyFunctionItem = new FunctionItemType(true);
 
     FunctionItemType(FunctionSignature signature) {
         if (signature == null) {

--- a/src/main/java/org/rumbledb/types/FundamentalFacetTypes.java
+++ b/src/main/java/org/rumbledb/types/FundamentalFacetTypes.java
@@ -14,7 +14,7 @@ public enum FundamentalFacetTypes {
     CARDINALITY("cardinality"),
     NUMERIC("numeric");
 
-    private String facetName;
+    private final String facetName;
 
     FundamentalFacetTypes(String facetName) {
         this.facetName = facetName;

--- a/src/main/java/org/rumbledb/types/ItemItemType.java
+++ b/src/main/java/org/rumbledb/types/ItemItemType.java
@@ -15,7 +15,7 @@ public class ItemItemType implements ItemType {
     private static final long serialVersionUID = 1L;
 
     static final ItemType item = new ItemItemType();
-    private Name name;
+    private final Name name;
 
     public ItemItemType() {
         this.name = Name.createVariableInDefaultTypeNamespace("item");

--- a/src/main/java/org/rumbledb/types/UnionItemType.java
+++ b/src/main/java/org/rumbledb/types/UnionItemType.java
@@ -18,15 +18,15 @@ public class UnionItemType implements ItemType {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    private static Set<ConstrainingFacetTypes> allowedFacets = new HashSet<>(
+    private static final Set<ConstrainingFacetTypes> allowedFacets = new HashSet<>(
             Arrays.asList(ConstrainingFacetTypes.CONTENT)
     );
 
-    private Name name;
-    private ItemType baseType;
-    private int typeTreeDepth;
-    private List<ItemType> types;
-    private boolean userDefined;
+    private final Name name;
+    private final ItemType baseType;
+    private final int typeTreeDepth;
+    private final List<ItemType> types;
+    private final boolean userDefined;
 
     UnionItemType(Name name, ItemType baseType, List<ItemType> types) {
         this(name, baseType, types, true);

--- a/src/main/java/sparksoniq/io/validation/OutputValidator.java
+++ b/src/main/java/sparksoniq/io/validation/OutputValidator.java
@@ -33,11 +33,12 @@ import java.util.Comparator;
 import java.util.List;
 
 public class OutputValidator {
-    private static String ZORBA_FILE_PATH = // "/home/stefan/Work/ETH/Thesis/benchmarks/validation/zorba-results/conf1";
+    private static final String ZORBA_FILE_PATH = // "/home/stefan/Work/ETH/Thesis/benchmarks/validation/zorba-results/conf1";
         "/home/stefan/Desktop/media_sdb1/Scoala/ETH/Big_Data/validation/zorba-results/where1Zorba";
     // private static String SPARK_OUTPUT_DIR =
     // "/home/stefan/Work/ETH/Thesis/benchmarks/validation/output-where/output-where-confusion1/output/";
-    private static String SPARK_OUTPUT_DIR = "/home/stefan/Desktop/media_sdb1/Scoala/ETH/Big_Data/validation/output/";
+    private static final String SPARK_OUTPUT_DIR =
+        "/home/stefan/Desktop/media_sdb1/Scoala/ETH/Big_Data/validation/output/";
 
     public static void main(String[] args) throws IOException {
         File sparkDir = new File(SPARK_OUTPUT_DIR);

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 public class FlworKey {
 
-    private List<Item> keyItems;
+    private final List<Item> keyItems;
 
     public FlworKey(List<Item> contents) {
         this.keyItems = new ArrayList<>();

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKeyComparator.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKeyComparator.java
@@ -33,7 +33,7 @@ public class FlworKeyComparator implements Comparator<FlworKey>, Serializable {
     @Serial
     private static final long serialVersionUID = 1L;
     private final List<OrderByClauseAnnotatedChildIterator> expressions;
-    private ExceptionMetadata metadata;
+    private final ExceptionMetadata metadata;
 
     public FlworKeyComparator(
             List<OrderByClauseAnnotatedChildIterator> expressions,

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
@@ -42,9 +42,9 @@ public class FlworTuple implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private LinkedHashMap<Name, List<Item>> localVariables;
-    private LinkedHashMap<Name, JavaRDD<Item>> rddVariables;
-    private LinkedHashMap<Name, JSoundDataFrame> dataFrameVariables;
+    private final LinkedHashMap<Name, List<Item>> localVariables;
+    private final LinkedHashMap<Name, JavaRDD<Item>> rddVariables;
+    private final LinkedHashMap<Name, JSoundDataFrame> dataFrameVariables;
     private RumbleRuntimeConfiguration configuration;
 
     public FlworTuple() {

--- a/src/main/java/sparksoniq/spark/ml/ApplyEstimatorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/ApplyEstimatorRuntimeIterator.java
@@ -41,8 +41,8 @@ public class ApplyEstimatorRuntimeIterator extends AtMostOneItemLocalRuntimeIter
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private String estimatorShortName;
-    private Estimator<?> estimator;
+    private final String estimatorShortName;
+    private final Estimator<?> estimator;
 
     private JSoundDataFrame inputDataset;
     private Item paramMapItem;

--- a/src/main/java/sparksoniq/spark/ml/ApplyTransformerRuntimeIterator.java
+++ b/src/main/java/sparksoniq/spark/ml/ApplyTransformerRuntimeIterator.java
@@ -34,12 +34,12 @@ public class ApplyTransformerRuntimeIterator extends DataFrameRuntimeIterator {
 
     @Serial
     private static final long serialVersionUID = 1L;
-    private String transformerShortName;
-    private Transformer transformer;
+    private final String transformerShortName;
+    private final Transformer transformer;
 
     private JSoundDataFrame inputDataset;
     private Item paramMapItem;
-    private List<String> columnNamesOfGeneratedVectors = new ArrayList<>();
+    private final List<String> columnNamesOfGeneratedVectors = new ArrayList<>();
 
     public ApplyTransformerRuntimeIterator(
             String transformerShortName,


### PR DESCRIPTION
More code safety. This is just a quick refactor done by IntelliJ. It does not cover all fields, because there might be setter methods that are actually unused.