### PR TITLE
Implement function name validation to prevent declarations in reserved namespaces

### DIFF
--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -41,6 +41,7 @@ import lombok.extern.log4j.Log4j2;
 import org.rumbledb.api.Item;
 import org.rumbledb.bindings.DataFrameBinding;
 import org.rumbledb.bindings.ExternalBindings;
+import org.rumbledb.compiler.utils.FunctionDeclarationValidator;
 import org.rumbledb.compiler.utils.URILiteralUtils;
 import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.config.RumbleConfiguration;

--- a/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/TranslationVisitor.java
@@ -730,6 +730,7 @@ public class TranslationVisitor extends JsoniqParserBaseVisitor<Node> {
     public Node visitFunctionDecl(JsoniqParser.FunctionDeclContext ctx) {
         List<Annotation> annotations = processAnnotations(ctx.annotations());
         Name name = parseFunctionName(ctx.functionName());
+        FunctionDeclarationValidator.validateFunctionName(name, createMetadataFromContext(ctx.functionName()));
         LinkedHashMap<Name, SequenceType> fnParams = new LinkedHashMap<>();
         SequenceType fnReturnType = null;
         Name paramName;

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -40,6 +40,7 @@ import lombok.extern.log4j.Log4j2;
 
 import org.rumbledb.bindings.DataFrameBinding;
 import org.rumbledb.bindings.ExternalBindings;
+import org.rumbledb.compiler.utils.FunctionDeclarationValidator;
 import org.rumbledb.compiler.utils.URILiteralUtils;
 import org.rumbledb.config.CompilationConfiguration;
 import org.rumbledb.config.RumbleConfiguration;

--- a/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
+++ b/src/main/java/org/rumbledb/compiler/XQueryTranslationVisitor.java
@@ -771,6 +771,7 @@ public class XQueryTranslationVisitor extends XQueryParserBaseVisitor<Node> {
     public Node visitFunctionDecl(XQueryParser.FunctionDeclContext ctx) {
         List<Annotation> annotations = processAnnotations(ctx.annotations());
         Name name = parseFunctionName(ctx.functionName());
+        FunctionDeclarationValidator.validateFunctionName(name, createMetadataFromContext(ctx.functionName()));
         LinkedHashMap<Name, SequenceType> fnParams = new LinkedHashMap<>();
         SequenceType fnReturnType = null;
         Name paramName;

--- a/src/main/java/org/rumbledb/compiler/utils/FunctionDeclarationValidator.java
+++ b/src/main/java/org/rumbledb/compiler/utils/FunctionDeclarationValidator.java
@@ -22,7 +22,7 @@ import org.rumbledb.exceptions.ExceptionMetadata;
 import org.rumbledb.exceptions.InvalidFunctionNamespaceException;
 
 /** Static validation shared by the JSONiq and XQuery function declaration translators. */
-final class FunctionDeclarationValidator {
+public final class FunctionDeclarationValidator {
 
     private FunctionDeclarationValidator() {}
 
@@ -40,7 +40,7 @@ final class FunctionDeclarationValidator {
      * Functions cannot be declared in the reserved namespaces.
      * See https://www.w3.org/TR/xquery-31/#FunctionDeclns for more information.
      */
-    static void validateFunctionName(Name name, ExceptionMetadata metadata) {
+    public static void validateFunctionName(Name name, ExceptionMetadata metadata) {
         String namespace = name.getNamespace();
         if (RESERVED_NAMESPACES.contains(namespace)) {
             throw new InvalidFunctionNamespaceException(

--- a/src/main/java/org/rumbledb/compiler/utils/FunctionDeclarationValidator.java
+++ b/src/main/java/org/rumbledb/compiler/utils/FunctionDeclarationValidator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor acknowledgements are maintained in the CONTRIBUTORS file at the project root.
+ */
+package org.rumbledb.compiler.utils;
+
+import java.util.Set;
+
+import org.rumbledb.context.Name;
+import org.rumbledb.exceptions.ExceptionMetadata;
+import org.rumbledb.exceptions.InvalidFunctionNamespaceException;
+
+/** Static validation shared by the JSONiq and XQuery function declaration translators. */
+final class FunctionDeclarationValidator {
+
+    private FunctionDeclarationValidator() {}
+
+    private static final Set<String> RESERVED_NAMESPACES = Set.of(
+            Name.XML_NS,
+            Name.XS_NS,
+            Name.XSI_NS,
+            Name.FN_NS,
+            Name.MATH_NS,
+            Name.XQUERY_ANNOTATIONS_NS,
+            Name.ARRAY_NS,
+            Name.MAP_NS);
+
+    /**
+     * Functions cannot be declared in the reserved namespaces.
+     * See https://www.w3.org/TR/xquery-31/#FunctionDeclns for more information.
+     */
+    static void validateFunctionName(Name name, ExceptionMetadata metadata) {
+        String namespace = name.getNamespace();
+        if (RESERVED_NAMESPACES.contains(namespace)) {
+            throw new InvalidFunctionNamespaceException(
+                    "Functions cannot be declared in the reserved namespace " + namespace + ".", metadata);
+        }
+    }
+}

--- a/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
+++ b/src/main/java/org/rumbledb/errorcodes/ErrorCode.java
@@ -178,7 +178,8 @@ public final class ErrorCode implements Serializable {
     public static final ErrorCode DuplicateFunctionIdentifier = registerBuiltIn("XQST0034");
     public static final ErrorCode DefaultCollationExceptionCode = registerBuiltIn("XQST0038");
     public static final ErrorCode DuplicateParamName = registerBuiltIn("XQST0039");
-    public static final ErrorCode AnnotationInReservedNamespaceErrorCode = registerBuiltIn("XQST0045");
+    public static final ErrorCode DeclarationInReservedNamespaceErrorCode = registerBuiltIn("XQST0045");
+    public static final ErrorCode AnnotationInReservedNamespaceErrorCode = DeclarationInReservedNamespaceErrorCode;
     public static final ErrorCode InvalidURILiteralErrorCode = registerBuiltIn("XQST0046");
     public static final ErrorCode DuplicateModuleTargetNamespace = registerBuiltIn("XQST0047");
     public static final ErrorCode NamespaceDoesNotMatchModule = registerBuiltIn("XQST0048");

--- a/src/main/java/org/rumbledb/exceptions/InvalidFunctionNamespaceException.java
+++ b/src/main/java/org/rumbledb/exceptions/InvalidFunctionNamespaceException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributor acknowledgements are maintained in the CONTRIBUTORS file at the project root.
+ */
+package org.rumbledb.exceptions;
+
+import java.io.Serial;
+
+import org.rumbledb.errorcodes.ErrorCode;
+
+public class InvalidFunctionNamespaceException extends SemanticException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public InvalidFunctionNamespaceException(String message, ExceptionMetadata metadata) {
+        super(message, ErrorCode.DeclarationInReservedNamespaceErrorCode, metadata);
+    }
+}


### PR DESCRIPTION
[Definition: A reserved namespace is a namespace that must not be used in the name of a function declaration.] It is a static error [err:XQST0045] if the function name in a function declaration (when expanded) is in a reserved namespace. The following namespaces are reserved namespaces:

- http://www.w3.org/XML/1998/namespace
- http://www.w3.org/2001/XMLSchema
- http://www.w3.org/2001/XMLSchema-instance
- http://www.w3.org/2005/xpath-functions
- http://www.w3.org/2005/xpath-functions/math
- http://www.w3.org/2012/xquery
- http://www.w3.org/2005/xpath-functions/array
- http://www.w3.org/2005/xpath-functions/map

See: https://www.w3.org/TR/xquery-31/#FunctionDeclns