### PR TITLE
Optimize MapWithAdditionalEntryItem by saving current map size and chain length

### DIFF
--- a/src/main/java/org/rumbledb/items/ItemFactory.java
+++ b/src/main/java/org/rumbledb/items/ItemFactory.java
@@ -370,6 +370,7 @@ public class ItemFactory {
             Item original,
             List<Item> keysToRemove
     ) {
+        original = rebaseDeepMapOverlay(original);
         return new MapWithRemovedEntryItem(original, keysToRemove);
     }
 
@@ -378,18 +379,30 @@ public class ItemFactory {
             Item keyToAdd,
             List<Item> valueToAdd
     ) {
-        if (
-            original instanceof MapWithAdditionalEntryItem mapWithAdditionalEntry
-                && mapWithAdditionalEntry.getChainLength() >= MapWithAdditionalEntryItem.MAX_CHAIN_LENGTH
-        ) {
-            original = createMapItem(
-                original.getItemKeys(),
-                original.getSequenceValues(),
-                ExceptionMetadata.EMPTY_METADATA,
-                false
-            );
-        }
+        original = rebaseDeepMapOverlay(original);
         return new MapWithAdditionalEntryItem(original, keyToAdd, valueToAdd);
+    }
+
+    static int getMapOverlayChainLength(Item item) {
+        if (item instanceof MapWithAdditionalEntryItem additionalEntry) {
+            return additionalEntry.getOverlayChainLength();
+        }
+        if (item instanceof MapWithRemovedEntryItem removedEntry) {
+            return removedEntry.getOverlayChainLength();
+        }
+        return 0;
+    }
+
+    private Item rebaseDeepMapOverlay(Item original) {
+        if (getMapOverlayChainLength(original) < MapWithAdditionalEntryItem.MAX_OVERLAY_CHAIN_LENGTH) {
+            return original;
+        }
+        return createMapItem(
+            original.getItemKeys(),
+            original.getSequenceValues(),
+            ExceptionMetadata.EMPTY_METADATA,
+            false
+        );
     }
 
     public Item createMapItem(

--- a/src/main/java/org/rumbledb/items/ItemFactory.java
+++ b/src/main/java/org/rumbledb/items/ItemFactory.java
@@ -378,6 +378,17 @@ public class ItemFactory {
             Item keyToAdd,
             List<Item> valueToAdd
     ) {
+        if (
+            original instanceof MapWithAdditionalEntryItem mapWithAdditionalEntry
+                && mapWithAdditionalEntry.getChainLength() >= MapWithAdditionalEntryItem.MAX_CHAIN_LENGTH
+        ) {
+            original = createMapItem(
+                original.getItemKeys(),
+                original.getSequenceValues(),
+                ExceptionMetadata.EMPTY_METADATA,
+                false
+            );
+        }
         return new MapWithAdditionalEntryItem(original, keyToAdd, valueToAdd);
     }
 

--- a/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
@@ -38,17 +38,29 @@ public class MapWithAdditionalEntryItem extends AbstractMapItem {
     @Serial
     private static final long serialVersionUID = 1L;
 
+    static final int MAX_CHAIN_LENGTH = 32;
+
     /**
      * This is an optimization version of maps when there is exactly one key-value pair.
      */
     private final Item original;
     private final Item additionalKey;
     private final List<Item> additionalValue;
+    private final int size;
+    private final int chainLength;
 
     public MapWithAdditionalEntryItem(Item original, Item additionalKey, List<Item> additionalValue) {
         this.original = original;
         this.additionalKey = additionalKey;
         this.additionalValue = additionalValue;
+        this.size = original.getSize() + (original.hasKey(additionalKey) ? 0 : 1);
+        this.chainLength = original instanceof MapWithAdditionalEntryItem mapWithAdditionalEntry
+            ? mapWithAdditionalEntry.chainLength + 1
+            : 1;
+    }
+
+    int getChainLength() {
+        return this.chainLength;
     }
 
     @Override
@@ -114,10 +126,7 @@ public class MapWithAdditionalEntryItem extends AbstractMapItem {
 
     @Override
     public int getSize() {
-        if (this.original.hasKey(this.additionalKey)) {
-            return this.original.getSize();
-        }
-        return this.original.getSize() + 1;
+        return this.size;
     }
 
     @Override

--- a/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithAdditionalEntryItem.java
@@ -38,7 +38,7 @@ public class MapWithAdditionalEntryItem extends AbstractMapItem {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    static final int MAX_CHAIN_LENGTH = 32;
+    static final int MAX_OVERLAY_CHAIN_LENGTH = 32;
 
     /**
      * This is an optimization version of maps when there is exactly one key-value pair.
@@ -54,12 +54,10 @@ public class MapWithAdditionalEntryItem extends AbstractMapItem {
         this.additionalKey = additionalKey;
         this.additionalValue = additionalValue;
         this.size = original.getSize() + (original.hasKey(additionalKey) ? 0 : 1);
-        this.chainLength = original instanceof MapWithAdditionalEntryItem mapWithAdditionalEntry
-            ? mapWithAdditionalEntry.chainLength + 1
-            : 1;
+        this.chainLength = ItemFactory.getMapOverlayChainLength(original) + 1;
     }
 
-    int getChainLength() {
+    int getOverlayChainLength() {
         return this.chainLength;
     }
 

--- a/src/main/java/org/rumbledb/items/MapWithRemovedEntryItem.java
+++ b/src/main/java/org/rumbledb/items/MapWithRemovedEntryItem.java
@@ -46,9 +46,11 @@ public class MapWithRemovedEntryItem extends AbstractMapItem {
      */
     private final Item original;
     private final Set<Item> removedKeys;
+    private final int chainLength;
 
     public MapWithRemovedEntryItem(Item original, List<Item> removedKeys) {
         this.original = original;
+        this.chainLength = ItemFactory.getMapOverlayChainLength(original) + 1;
         this.removedKeys = new HashSet<>();
         for (Item key : removedKeys) {
             if (this.original.isObject()) {
@@ -64,6 +66,10 @@ public class MapWithRemovedEntryItem extends AbstractMapItem {
                 }
             }
         }
+    }
+
+    int getOverlayChainLength() {
+        return this.chainLength;
     }
 
     @Override


### PR DESCRIPTION
This avoids calling `hasKey` method every time when `getSize` is invoked. Because the map is immutable. 

Also, a compact threashold is added: when the length of MapWithAdditionalEntryItem / MapWithRemovedEntryItem exceeds MAX_OVERLAY_CHAIN_LENGTH, a new normal MapItem is created with original keys and values.