### PR TITLE
Add `varBinding` rule to grammar 

### DIFF
--- a/.github/workflows/run-qt3.yml
+++ b/.github/workflows/run-qt3.yml
@@ -104,7 +104,7 @@ jobs:
 
   qt3-jsoniq:
     needs: [resolve-baseline, build]
-    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@master
+    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@jimmy/varbinding
     with:
       tested_parser: jsoniq
       rumble_artifact_name: rumble-build
@@ -112,7 +112,7 @@ jobs:
 
   qt3-xquery:
     needs: [resolve-baseline, build]
-    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@master
+    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@jimmy/varbinding
     with:
       tested_parser: xquery
       rumble_artifact_name: rumble-build

--- a/.github/workflows/run-qt3.yml
+++ b/.github/workflows/run-qt3.yml
@@ -104,7 +104,7 @@ jobs:
 
   qt3-jsoniq:
     needs: [resolve-baseline, build]
-    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@jimmy/varbinding
+    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@master
     with:
       tested_parser: jsoniq
       rumble_artifact_name: rumble-build
@@ -112,7 +112,7 @@ jobs:
 
   qt3-xquery:
     needs: [resolve-baseline, build]
-    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@jimmy/varbinding
+    uses: RumbleDB/rumble-test-suite/.github/workflows/qt3-suite.yml@master
     with:
       tested_parser: xquery
       rumble_artifact_name: rumble-build

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -801,7 +801,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         SequenceType paramType;
         if (ctx.paramList() != null) {
             for (JsoniqParser.ParamContext param : ctx.paramList().param()) {
-                paramName = parseName(param.qname(), false, false, false, false);
+                paramName = parseVariableBinding(param.name);
                 paramType = SequenceType.createSequenceType("item*");
                 if (fnParams.containsKey(paramName)) {
                     throw new DuplicateParamNameException(
@@ -1077,14 +1077,14 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     public Node visitForVar(JsoniqParser.ForVarContext ctx) {
         SequenceType seq = null;
         boolean emptyFlag;
-        Name var = ((VariableReferenceExpression) this.visitVarRef(ctx.var_ref)).getVariableName();
+        Name var = parseVariableBinding(ctx.var_ref);
         if (ctx.seq != null) {
             seq = this.processSequenceType(ctx.seq);
         }
         emptyFlag = (ctx.flag != null);
         Name atVar = null;
         if (ctx.at != null) {
-            atVar = ((VariableReferenceExpression) this.visitVarRef(ctx.at)).getVariableName();
+            atVar = parseVariableBinding(ctx.at);
             if (atVar.equals(var)) {
                 throw new PositionalVariableNameSameAsForVariableException(
                         "Positional variable " + var + " cannot have the same name as the main for variable.",
@@ -1125,7 +1125,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     @Override
     public Node visitLetVar(JsoniqParser.LetVarContext ctx) {
         SequenceType seq = null;
-        Name var = ((VariableReferenceExpression) this.visitVarRef(ctx.var_ref)).getVariableName();
+        Name var = parseVariableBinding(ctx.var_ref);
         if (ctx.seq != null) {
             seq = this.processSequenceType(ctx.seq);
         }
@@ -1147,7 +1147,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     @Override
     public Node visitTumblingWindowClause(JsoniqParser.TumblingWindowClauseContext ctx) {
-        Name windowVariable = parseEqName(ctx.varName().eqName(), false, false, false, false);
+        Name windowVariable = parseVariableBinding(ctx.name);
         SequenceType type = ctx.type == null ? null : processSequenceType(ctx.type.sequenceType());
         Expression expression = (Expression) visitExprSingle(ctx.exprSingle());
         WindowClause.WindowCondition start = buildWindowStartCondition(ctx.windowStartCondition());
@@ -1168,7 +1168,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     @Override
     public Node visitSlidingWindowClause(JsoniqParser.SlidingWindowClauseContext ctx) {
-        Name windowVariable = parseEqName(ctx.varName().eqName(), false, false, false, false);
+        Name windowVariable = parseVariableBinding(ctx.name);
         SequenceType type = ctx.type == null ? null : processSequenceType(ctx.type.sequenceType());
         Expression expression = (Expression) visitExprSingle(ctx.exprSingle());
         WindowClause.WindowCondition start = buildWindowStartCondition(ctx.windowStartCondition());
@@ -1202,12 +1202,12 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     }
 
     private WindowClause.WindowVars buildWindowVars(JsoniqParser.WindowVarsContext ctx) {
-        Name current = ctx.currentItem == null ? null : parseEqName(ctx.currentItem, false, false, false, false);
+        Name current = ctx.currentItem == null ? null : parseVariableBinding(ctx.currentItem);
         Name position = ctx.positionalVar() == null
             ? null
-            : parseEqName(ctx.positionalVar().pvar.eqName(), false, false, false, false);
-        Name previous = ctx.previousItem == null ? null : parseEqName(ctx.previousItem, false, false, false, false);
-        Name next = ctx.nextItem == null ? null : parseEqName(ctx.nextItem, false, false, false, false);
+            : parseVariableBinding(ctx.positionalVar().pvar);
+        Name previous = ctx.previousItem == null ? null : parseVariableBinding(ctx.previousItem);
+        Name next = ctx.nextItem == null ? null : parseVariableBinding(ctx.nextItem);
         return new WindowClause.WindowVars(current, position, previous, next);
     }
 
@@ -1302,7 +1302,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         }
         SequenceType seq = null;
         Expression expr = null;
-        Name var = ((VariableReferenceExpression) this.visitVarRef(ctx.var_ref)).getVariableName();
+        Name var = parseVariableBinding(ctx.var_ref);
 
         if (ctx.seq != null) {
             seq = this.processSequenceType(ctx.seq);
@@ -1324,8 +1324,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     @Override
     public Node visitCountClause(JsoniqParser.CountClauseContext ctx) {
-        VariableReferenceExpression child = (VariableReferenceExpression) this.visitVarRef(ctx.varRef());
-        return new CountClause(child.getVariableName(), createMetadataFromContext(ctx));
+        return new CountClause(parseVariableBinding(ctx.varBinding()), createMetadataFromContext(ctx));
     }
     // endregion
 
@@ -1846,7 +1845,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         List<CopyDeclaration> copyDecls = ctx.copyDecl()
             .stream()
             .map(copyDeclCtx -> {
-                Name var = ((VariableReferenceExpression) this.visitVarRef(copyDeclCtx.var_ref)).getVariableName();
+                Name var = parseVariableBinding(copyDeclCtx.var_ref);
                 Expression expr = (Expression) this.visitExprSingle(copyDeclCtx.src_expr);
                 return new CopyDeclaration(var, expr);
             })
@@ -2658,8 +2657,22 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     @Override
     public Node visitVarRef(JsoniqParser.VarRefContext ctx) {
-        Name name = parseEqName(ctx.eqName(), false, false, false, false);
-        return new VariableReferenceExpression(name, createMetadataFromContext(ctx));
+        return new VariableReferenceExpression(
+                parseVariableReference(ctx),
+                createMetadataFromContext(ctx)
+        );
+    }
+
+    private Name parseVariableReference(JsoniqParser.VarRefContext ctx) {
+        return parseVariableName(ctx.eqName());
+    }
+
+    private Name parseVariableBinding(JsoniqParser.VarBindingContext ctx) {
+        return parseVariableName(ctx.eqName());
+    }
+
+    private Name parseVariableName(JsoniqParser.EqNameContext ctx) {
+        return parseEqName(ctx, false, false, false, false);
     }
 
     @Override
@@ -2959,7 +2972,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         SequenceType paramType;
         if (ctx.paramList() != null) {
             for (JsoniqParser.ParamContext param : ctx.paramList().param()) {
-                paramName = parseName(param.qname(), false, false, false, false);
+                paramName = parseVariableBinding(param.name);
                 paramType = SequenceType.createSequenceType("item*");
                 if (fnParams.containsKey(paramName)) {
                     throw new DuplicateParamNameException(
@@ -3035,9 +3048,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
             List<SequenceType> union = new ArrayList<>();
             Name variableName = null;
             if (expr.var_ref != null) {
-                variableName = ((VariableReferenceExpression) this.visitVarRef(
-                    expr.var_ref
-                )).getVariableName();
+                variableName = parseVariableBinding(expr.var_ref);
             }
             if (expr.union != null && !expr.union.isEmpty()) {
                 for (JsoniqParser.SequenceTypeContext sequenceType : expr.union) {
@@ -3055,9 +3066,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         }
         Name defaultVariableName = null;
         if (ctx.var_ref != null) {
-            defaultVariableName = ((VariableReferenceExpression) this.visitVarRef(
-                ctx.var_ref
-            )).getVariableName();
+            defaultVariableName = parseVariableBinding(ctx.var_ref);
         }
         Expression defaultCase = (Expression) this.visitExprSingle(ctx.def);
         return new TypeSwitchExpression(
@@ -3081,9 +3090,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         for (JsoniqParser.QuantifiedExprVarContext currentVariable : ctx.vars) {
             Expression varExpression;
             SequenceType sequenceType = null;
-            Name variableName = ((VariableReferenceExpression) this.visitVarRef(
-                currentVariable.varRef()
-            )).getVariableName();
+            Name variableName = parseVariableBinding(currentVariable.varBinding());
             if (currentVariable.sequenceType() != null) {
                 sequenceType = this.processSequenceType(currentVariable.sequenceType());
             }
@@ -3211,7 +3218,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         List<Annotation> annotations = processAnnotations(ctx.annotations());
         SequenceType seq = null;
         boolean external;
-        Name var = ((VariableReferenceExpression) this.visitVarRef(ctx.varRef())).getVariableName();
+        Name var = parseVariableBinding(ctx.varBinding());
         if (ctx.sequenceType() != null) {
             seq = this.processSequenceType(ctx.sequenceType());
         }
@@ -3335,7 +3342,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
 
     @Override
     public Node visitAssignStatement(JsoniqParser.AssignStatementContext ctx) {
-        Name paramName = parseEqName(ctx.varName().eqName(), false, false, false, false);
+        Name paramName = parseVariableReference(ctx.var_ref);
         Expression exprSingle = (Expression) this.visitExprSingle(ctx.exprSingle());
         return new AssignStatement(exprSingle, paramName, createMetadataFromContext(ctx));
     }
@@ -3539,7 +3546,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
             List<SequenceType> union = new ArrayList<>();
             Name variableName = null;
             if (stmt.var_ref != null) {
-                variableName = ((VariableReferenceExpression) this.visitVarRef(stmt.var_ref)).getVariableName();
+                variableName = parseVariableBinding(stmt.var_ref);
             }
             if (stmt.union != null && !stmt.union.isEmpty()) {
                 stmt.union.forEach(sequenceTypeContext -> {
@@ -3551,7 +3558,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         }
         Name defaultVariableName = null;
         if (ctx.var_ref != null) {
-            defaultVariableName = ((VariableReferenceExpression) this.visitVarRef(ctx.var_ref)).getVariableName();
+            defaultVariableName = parseVariableBinding(ctx.var_ref);
         }
         Statement defaultStatement = (Statement) this.visitStatement(ctx.def);
         return new TypeSwitchStatement(
@@ -3582,7 +3589,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
         List<VariableDeclStatement> variables = new ArrayList<>();
         for (JsoniqParser.VarDeclForStatementContext varDecl : ctx.varDeclForStatement()) {
             SequenceType seq = null;
-            Name var = ((VariableReferenceExpression) this.visitVarRef(varDecl.var_ref)).getVariableName();
+            Name var = parseVariableBinding(varDecl.var_ref);
             Expression exprSingle = null;
 
             if (varDecl.sequenceType() != null) {

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -787,7 +787,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         SequenceType paramType;
         if (ctx.paramList() != null) {
             for (XQueryParser.ParamContext param : ctx.paramList().param()) {
-                paramName = parseName(param.qname(), false, false, false, false);
+                paramName = parseVariableBinding(param.name);
                 paramType = createSequenceType("item*");
                 if (fnParams.containsKey(paramName)) {
                     throw new DuplicateParamNameException(
@@ -987,14 +987,14 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     public Node visitForVar(XQueryParser.ForVarContext ctx) {
         SequenceType seq = null;
         boolean emptyFlag;
-        Name var = ((VariableReferenceExpression) this.visitVarRef(ctx.var_ref)).getVariableName();
+        Name var = parseVariableBinding(ctx.var_ref);
         if (ctx.seq != null) {
             seq = this.processSequenceType(ctx.seq);
         }
         emptyFlag = (ctx.flag != null);
         Name atVar = null;
         if (ctx.at != null) {
-            atVar = ((VariableReferenceExpression) this.visitVarRef(ctx.at)).getVariableName();
+            atVar = parseVariableBinding(ctx.at);
             if (atVar.equals(var)) {
                 throw new PositionalVariableNameSameAsForVariableException(
                         "Positional variable " + var + " cannot have the same name as the main for variable.",
@@ -1035,7 +1035,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     @Override
     public Node visitLetVar(XQueryParser.LetVarContext ctx) {
         SequenceType seq = null;
-        Name var = ((VariableReferenceExpression) this.visitVarRef(ctx.var_ref)).getVariableName();
+        Name var = parseVariableBinding(ctx.var_ref);
         if (ctx.seq != null) {
             seq = this.processSequenceType(ctx.seq);
         }
@@ -1058,7 +1058,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
 
     @Override
     public Node visitTumblingWindowClause(XQueryParser.TumblingWindowClauseContext ctx) {
-        Name windowVariable = parseEqName(ctx.varName().eqName(), false, false, false, false);
+        Name windowVariable = parseVariableBinding(ctx.name);
         SequenceType sequenceType = ctx.type == null ? null : this.processSequenceType(ctx.type.sequenceType());
         Expression expression = (Expression) this.visitExprSingle(ctx.exprSingle());
         WindowClause.WindowCondition start = this.buildWindowStartCondition(ctx.windowStartCondition());
@@ -1079,7 +1079,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
 
     @Override
     public Node visitSlidingWindowClause(XQueryParser.SlidingWindowClauseContext ctx) {
-        Name windowVariable = parseEqName(ctx.varName().eqName(), false, false, false, false);
+        Name windowVariable = parseVariableBinding(ctx.name);
         SequenceType sequenceType = ctx.type == null ? null : this.processSequenceType(ctx.type.sequenceType());
         Expression expression = (Expression) this.visitExprSingle(ctx.exprSingle());
         WindowClause.WindowCondition start = this.buildWindowStartCondition(ctx.windowStartCondition());
@@ -1113,12 +1113,12 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     }
 
     private WindowClause.WindowVars buildWindowVars(XQueryParser.WindowVarsContext ctx) {
-        Name current = ctx.currentItem == null ? null : parseEqName(ctx.currentItem, false, false, false, false);
+        Name current = ctx.currentItem == null ? null : parseVariableBinding(ctx.currentItem);
         Name position = ctx.positionalVar() == null
             ? null
-            : parseEqName(ctx.positionalVar().pvar.eqName(), false, false, false, false);
-        Name previous = ctx.previousItem == null ? null : parseEqName(ctx.previousItem, false, false, false, false);
-        Name next = ctx.nextItem == null ? null : parseEqName(ctx.nextItem, false, false, false, false);
+            : parseVariableBinding(ctx.positionalVar().pvar);
+        Name previous = ctx.previousItem == null ? null : parseVariableBinding(ctx.previousItem);
+        Name next = ctx.nextItem == null ? null : parseVariableBinding(ctx.nextItem);
         return new WindowClause.WindowVars(current, position, previous, next);
     }
 
@@ -1215,7 +1215,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         }
         SequenceType seq = null;
         Expression expr = null;
-        Name var = ((VariableReferenceExpression) this.visitVarRef(ctx.var_ref)).getVariableName();
+        Name var = parseVariableBinding(ctx.var_ref);
 
         if (ctx.seq != null) {
             seq = this.processSequenceType(ctx.seq);
@@ -1237,8 +1237,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
 
     @Override
     public Node visitCountClause(XQueryParser.CountClauseContext ctx) {
-        VariableReferenceExpression child = (VariableReferenceExpression) this.visitVarRef(ctx.varRef());
-        return new CountClause(child.getVariableName(), createMetadataFromContext(ctx));
+        return new CountClause(parseVariableBinding(ctx.varBinding()), createMetadataFromContext(ctx));
     }
     // endregion
 
@@ -1757,7 +1756,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     // List<CopyDeclaration> copyDecls = ctx.copyDecl()
     // .stream()
     // .map(copyDeclCtx -> {
-    // Name var = ((VariableReferenceExpression) this.visitVarRef(copyDeclCtx.var_ref)).getVariableName();
+    // Name var = parseVariableBinding(copyDeclCtx.var_ref);
     // Expression expr = (Expression) this.visitExprSingle(copyDeclCtx.src_expr);
     // return new CopyDeclaration(var, expr);
     // })
@@ -2362,8 +2361,22 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
 
     @Override
     public Node visitVarRef(XQueryParser.VarRefContext ctx) {
-        Name name = parseEqName(ctx.eqName(), false, false, false, false);
-        return new VariableReferenceExpression(name, createMetadataFromContext(ctx));
+        return new VariableReferenceExpression(
+                parseVariableReference(ctx),
+                createMetadataFromContext(ctx)
+        );
+    }
+
+    private Name parseVariableReference(XQueryParser.VarRefContext ctx) {
+        return parseVariableName(ctx.eqName());
+    }
+
+    private Name parseVariableBinding(XQueryParser.VarBindingContext ctx) {
+        return parseVariableName(ctx.eqName());
+    }
+
+    private Name parseVariableName(XQueryParser.EqNameContext ctx) {
+        return parseEqName(ctx, false, false, false, false);
     }
 
     @Override
@@ -2659,7 +2672,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         SequenceType paramType;
         if (ctx.paramList() != null) {
             for (XQueryParser.ParamContext param : ctx.paramList().param()) {
-                paramName = parseName(param.qname(), false, false, false, false);
+                paramName = parseVariableBinding(param.name);
                 paramType = SequenceType.createSequenceType("item*");
                 if (fnParams.containsKey(paramName)) {
                     throw new DuplicateParamNameException(
@@ -2735,9 +2748,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
             List<SequenceType> union = new ArrayList<>();
             Name variableName = null;
             if (expr.var_ref != null) {
-                variableName = ((VariableReferenceExpression) this.visitVarRef(
-                    expr.var_ref
-                )).getVariableName();
+                variableName = parseVariableBinding(expr.var_ref);
             }
             if (expr.union != null && !expr.union.isEmpty()) {
                 for (XQueryParser.SequenceTypeContext sequenceType : expr.union) {
@@ -2755,9 +2766,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         }
         Name defaultVariableName = null;
         if (ctx.var_ref != null) {
-            defaultVariableName = ((VariableReferenceExpression) this.visitVarRef(
-                ctx.var_ref
-            )).getVariableName();
+            defaultVariableName = parseVariableBinding(ctx.var_ref);
         }
         Expression defaultCase = (Expression) this.visitExprSingle(ctx.def);
         return new TypeSwitchExpression(
@@ -2781,9 +2790,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         for (XQueryParser.QuantifiedExprVarContext currentVariable : ctx.vars) {
             Expression varExpression;
             SequenceType sequenceType = null;
-            Name variableName = ((VariableReferenceExpression) this.visitVarRef(
-                currentVariable.varRef()
-            )).getVariableName();
+            Name variableName = parseVariableBinding(currentVariable.varBinding());
             if (currentVariable.sequenceType() != null) {
                 sequenceType = this.processSequenceType(currentVariable.sequenceType());
             }
@@ -2911,7 +2918,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         List<Annotation> annotations = processAnnotations(ctx.annotations());
         SequenceType seq = null;
         boolean external;
-        Name var = ((VariableReferenceExpression) this.visitVarRef(ctx.varRef())).getVariableName();
+        Name var = parseVariableBinding(ctx.varBinding());
         if (ctx.sequenceType() != null) {
             seq = this.processSequenceType(ctx.sequenceType());
         }
@@ -3035,7 +3042,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
 
     @Override
     public Node visitAssignStatement(XQueryParser.AssignStatementContext ctx) {
-        Name paramName = parseEqName(ctx.varName().eqName(), false, false, false, false);
+        Name paramName = parseVariableReference(ctx.var_ref);
         Expression exprSingle = (Expression) this.visitExprSingle(ctx.exprSingle());
         return new AssignStatement(exprSingle, paramName, createMetadataFromContext(ctx));
     }
@@ -3231,7 +3238,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
             List<SequenceType> union = new ArrayList<>();
             Name variableName = null;
             if (stmt.var_ref != null) {
-                variableName = ((VariableReferenceExpression) this.visitVarRef(stmt.var_ref)).getVariableName();
+                variableName = parseVariableBinding(stmt.var_ref);
             }
             if (stmt.union != null && !stmt.union.isEmpty()) {
                 stmt.union.forEach(sequenceTypeContext -> {
@@ -3243,7 +3250,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         }
         Name defaultVariableName = null;
         if (ctx.var_ref != null) {
-            defaultVariableName = ((VariableReferenceExpression) this.visitVarRef(ctx.var_ref)).getVariableName();
+            defaultVariableName = parseVariableBinding(ctx.var_ref);
         }
         Statement defaultStatement = (Statement) this.visitStatement(ctx.def);
         return new TypeSwitchStatement(
@@ -3274,7 +3281,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
         List<VariableDeclStatement> variables = new ArrayList<>();
         for (XQueryParser.VarDeclForStatementContext varDecl : ctx.varDeclForStatement()) {
             SequenceType seq = null;
-            Name var = ((VariableReferenceExpression) this.visitVarRef(varDecl.var_ref)).getVariableName();
+            Name var = parseVariableBinding(varDecl.var_ref);
             Expression exprSingle = null;
 
             if (varDecl.sequenceType() != null) {

--- a/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
+++ b/src/main/java/org/rumbledb/parser/jsoniq/JsoniqParser.g4
@@ -156,9 +156,7 @@ namespaceDecl
    ;
 
 varDecl
-   : KW_DECLARE (annotations | ncName) KW_VARIABLE
-   // replaced "$" varName with varRef to match the JSONiq grammar
-   varRef
+   : KW_DECLARE (annotations | ncName) KW_VARIABLE varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    (KW_AS sequenceType)? (
    // replaced with the varValue production to match the JSONiq grammar
@@ -198,7 +196,7 @@ paramList
     Renamed from functionParam to param to match the JSONiq grammar
     Replaced with the typeDeclaration production to match the JSONiq grammar
 */ param
-   : DOLLAR name = qname (KW_AS sequenceType)?
+   : name = varBinding (KW_AS sequenceType)?
    ;
 
 annotations
@@ -245,11 +243,11 @@ forClause
    // renamed from forBinding to forVar to match the JSONiq grammar
    
 forVar
-   : var_ref = varRef
+   : var_ref = varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    (KW_AS seq = sequenceType)? (flag = allowingEmpty)?
    // replaced with the positionalVar production to match the JSONiq grammar
-   (KW_AT at = varRef)? KW_IN ex = exprSingle
+   (KW_AT at = varBinding)? KW_IN ex = exprSingle
    ;
 
 allowingEmpty
@@ -257,7 +255,7 @@ allowingEmpty
    ;
 
 positionalVar
-   : KW_AT DOLLAR pvar = varName
+   : KW_AT pvar = varBinding
    ;
 
 letClause
@@ -266,7 +264,7 @@ letClause
    // renamed from letBinding to letVar to match the JSONiq grammar
    
 letVar
-   : var_ref = varRef
+   : var_ref = varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    (KW_AS seq = sequenceType)? COLON_EQ ex = exprSingle
    ;
@@ -276,11 +274,11 @@ windowClause
    ;
 
 tumblingWindowClause
-   : KW_TUMBLING KW_WINDOW DOLLAR name = varName type = typeDeclaration? KW_IN exprSingle windowStartCondition windowEndCondition?
+   : KW_TUMBLING KW_WINDOW name = varBinding type = typeDeclaration? KW_IN exprSingle windowStartCondition windowEndCondition?
    ;
 
 slidingWindowClause
-   : KW_SLIDING KW_WINDOW DOLLAR name = varName type = typeDeclaration? KW_IN exprSingle windowStartCondition windowEndCondition
+   : KW_SLIDING KW_WINDOW name = varBinding type = typeDeclaration? KW_IN exprSingle windowStartCondition windowEndCondition
    ;
 
 windowStartCondition
@@ -292,11 +290,11 @@ windowEndCondition
    ;
 
 windowVars
-   : (DOLLAR currentItem = eqName)? positionalVar? (KW_PREVIOUS DOLLAR previousItem = eqName)? (KW_NEXT DOLLAR nextItem = eqName)?
+   : (currentItem = varBinding)? positionalVar? (KW_PREVIOUS previousItem = varBinding)? (KW_NEXT nextItem = varBinding)?
    ;
 
 countClause
-   : KW_COUNT varRef
+   : KW_COUNT varBinding
    ;
 
 whereClause
@@ -310,7 +308,7 @@ groupByClause
 
 groupByVar
    // renamed from groupingSpec to groupByVar to match the JSONiq grammar
-   : var_ref = varRef
+   : var_ref = varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    ((KW_AS seq = sequenceType)? decl = COLON_EQ ex = exprSingle)? (KW_COLLATION uri = uriLiteral)?
    ;
@@ -330,7 +328,7 @@ quantifiedExpr
 
 quantifiedExprVar
    // renamed from quantifiedVar to quantifiedExprVar to match the JSONiq grammar
-   : var_ref = varRef
+   : var_ref = varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    (KW_AS seq = sequenceType)? KW_IN exprSingle
    ;
@@ -344,11 +342,11 @@ switchCaseClause
    ;
 
 typeswitchExpr
-   : KW_TYPESWITCH LPAREN cond = expr RPAREN cses += caseClause+ KW_DEFAULT (var_ref = varRef)? KW_RETURN def = exprSingle
+   : KW_TYPESWITCH LPAREN cond = expr RPAREN cses += caseClause+ KW_DEFAULT (var_ref = varBinding)? KW_RETURN def = exprSingle
    ;
 
 caseClause
-   : KW_CASE (var_ref = varRef KW_AS)? union += sequenceType (VBAR union += sequenceType)* KW_RETURN ret = exprSingle
+   : KW_CASE (var_ref = varBinding KW_AS)? union += sequenceType (VBAR union += sequenceType)* KW_RETURN ret = exprSingle
    ;
 
 ifExpr
@@ -363,7 +361,7 @@ tryCatchExpr
 catchClause
    : KW_CATCH
    // replaced with the catchErrorList production to match the JSONiq grammar
-   ((jokers += wildcard | errors += eqName) (VBAR (jokers += wildcard | errors += eqName))* | (LPAREN DOLLAR varName RPAREN))
+   ((jokers += wildcard | errors += eqName) (VBAR (jokers += wildcard | errors += eqName))* | (LPAREN catch_var = varBinding RPAREN))
    // replaced with the enclosedExpression production to match the JSONiq grammar
    LBRACE catch_expression = expr? RBRACE
    ;
@@ -648,8 +646,11 @@ varRef
    : DOLLAR var_name = eqName
    ;
 
-varName
-   : eqName
+/**
+ * Variable bindings and references have the same lexical form, but distinct parser contexts make
+ * their semantic roles explicit to parse-tree consumers.
+ */ varBinding
+   : DOLLAR var_name = eqName
    ;
 
 parenthesizedExpr
@@ -1361,7 +1362,7 @@ applyStatement
    ;
 
 assignStatement
-   : DOLLAR varName COLON_EQ exprSingle SEMICOLON
+   : var_ref = varRef COLON_EQ exprSingle SEMICOLON
    ;
 
 blockStatement
@@ -1414,15 +1415,15 @@ tryCatchStatement
 catchCaseStatement
    : KW_CATCH (jokers += wildcard | errors += eqName) (VBAR (jokers += wildcard | errors += eqName))* catch_block = blockStatement
    ;
-   // replaced "$" varName with varRef to match the JSONiq grammar
+   // The optional variable is local to the default branch.
    
 typeSwitchStatement
-   : KW_TYPESWITCH LPAREN cond = expr RPAREN cases += caseStatement+ KW_DEFAULT (var_ref = varRef)? (KW_RETURN) def = statement
+   : KW_TYPESWITCH LPAREN cond = expr RPAREN cases += caseStatement+ KW_DEFAULT (var_ref = varBinding)? (KW_RETURN) def = statement
    ;
-   // replaced "$" varName with varRef to match the JSONiq grammar
+   // The optional variable is local to this case branch.
    
 caseStatement
-   : KW_CASE (var_ref = varRef KW_AS)? union += sequenceType (VBAR union += sequenceType)* (KW_RETURN) ret = statement
+   : KW_CASE (var_ref = varBinding KW_AS)? union += sequenceType (VBAR union += sequenceType)* (KW_RETURN) ret = statement
    ;
 
 varDeclStatement
@@ -1431,7 +1432,7 @@ varDeclStatement
    // added to match the JSONiq grammar
    
 varDeclForStatement
-   : var_ref = varRef (KW_AS sequenceType)? (COLON_EQ expr_vals += exprSingle)?
+   : var_ref = varBinding (KW_AS sequenceType)? (COLON_EQ expr_vals += exprSingle)?
    ;
 
 whileStatement
@@ -1508,7 +1509,7 @@ updateLocator
    ;
 
 copyDecl
-   : var_ref = varRef COLON_EQ src_expr = exprSingle
+   : var_ref = varBinding COLON_EQ src_expr = exprSingle
    ;
    ///////////////////////// Top Level Updating Expressions
    

--- a/src/main/java/org/rumbledb/parser/xquery/XQueryParser.g4
+++ b/src/main/java/org/rumbledb/parser/xquery/XQueryParser.g4
@@ -157,9 +157,7 @@ namespaceDecl
    ;
 
 varDecl
-   : KW_DECLARE (annotations | ncName) KW_VARIABLE
-   // replaced "$" varName with varRef to match the JSONiq grammar
-   varRef
+   : KW_DECLARE (annotations | ncName) KW_VARIABLE varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    (KW_AS sequenceType)? (
    // replaced with the varValue production to match the JSONiq grammar
@@ -203,7 +201,7 @@ paramList
    
    
 param
-   : DOLLAR name = qname (KW_AS sequenceType)?
+   : name = varBinding (KW_AS sequenceType)?
    ;
 
 annotations
@@ -240,11 +238,11 @@ forClause
    // renamed from forBinding to forVar to match the JSONiq grammar
    
 forVar
-   : var_ref = varRef
+   : var_ref = varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    (KW_AS seq = sequenceType)? (flag = allowingEmpty)?
    // replaced with the positionalVar production to match the JSONiq grammar
-   (KW_AT at = varRef)? KW_IN ex = exprSingle
+   (KW_AT at = varBinding)? KW_IN ex = exprSingle
    ;
 
 allowingEmpty
@@ -252,7 +250,7 @@ allowingEmpty
    ;
 
 positionalVar
-   : KW_AT DOLLAR pvar = varName
+   : KW_AT pvar = varBinding
    ;
 
 letClause
@@ -261,7 +259,7 @@ letClause
    // renamed from letBinding to letVar to match the JSONiq grammar
    
 letVar
-   : var_ref = varRef
+   : var_ref = varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    (KW_AS seq = sequenceType)? COLON_EQ ex = exprSingle
    ;
@@ -271,11 +269,11 @@ windowClause
    ;
 
 tumblingWindowClause
-   : KW_TUMBLING KW_WINDOW DOLLAR name = varName type = typeDeclaration? KW_IN exprSingle windowStartCondition windowEndCondition?
+   : KW_TUMBLING KW_WINDOW name = varBinding type = typeDeclaration? KW_IN exprSingle windowStartCondition windowEndCondition?
    ;
 
 slidingWindowClause
-   : KW_SLIDING KW_WINDOW DOLLAR name = varName type = typeDeclaration? KW_IN exprSingle windowStartCondition windowEndCondition
+   : KW_SLIDING KW_WINDOW name = varBinding type = typeDeclaration? KW_IN exprSingle windowStartCondition windowEndCondition
    ;
 
 windowStartCondition
@@ -287,11 +285,11 @@ windowEndCondition
    ;
 
 windowVars
-   : (DOLLAR currentItem = eqName)? positionalVar? (KW_PREVIOUS DOLLAR previousItem = eqName)? (KW_NEXT DOLLAR nextItem = eqName)?
+   : (currentItem = varBinding)? positionalVar? (KW_PREVIOUS previousItem = varBinding)? (KW_NEXT nextItem = varBinding)?
    ;
 
 countClause
-   : KW_COUNT varRef
+   : KW_COUNT varBinding
    ;
 
 whereClause
@@ -305,7 +303,7 @@ groupByClause
    // renamed from groupingSpec to groupByVar to match the JSONiq grammar
    
 groupByVar
-   : var_ref = varRef
+   : var_ref = varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    ((KW_AS seq = sequenceType)? decl = COLON_EQ ex = exprSingle)? (KW_COLLATION uri = uriLiteral)?
    ;
@@ -325,7 +323,7 @@ quantifiedExpr
    // renamed from quantifiedVar to quantifiedExprVar to match the JSONiq grammar
    
 quantifiedExprVar
-   : var_ref = varRef
+   : var_ref = varBinding
    // replaced with the typeDeclaration production to match the JSONiq grammar
    (KW_AS seq = sequenceType)? KW_IN exprSingle
    ;
@@ -339,11 +337,11 @@ switchCaseClause
    ;
 
 typeswitchExpr
-   : KW_TYPESWITCH LPAREN cond = expr RPAREN cses += caseClause+ KW_DEFAULT (var_ref = varRef)? KW_RETURN def = exprSingle
+   : KW_TYPESWITCH LPAREN cond = expr RPAREN cses += caseClause+ KW_DEFAULT (var_ref = varBinding)? KW_RETURN def = exprSingle
    ;
 
 caseClause
-   : KW_CASE (var_ref = varRef KW_AS)? union += sequenceType (VBAR union += sequenceType)* KW_RETURN ret = exprSingle
+   : KW_CASE (var_ref = varBinding KW_AS)? union += sequenceType (VBAR union += sequenceType)* KW_RETURN ret = exprSingle
    ;
 
 ifExpr
@@ -358,7 +356,7 @@ tryCatchExpr
 catchClause
    : KW_CATCH
    // replaced with the catchErrorList production to match the JSONiq grammar
-   ((jokers += wildcard | errors += eqName) (VBAR (jokers += wildcard | errors += eqName))* | (LPAREN DOLLAR varName RPAREN))
+   ((jokers += wildcard | errors += eqName) (VBAR (jokers += wildcard | errors += eqName))* | (LPAREN catch_var = varBinding RPAREN))
    // replaced with the enclosedExpression production to match the JSONiq grammar
    LBRACE catch_expression = expr? RBRACE
    ;
@@ -622,8 +620,11 @@ varRef
    : DOLLAR var_name = eqName
    ;
 
-varName
-   : eqName
+/**
+ * Variable bindings and references have the same lexical form, but distinct parser contexts make
+ * their semantic roles explicit to parse-tree consumers.
+ */ varBinding
+   : DOLLAR var_name = eqName
    ;
 
 parenthesizedExpr
@@ -1331,7 +1332,7 @@ applyStatement
    ;
 
 assignStatement
-   : DOLLAR varName COLON_EQ exprSingle SEMICOLON
+   : var_ref = varRef COLON_EQ exprSingle SEMICOLON
    ;
 
 blockStatement
@@ -1384,15 +1385,15 @@ tryCatchStatement
 catchCaseStatement
    : KW_CATCH (jokers += wildcard | errors += eqName) (VBAR (jokers += wildcard | errors += eqName))* catch_block = blockStatement
    ;
-   // replaced "$" varName with varRef to match the JSONiq grammar
+   // The optional variable is local to the default branch.
    
 typeSwitchStatement
-   : KW_TYPESWITCH LPAREN cond = expr RPAREN cases += caseStatement+ KW_DEFAULT (var_ref = varRef)? (KW_RETURN) def = statement
+   : KW_TYPESWITCH LPAREN cond = expr RPAREN cases += caseStatement+ KW_DEFAULT (var_ref = varBinding)? (KW_RETURN) def = statement
    ;
-   // replaced "$" varName with varRef to match the JSONiq grammar
+   // The optional variable is local to this case branch.
    
 caseStatement
-   : KW_CASE (var_ref = varRef KW_AS)? union += sequenceType (VBAR union += sequenceType)* (KW_RETURN) ret = statement
+   : KW_CASE (var_ref = varBinding KW_AS)? union += sequenceType (VBAR union += sequenceType)* (KW_RETURN) ret = statement
    ;
 
 varDeclStatement
@@ -1401,7 +1402,7 @@ varDeclStatement
    // added to match the JSONiq grammar
    
 varDeclForStatement
-   : var_ref = varRef (KW_AS sequenceType)? (COLON_EQ expr_vals += exprSingle)?
+   : var_ref = varBinding (KW_AS sequenceType)? (COLON_EQ expr_vals += exprSingle)?
    ;
 
 whileStatement
@@ -1478,7 +1479,7 @@ updateLocator
    ;
 
 copyDecl
-   : var_ref = varRef COLON_EQ src_expr = exprSingle
+   : var_ref = varBinding COLON_EQ src_expr = exprSingle
    ;
    ///////////////////////// Top Level Updating Expressions
    


### PR DESCRIPTION
Currently, both variable declaration and reference uses `varRef` rule. Separating them makes the parsing easier (for language server for example, which no longer needs to check parent rule to distinguish between declaration and reference).